### PR TITLE
Adjust Prompt-Master response formatting

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -709,16 +709,28 @@ PROMPT_MASTER_TIMEOUT = 27.0
 PROMPT_MASTER_ERROR_MESSAGE = (
     f"{cemoji('cross')} Не удалось собрать промпт. Попробуй сформулировать короче."
 )
-PROMPT_MASTER_CARD_TEMPLATE = (
-    f"{cemoji('brain')} Карточка Prompt-Master\n"
-    f"{cemoji('paperclip')} Промпт:\n<code>{{prompt}}</code>"
-)
+
+
+def _format_prompt_master_quote(text: str) -> str:
+    lines = text.splitlines()
+    if not lines:
+        return ""
+    quoted = []
+    for line in lines:
+        cleaned = line.rstrip("\r")
+        quoted.append(f"> {cleaned}" if cleaned else ">")
+    return "\n".join(quoted)
 def state(ctx: ContextTypes.DEFAULT_TYPE) -> Dict[str, Any]:
     ud = ctx.user_data
     for k, v in DEFAULT_STATE.items():
         if k not in ud: ud[k] = [] if isinstance(v, list) else v
     if not isinstance(ud.get("banana_images"), list): ud["banana_images"] = []
     return ud
+
+
+def activate_prompt_master_mode(ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    s = state(ctx)
+    s["mode"] = MODE_PROMPTMASTER
 
 # odex/fix-balance-reset-after-deploy
 # main
@@ -2745,8 +2757,26 @@ async def on_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
             await update.message.reply_text(PROMPT_MASTER_ERROR_MESSAGE, parse_mode=ParseMode.HTML)
             return
 
-        card_text = PROMPT_MASTER_CARD_TEMPLATE.format(prompt=escape(prompt_text))
-        await update.message.reply_text(card_text, parse_mode=ParseMode.HTML)
+        quoted_text = _format_prompt_master_quote(prompt_text)
+        if not quoted_text:
+            quoted_text = prompt_text
+        reply_markup = InlineKeyboardMarkup([
+            [
+                inline_button(
+                    "📋 Скопировать",
+                    api_kwargs={"copy_text": {"text": quoted_text}},
+                ),
+                inline_button(
+                    "🔄 Новый промпт",
+                    callback_data="mode:prompt_master",
+                ),
+            ]
+        ])
+        await update.message.reply_text(
+            quoted_text,
+            reply_markup=reply_markup,
+            disable_web_page_preview=True,
+        )
         return
 
     # PROMO


### PR DESCRIPTION
## Summary
- remove the Prompt-Master card header and render responses as a single quoted block for easier copying
- add a formatter helper plus copy and new prompt inline buttons that expose the generated text via the new copy_text API
- ensure the Prompt-Master mode setter updates user state before prompting

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c91842e788832298f3b84efa0950ef