### PR TITLE
Add compact main menu layout toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ TELEGRAM_TOKEN=your-telegram-token
 PROMPTS_CHANNEL_URL=https://t.me/bestveo3promts
 STARS_BUY_URL=https://t.me/PremiumBot
 PROMO_ENABLED=true
+MENU_COMPACT=false
 PROMO_CODES=WELCOME50=50,FREE10=10              # опционально: список CODE=AMOUNT через запятую или перенос строки
 PROMO_CODES_JSON={"SPRING200": 200}            # опционально: JSON-словарь с промокодами
 PROMO_CODES_FILE=/app/config/promo_codes.txt    # опционально: путь до файла с промокодами (JSON или CODE=AMOUNT)

--- a/bot.py
+++ b/bot.py
@@ -111,6 +111,7 @@ TELEGRAM_TOKEN      = _env("TELEGRAM_TOKEN")
 PROMPTS_CHANNEL_URL = _env("PROMPTS_CHANNEL_URL", "https://t.me/bestveo3promts")
 STARS_BUY_URL       = _env("STARS_BUY_URL", "https://t.me/PremiumBot")
 PROMO_ENABLED       = _env("PROMO_ENABLED", "true").lower() == "true"
+MENU_COMPACT        = _env("MENU_COMPACT", "false").lower() == "true"
 DEV_MODE            = _env("DEV_MODE", "false").lower() == "true"
 
 OPENAI_API_KEY = _env("OPENAI_API_KEY")
@@ -893,6 +894,22 @@ def render_faq_text() -> str:
     )
 
 def main_menu_kb() -> InlineKeyboardMarkup:
+    if MENU_COMPACT:
+        keyboard = [
+            [inline_button(button_emoji("clapper"), " Генерация видео", callback_data="menu:video")],
+            [inline_button(button_emoji("frame"), " Генерация изображений", callback_data="menu:image")],
+            [
+                inline_button(button_emoji("brain"), " Prompt-Master", callback_data="mode:prompt_master"),
+                inline_button(button_emoji("speech"), " Обычный чат", callback_data="mode:chat"),
+            ],
+            [inline_button(button_emoji("diamond"), " Пополнить баланс", callback_data="topup_open")],
+        ]
+
+        if PROMO_ENABLED:
+            keyboard.append([inline_button("🎁 Активировать промокод", callback_data="promo_open")])
+
+        return InlineKeyboardMarkup(keyboard)
+
     keyboard = [
         [inline_button(button_emoji("clapper"), " Генерация видео", callback_data="menu:video")],
         [inline_button(button_emoji("frame"), " Генерация изображений", callback_data="menu:image")],


### PR DESCRIPTION
## Summary
- add a `MENU_COMPACT` flag to switch the main menu to the new compact layout with the required rows and emoji
- document the new configuration flag in the environment variable reference

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c949e3cc688322869aca4ea621269e