### PR TITLE
Fix Render build command chaining

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,9 +3,7 @@ services:
     name: best-veo3-bot
     env: python
     pythonVersion: 3.11.9
-    buildCommand: |
-      pip install --upgrade pip
-      pip install -r requirements.txt
+    buildCommand: python -m pip install --upgrade pip && python -m pip install -r requirements.txt
     startCommand: python -u bot.py
     plan: starter
     region: frankfurt


### PR DESCRIPTION
## Summary
- update the Render build command to chain pip invocations with && so multi-command builds execute correctly
- switch to python -m pip to avoid relying on a pip executable

## Testing
- not run (config change only)


------
https://chatgpt.com/codex/tasks/task_e_68c99a401cf08322935ea60def96782b