### PR TITLE
Remove stray directive causing syntax error

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1050,7 +1050,7 @@ def get_kie_veo_status(task_id: str) -> Tuple[bool, Optional[int], Optional[str]
         return True, flag, message, url
     return False, None, f"Ошибка статуса VEO: {resp}", None
 
-codex/implement-1080p-video-fetch-and-send
+
 def fetch_1080p_result_url(task_id: str, index: Optional[int] = None) -> Tuple[Optional[str], Dict[str, Any]]:
     params: Dict[str, Any] = {"taskId": task_id}
     if index is not None:


### PR DESCRIPTION
## Summary
- remove an accidental codex directive line that broke bot.py execution by producing a syntax error

## Testing
- python -m compileall bot.py

------
https://chatgpt.com/codex/tasks/task_e_68c87501bc8c83229abc01963bbc7655