### PR TITLE
Pin psycopg binaries for Render compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ python-dotenv==1.0.1
 requests==2.32.3
 openai==0.28.1
 redis==5.0.7
-psycopg[binary]==3.2.1
-psycopg-pool==3.2.1
+# Pin psycopg 3.1.x to ensure binary wheels work on Render's Python 3.11 images.
+psycopg[binary]==3.1.20
+psycopg-pool==3.1.9


### PR DESCRIPTION
## Summary
- pin the psycopg binary extra to version 3.1.20 and align psycopg-pool to 3.1.9 so Render's Python 3.11 environment can install without missing system libraries
- document the reason for the psycopg pin inside requirements.txt

## Testing
- pip install --no-cache-dir -r requirements.txt
- pip check
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9579119e483229bf640fbff0f8858