### PR TITLE
Docs-aligned: KIE API conformance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 - KIE_API_KEY         = <ключ KIE>              # просто ключ; код сам добавит 'Bearer '
 - KIE_BASE_URL        = https://api.kie.ai
 - KIE_GEN_PATH        = /api/v1/veo/generate
-- KIE_STATUS_PATH     = /api/v1/veo/record-info
-- KIE_HD_PATH         = /api/v1/veo/get-1080p-video
+- KIE_STATUS_PATH     = /api/v1/veo/recordInfo
+- KIE_HD_PATH         = /api/v1/veo/get1080pVideo
 - KIE_ENABLE_FALLBACK = false                   # true только если надо включать Fallback при 16:9
 - KIE_DEFAULT_SEED    =                          # опционально: число 10000–99999
 - KIE_WATERMARK_TEXT  =                          # опционально


### PR DESCRIPTION
## Summary
- switch the default KIE status and HD endpoints to the documented camelCase paths and surface them in the README
- centralize KIE HTTP calls so every request uses Bearer auth, JSON content negotiation, and structured request-id logging
- harden VEO/MJ polling by parsing nested JSON payloads, extracting URLs robustly, and recording final result links while keeping vertical handling intact

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c83a96d15c8322809644a96633b6c2