### PR TITLE
Format Prompt-Master replies as headerless quotes

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -28,7 +28,7 @@ from telegram.ext import (
 )
 
 from handlers.prompt_master_handler import PROMPT_MASTER_HINT
-from prompt_master import generate_prompt_master
+from prompt_master import generate_prompt_master, PM_QUOTE_MODE, ensure_quote_block
 
 # === KIE Banana wrapper ===
 from kie_banana import create_banana_task, wait_for_banana_result, KieBananaError
@@ -715,14 +715,20 @@ PROMPT_MASTER_ERROR_MESSAGE = (
 
 
 def _format_prompt_master_quote(text: str) -> str:
-    lines = text.splitlines()
-    if not lines:
-        return ""
-    quoted = []
+    return ensure_quote_block(text)
+
+
+def _is_prompt_master_blockquote(text: str) -> bool:
+    lines = (text or "").splitlines()
+    has_content = False
     for line in lines:
-        cleaned = line.rstrip("\r")
-        quoted.append(f"> {cleaned}" if cleaned else ">")
-    return "\n".join(quoted)
+        stripped = line.strip()
+        if not stripped:
+            continue
+        has_content = True
+        if not stripped.startswith(">"):
+            return False
+    return has_content
 def state(ctx: ContextTypes.DEFAULT_TYPE) -> Dict[str, Any]:
     ud = ctx.user_data
     for k, v in DEFAULT_STATE.items():
@@ -2795,14 +2801,25 @@ async def on_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
             await update.message.reply_text(PROMPT_MASTER_ERROR_MESSAGE, parse_mode=ParseMode.HTML)
             return
 
-        quoted_text = _format_prompt_master_quote(prompt_text)
-        if not quoted_text:
-            quoted_text = prompt_text
+        formatted_text = prompt_text
+        if PM_QUOTE_MODE == "bot":
+            candidate = _format_prompt_master_quote(prompt_text)
+            if candidate:
+                formatted_text = candidate
+        elif PM_QUOTE_MODE == "off":
+            formatted_text = prompt_text
+        else:  # default behaviour — expect generator to quote
+            if not _is_prompt_master_blockquote(prompt_text):
+                candidate = _format_prompt_master_quote(prompt_text)
+                if candidate:
+                    formatted_text = candidate
+        if not formatted_text:
+            formatted_text = prompt_text
         reply_markup = InlineKeyboardMarkup([
             [
                 inline_button(
                     "📋 Скопировать",
-                    api_kwargs={"copy_text": {"text": quoted_text}},
+                    api_kwargs={"copy_text": {"text": formatted_text}},
                 ),
                 inline_button(
                     "🔄 Новый промпт",
@@ -2811,7 +2828,7 @@ async def on_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
             ]
         ])
         await update.message.reply_text(
-            quoted_text,
+            formatted_text,
             reply_markup=reply_markup,
             disable_web_page_preview=True,
         )

--- a/tests/test_prompt_master_formatting.py
+++ b/tests/test_prompt_master_formatting.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+import importlib
+import sys
+
+
+def _reload_prompt_master(monkeypatch, mode=None):
+    if mode is None:
+        monkeypatch.delenv("PM_QUOTE_MODE", raising=False)
+    else:
+        monkeypatch.setenv("PM_QUOTE_MODE", mode)
+
+    if "prompt_master" in sys.modules:
+        del sys.modules["prompt_master"]
+
+    return importlib.import_module("prompt_master")
+
+
+def _all_lines_quoted(text: str) -> bool:
+    return all(line.startswith(">") for line in text.splitlines() if line)
+
+
+def test_prompt_master_generator_mode_blockquote(monkeypatch):
+    pm = _reload_prompt_master(monkeypatch, None)
+    pm._client = None  # ensure fallback mode
+
+    text = pm.generate_prompt_master("Тёплый осенний вечер в городе, огни витрин, живые эмоции")
+
+    assert text
+    assert pm.PM_QUOTE_MODE == "generator"
+    assert _all_lines_quoted(text)
+    assert "Карточка Prompt-Master" not in text
+
+
+def test_prompt_master_bot_mode_plain_then_quote(monkeypatch):
+    pm = _reload_prompt_master(monkeypatch, "bot")
+    pm._client = None  # ensure fallback mode
+
+    text = pm.generate_prompt_master("Контрастное освещение, портрет крупным планом")
+
+    assert text
+    assert pm.PM_QUOTE_MODE == "bot"
+    assert not text.startswith(">")
+    assert "Карточка Prompt-Master" not in text
+
+    quoted = pm.ensure_quote_block(text)
+    assert _all_lines_quoted(quoted)
+
+    _reload_prompt_master(monkeypatch, None)  # restore default for other tests


### PR DESCRIPTION
## Summary
- normalize Prompt-Master output by stripping the header and applying blockquote formatting controlled via `PM_QUOTE_MODE`
- update the bot reply flow to respect the configured quote mode and reuse the shared formatter
- add regression tests covering generator and bot quote modes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c949fe577c8322ae537da0bcd12a08