### PR TITLE
Add prompt master conversation handler

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -27,10 +27,7 @@ from telegram.ext import (
     CallbackQueryHandler, filters, AIORateLimiter, PreCheckoutQueryHandler
 )
 
-try:
-    from handlers.prompt_master_handler import prompt_master_conv
-except Exception:  # pragma: no cover - optional handler
-    prompt_master_conv = None
+from handlers import prompt_master_conv
 from prompt_master import generate_prompt_master
 
 # === KIE Banana wrapper ===
@@ -2736,11 +2733,7 @@ async def run_bot_async() -> None:
 # codex/fix-balance-reset-after-deploy
     application.add_handler(CommandHandler("balance", balance_command))
     application.add_handler(CommandHandler("balance_recalc", balance_recalc))
-    try:
-        if prompt_master_conv:
-            application.add_handler(prompt_master_conv, group=10)
-    except Exception:
-        pass
+    application.add_handler(prompt_master_conv, group=10)
 # main
     application.add_handler(PreCheckoutQueryHandler(precheckout_callback))
     application.add_handler(MessageHandler(filters.SUCCESSFUL_PAYMENT, successful_payment_handler))

--- a/handlers/prompt_master_handler.py
+++ b/handlers/prompt_master_handler.py
@@ -1,5 +1,3 @@
-# handlers/prompt_master_handler.py
-from __future__ import annotations
 from telegram import Update
 from telegram.ext import (
     ConversationHandler,
@@ -11,26 +9,25 @@ from telegram.ext import (
 
 ASK_PROMPT = 1
 
+
 async def pm_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-    await update.effective_chat.send_message("Пришлите текст промпта. /cancel — выход.")
+    await update.message.reply_text("Введите ваш промпт. /cancel для отмены.")
     return ASK_PROMPT
+
 
 async def pm_recv(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     text = (update.message.text or "").strip()
-    if not text:
-        await update.effective_chat.send_message("Пусто. Пришлите текст или /cancel.")
-        return ASK_PROMPT
-    # Здесь в дальнейшем можно вставить PromptMaster/OpenAI-логику
-    await update.effective_chat.send_message(f"Принято:\n\n{text}")
+    await update.message.reply_text(f"Вы прислали:\n\n{text}")
     return ConversationHandler.END
 
+
 async def pm_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
-    await update.effective_chat.send_message("Отменено.")
+    await update.message.reply_text("Отмена.")
     return ConversationHandler.END
+
 
 prompt_master_conv = ConversationHandler(
     entry_points=[CommandHandler("promptmaster", pm_start)],
     states={ASK_PROMPT: [MessageHandler(filters.TEXT & ~filters.COMMAND, pm_recv)]},
     fallbacks=[CommandHandler("cancel", pm_cancel)],
-    name="prompt_master_conv",
 )


### PR DESCRIPTION
## Summary
- add prompt master conversation handler module and export from handlers package
- register the conversation handler with the application startup

## Testing
- python -m compileall handlers/prompt_master_handler.py bot.py

------
https://chatgpt.com/codex/tasks/task_e_68d25dbd45808322a6eea997c62981c6