### PR TITLE
Wire Prompt-Master handler exports

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -28,7 +28,7 @@ from telegram.ext import (
     CallbackQueryHandler, filters, AIORateLimiter, PreCheckoutQueryHandler
 )
 
-from handlers import prompt_master_conv
+from handlers import activate_prompt_master_mode, prompt_master_conv, PROMPT_MASTER_HINT
 from prompt_master import generate_prompt_master
 
 # === KIE Banana wrapper ===
@@ -116,7 +116,6 @@ STARS_BUY_URL       = _env("STARS_BUY_URL", "https://t.me/PremiumBot")
 PROMO_ENABLED       = _env("PROMO_ENABLED", "true").lower() == "true"
 DEV_MODE            = _env("DEV_MODE", "false").lower() == "true"
 
-PROMPT_MASTER_HINT = "Пришлите текст промпта. /cancel — выход."
 
 OPENAI_API_KEY = _env("OPENAI_API_KEY")
 try:
@@ -1923,7 +1922,7 @@ async def on_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     if data.startswith("mode:"):
         selected_mode = data.split(":", 1)[1]
         if selected_mode == "prompt_master":
-            activate_prompt_master_mode(ctx)
+            activate_prompt_master_mode(update, ctx)
             await q.message.reply_text(PROMPT_MASTER_HINT)
             return
         s["mode"] = selected_mode

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,1 +1,7 @@
-from .prompt_master_handler import prompt_master_conv  # noqa: F401
+from .prompt_master_handler import (  # noqa: F401
+    activate_prompt_master_mode,
+    prompt_master_conv,
+    PROMPT_MASTER_HINT,
+)
+
+__all__ = ["activate_prompt_master_mode", "prompt_master_conv", "PROMPT_MASTER_HINT"]

--- a/handlers/prompt_master_handler.py
+++ b/handlers/prompt_master_handler.py
@@ -19,6 +19,7 @@ LOGGER = logging.getLogger(__name__)
 
 ASK_PROMPT = 1
 START_MESSAGE = "Пришлите текст промпта. /cancel — выход."
+PROMPT_MASTER_HINT = START_MESSAGE
 ACCEPT_TEMPLATE = "Принято: {text}"
 ERROR_MESSAGE = "⚠️ Системная ошибка. Попробуйте ещё раз."
 CANCEL_MESSAGE = "Диалог завершён."
@@ -133,3 +134,25 @@ prompt_master_conv = ConversationHandler(
     fallbacks=[CommandHandler("cancel", prompt_master_cancel)],
     name="prompt_master",
 )
+
+
+def activate_prompt_master_mode(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:
+    """Force Prompt-Master conversation state for the user triggered via inline button."""
+
+    del context  # Context is not used but kept for compatibility.
+
+    try:
+        key = prompt_master_conv._get_key(update)  # type: ignore[attr-defined]
+    except Exception:
+        _log_exception("Failed to compute Prompt-Master conversation key")
+        return
+
+    try:
+        prompt_master_conv._update_state(ASK_PROMPT, key)  # type: ignore[attr-defined]
+    except Exception:
+        _log_exception("Failed to activate Prompt-Master conversation state")
+
+
+__all__ = ["activate_prompt_master_mode", "prompt_master_conv", "PROMPT_MASTER_HINT"]


### PR DESCRIPTION
## Summary
- export the Prompt-Master conversation utilities from the handler module and provide the activation helper required by bot.py
- import the Prompt-Master activation routine and hint into the bot so inline callback handling can start the conversation without errors
- keep the main callback wiring intact while ensuring the conversation state is primed when the Prompt-Master mode button is pressed

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d2982d3a008322a16c37f88f165f81