### PR TITLE
fix(veo): correct endpoint names for status polling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Telegram bot token
+TELEGRAM_TOKEN=
+
+# Optional: Prompt-Master / OpenAI
+OPENAI_API_KEY=
+
+# KIE configuration
+KIE_API_KEY=
+KIE_BASE_URL=https://api.kie.ai
+KIE_VEO_GEN_PATH=/api/v1/veo/generate
+KIE_VEO_STATUS_PATH=/api/v1/veo/record-info
+KIE_VEO_1080_PATH=/api/v1/veo/get-1080p-video
+KIE_MJ_GENERATE=/api/v1/mj/generate
+KIE_MJ_STATUS=/api/v1/mj/recordInfo
+
+# Video processing
+FFMPEG_BIN=ffmpeg
+ENABLE_VERTICAL_NORMALIZE=true
+ALWAYS_FORCE_FHD=true
+MAX_TG_VIDEO_MB=48
+POLL_INTERVAL_SECS=6
+POLL_TIMEOUT_SECS=1200
+
+# Logging
+LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 - OPENAI_API_KEY      = <ключ OpenAI>           # для Prompt-Master (можно пусто — тогда PM отключён)
 - KIE_API_KEY         = <ключ KIE>              # просто ключ; код сам добавит 'Bearer '
 - KIE_BASE_URL        = https://api.kie.ai
-- KIE_GEN_PATH        = /api/v1/veo/generate
-- KIE_STATUS_PATH     = /api/v1/veo/recordInfo
-- KIE_HD_PATH         = /api/v1/veo/get1080pVideo
+- KIE_VEO_GEN_PATH    = /api/v1/veo/generate
+- KIE_VEO_STATUS_PATH = /api/v1/veo/record-info
+- KIE_VEO_1080_PATH   = /api/v1/veo/get-1080p-video
 - KIE_ENABLE_FALLBACK = false                   # true только если надо включать Fallback при 16:9
 - KIE_DEFAULT_SEED    =                          # опционально: число 10000–99999
 - KIE_WATERMARK_TEXT  =                          # опционально


### PR DESCRIPTION
## Summary
- switch the default VEO status/HD endpoints to the kebab-case paths from the latest KIE API and keep legacy routes as fallbacks
- add adaptive polling helpers that retry alternative endpoints and log which URL succeeds
- document the new defaults in README and a fresh `.env.example`

## Testing
- python -m compileall bot.py

------
https://chatgpt.com/codex/tasks/task_e_68c84ddbf0c08322b9331c8a6846d65c