### PR TITLE
Fix promo code handling and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ TELEGRAM_TOKEN=your-telegram-token
 PROMPTS_CHANNEL_URL=https://t.me/bestveo3promts
 STARS_BUY_URL=https://t.me/PremiumBot
 PROMO_ENABLED=true
+PROMO_CODES=WELCOME50=50,FREE10=10              # опционально: список CODE=AMOUNT через запятую или перенос строки
+PROMO_CODES_JSON={"SPRING200": 200}            # опционально: JSON-словарь с промокодами
+PROMO_CODES_FILE=/app/config/promo_codes.txt    # опционально: путь до файла с промокодами (JSON или CODE=AMOUNT)
 DEV_MODE=false
 
 # OpenAI / Prompt Master (optional)

--- a/bot.py
+++ b/bot.py
@@ -41,6 +41,7 @@ from ledger import (
     BalanceRecalcResult,
     InsufficientBalance,
 )
+from promo_codes import DEFAULT_PROMO_CODES, load_promo_codes, normalize_promo_code
 try:
     import redis.asyncio as redis_asyncio  # type: ignore
 except Exception:  # pragma: no cover - fallback if asyncio interface unavailable
@@ -239,43 +240,45 @@ CHAT_UNLOCK_PRICE = 0
 # ==========================
 #   Promo codes (one-time / global)
 # ==========================
-PROMO_CODES = {
-    "WELCOME50": 50,
-    "FREE10": 10,
-    "LABACCENT100": 100,
-    "BONUS50": 50,
-    "FRIENDS150": 150,
-}
+PROMO_CODES = load_promo_codes(DEFAULT_PROMO_CODES)
+if PROMO_CODES:
+    loaded_codes = ", ".join(f"{code}={amount}" for code, amount in sorted(PROMO_CODES.items()))
+    log.info("Promo codes loaded (%s): %s", len(PROMO_CODES), loaded_codes)
+else:
+    log.warning("No promo codes configured")
 
 def promo_amount(code: str) -> Optional[int]:
-    code = (code or "").strip().upper()
-    if not code: return None
+    normalized = normalize_promo_code(code)
+    if not normalized:
+        return None
     if redis_client:
-        v = redis_client.get(_rk("promo", "amount", code))
+        v = redis_client.get(_rk("promo", "amount", normalized))
         if v:
             try: return int(v)
             except: pass
-    return PROMO_CODES.get(code)
+    return PROMO_CODES.get(normalized)
 
 def promo_used_global(code: str) -> Optional[int]:
-    code = (code or "").strip().upper()
-    if not code: return None
+    normalized = normalize_promo_code(code)
+    if not normalized:
+        return None
     if redis_client:
-        u = redis_client.get(_rk("promo", "used_by", code))
+        u = redis_client.get(_rk("promo", "used_by", normalized))
         try: return int(u) if u is not None else None
         except: return None
     try:
-        owner = ledger_storage.get_promo_owner(code)
+        owner = ledger_storage.get_promo_owner(normalized)
         return owner
     except Exception as exc:
-        log.warning("Failed to fetch promo owner for %s: %s", code, exc)
+        log.warning("Failed to fetch promo owner for %s: %s", normalized, exc)
         return None
 
 def promo_mark_used(code: str, uid: int):
-    code = (code or "").strip().upper()
-    if not code: return
+    normalized = normalize_promo_code(code)
+    if not normalized:
+        return
     if redis_client:
-        redis_client.setnx(_rk("promo", "used_by", code), str(uid))
+        redis_client.setnx(_rk("promo", "used_by", normalized), str(uid))
 
 # локальный кэш процесса (если Redis выключен)
 app_cache: Dict[Any, Any] = {}
@@ -2727,9 +2730,18 @@ async def on_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
             )
             s["mode"] = None
             return
-        code = text.upper()
+
+        normalized_code = normalize_promo_code(text)
+        if not normalized_code:
+            await update.message.reply_text(
+                f"{CE['cross']} Неверный промокод.",
+                parse_mode=ParseMode.HTML,
+            )
+            s["mode"] = None
+            return
+
         uid = update.effective_user.id
-        bonus = promo_amount(code)
+        bonus = promo_amount(normalized_code)
         if not bonus:
             await update.message.reply_text(
                 f"{CE['cross']} Неверный промокод.",
@@ -2737,7 +2749,8 @@ async def on_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
             )
             s["mode"] = None
             return
-        used_by = promo_used_global(code)
+
+        used_by = promo_used_global(normalized_code)
         if used_by and used_by != uid:
             await update.message.reply_text(
                 f"{CE['cross']} Этот промокод уже использован.",
@@ -2745,12 +2758,13 @@ async def on_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
             )
             s["mode"] = None
             return
+
         try:
             result = ledger_storage.apply_promo(
                 uid,
-                code,
+                normalized_code,
                 bonus,
-                {"source": "promo_command"},
+                {"source": "promo_command", "raw_code": text},
             )
             _set_cached_balance(ctx, result.balance)
             if not result.applied:
@@ -2767,7 +2781,7 @@ async def on_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
                 s["mode"] = None
                 return
         except Exception as exc:
-            log.exception("Promo apply failed for %s (%s): %s", uid, code, exc)
+            log.exception("Promo apply failed for %s (%s): %s", uid, normalized_code, exc)
             await update.message.reply_text(
                 f"{CE['bulb']} Не удалось применить промокод. Попробуйте позже.",
                 parse_mode=ParseMode.HTML,
@@ -2775,11 +2789,12 @@ async def on_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
             s["mode"] = None
             return
 
-        promo_mark_used(code, uid)
+        promo_mark_used(normalized_code, uid)
         new_balance = get_user_balance_value(ctx, force_refresh=True)
+        bonus_text = f"+{escape(str(bonus))}{CE['star']}"
         await update.message.reply_text(
             (
-                f"{CE['check']} Промокод активирован! Вам начислено {escape(str(bonus))} токенов.\n"
+                f"{CE['check']} Промокод активирован, на баланс добавлено {bonus_text}.\n"
                 f"{format_balance_line(new_balance)}"
             ),
             parse_mode=ParseMode.HTML,

--- a/promo_codes.py
+++ b/promo_codes.py
@@ -1,0 +1,155 @@
+"""Utilities for working with promo codes."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict
+
+log = logging.getLogger(__name__)
+
+
+# Default promo codes that ship with the bot. They can be overridden via
+# environment variables or an external file – see :func:`load_promo_codes`.
+DEFAULT_PROMO_CODES: Dict[str, int] = {
+    "WELCOME50": 50,
+    "FREE10": 10,
+    "LABACCENT100": 100,
+    "BONUS50": 50,
+    "FRIENDS150": 150,
+}
+
+
+_WHITESPACE_RE = re.compile(r"\s+", re.UNICODE)
+
+
+def normalize_promo_code(code: str | None) -> str:
+    """Return a canonical representation of a promo code.
+
+    The function removes surrounding whitespace, collapses inner whitespace and
+    forces uppercase letters. Invisible whitespace characters (like zero-width
+    spaces) are also stripped. The returned string can be safely used as a key
+    in dictionaries, Redis or the database.
+    """
+
+    if not code:
+        return ""
+    text = str(code).strip()
+    if not text:
+        return ""
+    # Remove any whitespace characters (including zero-width spaces) to avoid
+    # issues when users copy promo codes from formatted messages.
+    text = _WHITESPACE_RE.sub("", text)
+    text = text.replace("\u200b", "")
+    return text.upper()
+
+
+def _parse_mapping_blob(blob: str, source: str) -> Dict[str, Any]:
+    """Parse promo codes from a blob of text.
+
+    The function tries JSON first and falls back to ``CODE=AMOUNT`` pairs
+    separated by newlines, commas or semicolons. Whitespace is ignored.
+    """
+
+    text = (blob or "").strip()
+    if not text:
+        return {}
+
+    # JSON format is the most explicit one. Expected structure: {"CODE": 10}
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+
+    if isinstance(parsed, dict):
+        return parsed
+
+    result: Dict[str, Any] = {}
+    # Accept "CODE=10", "CODE:10" or "CODE 10" separated by newline/comma/semicolon.
+    for raw in re.split(r"[\n,;]+", text):
+        entry = raw.strip()
+        if not entry:
+            continue
+        for delimiter in ("=", ":"):
+            if delimiter in entry:
+                code, value = entry.split(delimiter, 1)
+                break
+        else:
+            parts = entry.split()
+            if len(parts) == 2:
+                code, value = parts
+            else:
+                log.warning("Ignoring malformed promo definition '%s' from %s", entry, source)
+                continue
+        result[code.strip()] = value.strip()
+    return result
+
+
+def _load_from_file(path: str) -> Dict[str, Any]:
+    file_path = Path(path).expanduser()
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        log.warning("Promo codes file '%s' not found", file_path)
+        return {}
+    except OSError as exc:
+        log.warning("Cannot read promo codes file '%s': %s", file_path, exc)
+        return {}
+    return _parse_mapping_blob(content, f"file:{file_path}")
+
+
+def load_promo_codes(defaults: Dict[str, int] | None = None) -> Dict[str, int]:
+    """Load promo codes from defaults, environment variables and optional files."""
+
+    merged: Dict[str, int] = {}
+
+    def _apply(mapping: Dict[str, Any] | None, source: str) -> None:
+        if not mapping:
+            return
+        for raw_code, raw_value in mapping.items():
+            normalized = normalize_promo_code(raw_code)
+            if not normalized:
+                log.warning("Ignoring empty promo code from %s", source)
+                continue
+            try:
+                amount = int(str(raw_value).strip())
+            except (TypeError, ValueError):
+                log.warning(
+                    "Ignoring promo code '%s' from %s: invalid amount %r",
+                    raw_code,
+                    source,
+                    raw_value,
+                )
+                continue
+            if amount <= 0:
+                log.warning(
+                    "Ignoring promo code '%s' from %s: non-positive amount %s",
+                    raw_code,
+                    source,
+                    amount,
+                )
+                continue
+            merged[normalized] = amount
+
+    _apply(defaults, "defaults")
+
+    env_json = os.getenv("PROMO_CODES_JSON")
+    if env_json:
+        _apply(_parse_mapping_blob(env_json, "env:PROMO_CODES_JSON"), "env:PROMO_CODES_JSON")
+
+    env_plain = os.getenv("PROMO_CODES")
+    if env_plain:
+        _apply(_parse_mapping_blob(env_plain, "env:PROMO_CODES"), "env:PROMO_CODES")
+
+    file_path = os.getenv("PROMO_CODES_FILE")
+    if file_path:
+        _apply(_load_from_file(file_path), f"file:{file_path}")
+
+    return merged
+
+
+__all__ = ["DEFAULT_PROMO_CODES", "load_promo_codes", "normalize_promo_code"]
+

--- a/tests/test_promo_codes.py
+++ b/tests/test_promo_codes.py
@@ -1,0 +1,45 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from promo_codes import load_promo_codes, normalize_promo_code
+
+
+class PromoCodesTestCase(unittest.TestCase):
+    def test_normalize_promo_code_removes_spaces_and_case(self) -> None:
+        self.assertEqual(normalize_promo_code(" weLcome 50 "), "WELCOME50")
+        self.assertEqual(normalize_promo_code("free\u200b10"), "FREE10")
+        self.assertEqual(normalize_promo_code(""), "")
+
+    def test_load_promo_codes_merges_sources(self) -> None:
+        defaults = {"WELCOME50": 50, "FREE10": 10}
+        with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as tmp:
+            tmp.write("extra = 30\nwelcome50 = 70\ninvalid=oops\nother: 15\n")
+            file_path = tmp.name
+
+        try:
+            with patch.dict(
+                os.environ,
+                {
+                    "PROMO_CODES_FILE": file_path,
+                    "PROMO_CODES": "bonus25=25",
+                    "PROMO_CODES_JSON": "",
+                },
+                clear=False,
+            ):
+                codes = load_promo_codes(defaults)
+        finally:
+            os.unlink(file_path)
+
+        self.assertEqual(codes["WELCOME50"], 70)  # overridden by file
+        self.assertEqual(codes["FREE10"], 10)     # from defaults
+        self.assertEqual(codes["EXTRA"], 30)      # from file
+        self.assertEqual(codes["OTHER"], 15)      # from file with ':'
+        self.assertEqual(codes["BONUS25"], 25)    # from env variable
+        self.assertNotIn("INVALID", codes)        # invalid amount is skipped
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- load promo codes through a dedicated helper that normalizes codes and merges defaults with env/file overrides
- update the promo activation flow to use normalized codes, persist raw values for auditing and send a clearer success message
- document the new configuration knobs and cover promo code parsing with unit tests

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68c9160420548322b0095512572fe490