### PR TITLE
Refactor bot startup for polling on Render

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ python-dotenv==1.0.1
 requests==2.32.3
 openai==0.28.1
 redis==5.0.7
-# Pin psycopg 3.1.x to ensure binary wheels work on Render's Python 3.11 images.
-psycopg[binary]==3.1.20
-psycopg-pool==3.1.9
+# Compatible with Python 3.11 runtime on Render.
+psycopg[binary]>=3.2.0,<3.3
+psycopg-pool>=3.2.0,<3.3


### PR DESCRIPTION
## Summary
- clean up merge artifacts in the Telegram bot settings and expose commit metadata for startup logging
- refactor the entrypoint to use a single Application.run_polling call with webhook cleanup, Redis lock management, startup logs, and graceful 409 handling
- update psycopg dependencies to a Render-compatible 3.2.x binary build for Python 3.11

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c960b310c48322ae854ea948ef6701