### PR TITLE
Persist user balances across restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Local balance backup
+balances.json


### PR DESCRIPTION
## Summary
- add a persistent balance storage helper that uses Redis as the primary source with a JSON backup file
- update balance accessors to hydrate user context from storage and write changes to Redis and the backup
- ignore the generated balance backup file in version control

## Testing
- python -m compileall bot.py

------
https://chatgpt.com/codex/tasks/task_e_68c852b3753c8322a4c3b6535cf74b4a