### PR TITLE
Fix main entry point invocation guard

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1788,7 +1788,6 @@ async def balance_recalc(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         )
     else:
         await update.message.reply_text(f"✅ Баланс актуален: {result.calculated} 💎")
-main
 
 async def health(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     parts = [


### PR DESCRIPTION
## Summary
- remove the stray top-level `main` call so importing the module no longer runs the bot immediately
- rely on the standard `if __name__ == "__main__": main()` block for script execution

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1a4bc2ee48322b9d6bbf2a9c34e22