### PR TITLE
Implement conversational Prompt-Master flow

### DIFF
--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,7 +1,15 @@
 from .prompt_master_handler import (  # noqa: F401
-    activate_prompt_master_mode,
+    PM_WAITING,
+    PROMPT_MASTER_CANCEL,
+    PROMPT_MASTER_OPEN,
+    configure_prompt_master,
     prompt_master_conv,
-    PROMPT_MASTER_HINT,
 )
 
-__all__ = ["activate_prompt_master_mode", "prompt_master_conv", "PROMPT_MASTER_HINT"]
+__all__ = [
+    "prompt_master_conv",
+    "configure_prompt_master",
+    "PROMPT_MASTER_OPEN",
+    "PROMPT_MASTER_CANCEL",
+    "PM_WAITING",
+]

--- a/handlers/prompt_master_handler.py
+++ b/handlers/prompt_master_handler.py
@@ -1,11 +1,16 @@
-"""Prompt-Master conversation handler."""
+"""Prompt-Master conversation handler that generates cinematic prompts."""
 
 from __future__ import annotations
 
+import asyncio
+import html
 import logging
+import os
 from contextlib import suppress
+from typing import Awaitable, Callable, Optional
 
-from telegram import Update
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
+from telegram.constants import ChatAction
 from telegram.ext import (
     CallbackQueryHandler,
     CommandHandler,
@@ -17,15 +22,55 @@ from telegram.ext import (
 
 LOGGER = logging.getLogger(__name__)
 
-ASK_PROMPT = 1
-START_MESSAGE = "Пришлите текст промпта. /cancel — выход."
-PROMPT_MASTER_HINT = START_MESSAGE
-ACCEPT_TEMPLATE = "Принято: {text}"
-ERROR_MESSAGE = "⚠️ Системная ошибка. Попробуйте ещё раз."
-CANCEL_MESSAGE = "Диалог завершён."
+PROMPT_MASTER_OPEN = "PROMPT_MASTER_OPEN"
+PROMPT_MASTER_CANCEL = "PROMPT_MASTER_CANCEL"
+
+# Conversation states
+PM_WAITING = range(1)
+_PM_STATE = PM_WAITING[0]
+
+REQUEST_MESSAGE = "Пришлите тему/идею. /cancel — выход."
+READY_MESSAGE_PREFIX = "🧠 Готово! Вот ваш кинопромпт:"
+ERROR_MESSAGE = "⚠️ Не удалось сгенерировать промпт, попробуйте ещё раз."
+CANCEL_MESSAGE = "Отмена"
+
+SYS_PROMPT = (
+    "Ты профессиональный сценарист. Сгенерируй лаконичный, структурированный кинопромпт на английском, "
+    "но диалоги и lip-sync на языке пользователя. Структура: Scene, Camera, Action, Dialogue, Lip-sync, Audio, "
+    "Lighting, Wardrobe/props, Framing. Без лишних пояснений, только разделы с короткими абзацами."
+)
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+try:
+    import openai  # type: ignore
+
+    if OPENAI_API_KEY:
+        openai.api_key = OPENAI_API_KEY
+except Exception:  # pragma: no cover - optional dependency
+    openai = None  # type: ignore
+
+_veo_card_updater: Optional[
+    Callable[[int, ContextTypes.DEFAULT_TYPE], Awaitable[None]]
+] = None
 
 
-def _get_reply_target(update: Update):
+def configure_prompt_master(*, update_veo_card: Optional[Callable[[int, ContextTypes.DEFAULT_TYPE], Awaitable[None]]]) -> None:
+    """Register dependencies required by Prompt-Master handlers."""
+
+    global _veo_card_updater
+    _veo_card_updater = update_veo_card
+
+
+def _result_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("📎 Вставить в VEO ещё раз", callback_data=PROMPT_MASTER_OPEN)],
+            [InlineKeyboardButton("↩️ Назад", callback_data=PROMPT_MASTER_CANCEL)],
+        ]
+    )
+
+
+def _effective_message(update: Update) -> Optional[Message]:
     if update.message:
         return update.message
     if update.callback_query and update.callback_query.message:
@@ -33,126 +78,181 @@ def _get_reply_target(update: Update):
     return None
 
 
-async def _send_error(update: Update) -> None:
-    message = _get_reply_target(update)
-    if message is None:
+async def _send_request_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    message = _effective_message(update)
+    if message is not None:
+        await message.reply_text(REQUEST_MESSAGE)
         return
-    with suppress(Exception):
-        await message.reply_text(ERROR_MESSAGE)
+    chat = update.effective_chat
+    if chat is not None:
+        await context.bot.send_message(chat.id, REQUEST_MESSAGE)
 
 
-def _log_exception(message: str) -> None:
-    LOGGER.exception(message)
+def _store_prompt(context: ContextTypes.DEFAULT_TYPE, prompt_text: str) -> None:
+    context.chat_data.setdefault("veo_card", {})["prompt"] = prompt_text
+    context.chat_data.setdefault("prompt_master", {})["last_prompt"] = prompt_text
+    context.user_data["last_prompt"] = prompt_text
 
 
-async def _start_dialog(update: Update) -> int:
-    message = _get_reply_target(update)
-    if message is None:
-        return ConversationHandler.END
-    await message.reply_text(START_MESSAGE)
-    return ASK_PROMPT
+def _stored_prompt(context: ContextTypes.DEFAULT_TYPE) -> str:
+    veo_card = context.chat_data.get("veo_card") or {}
+    prompt = veo_card.get("prompt")
+    if isinstance(prompt, str):
+        return prompt
+    last_prompt = context.chat_data.get("prompt_master", {}).get("last_prompt")
+    return last_prompt if isinstance(last_prompt, str) else ""
 
 
-async def prompt_master_start_command(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def _update_veo_card_if_visible(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    chat = update.effective_chat
+    if chat is None or not callable(_veo_card_updater):
+        return
+    last_ui_msg_id = context.user_data.get("last_ui_msg_id")
+    if not last_ui_msg_id:
+        return
     try:
-        return await _start_dialog(update)
+        await _veo_card_updater(chat.id, context)  # type: ignore[arg-type]
+    except Exception:  # pragma: no cover - UI update should not crash flow
+        LOGGER.exception("Failed to update VEO card from Prompt-Master")
+
+
+def _is_result_message(message: Optional[Message]) -> bool:
+    if not message or not message.text:
+        return False
+    return message.text.startswith(READY_MESSAGE_PREFIX)
+
+
+async def _call_openai(user_lang: str, topic: str) -> str:
+    if openai is None or not OPENAI_API_KEY:
+        raise RuntimeError("OpenAI client is not configured")
+
+    def _sync_call() -> str:
+        response = openai.ChatCompletion.create(  # type: ignore[union-attr]
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": SYS_PROMPT},
+                {"role": "user", "content": f"Language: {user_lang}\nTopic: {topic}"},
+            ],
+            temperature=0.7,
+            max_tokens=700,
+        )
+        choice = response.choices[0].message["content"].strip()
+        return choice
+
+    return await asyncio.to_thread(_sync_call)
+
+
+async def _generate_prompt(update: Update, context: ContextTypes.DEFAULT_TYPE, topic: str) -> Optional[str]:
+    chat = update.effective_chat
+    if chat is not None:
+        with suppress(Exception):
+            await context.bot.send_chat_action(chat_id=chat.id, action=ChatAction.TYPING)
+
+    user_lang = "en"
+    if update.effective_user and update.effective_user.language_code:
+        user_lang = update.effective_user.language_code
+
+    try:
+        prompt_text = await _call_openai(user_lang, topic)
     except Exception:
-        _log_exception("Failed to start Prompt-Master via command")
-        await _send_error(update)
-        return ConversationHandler.END
+        LOGGER.exception("Prompt-Master generation failed")
+        return None
+    return prompt_text.strip()
 
 
-async def prompt_master_start_callback(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
+async def prompt_master_open(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     query = update.callback_query
-    try:
-        if query:
+    reapply = False
+    answer_text: Optional[str] = None
+    if query:
+        if _is_result_message(query.message):
+            reapply = True
+
+    if reapply:
+        prompt = _stored_prompt(context)
+        if prompt:
+            _store_prompt(context, prompt)
+            await _update_veo_card_if_visible(update, context)
+            answer_text = "Промпт вставлен в карточку VEO."
+
+    if query:
+        await query.answer(answer_text)
+
+    await _send_request_message(update, context)
+    return _PM_STATE
+
+
+async def prompt_master_reapply(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    query = update.callback_query
+    if query:
+        prompt = _stored_prompt(context)
+        if prompt:
+            _store_prompt(context, prompt)
+            await _update_veo_card_if_visible(update, context)
+            await query.answer("Промпт вставлен в карточку VEO.")
+        else:
             await query.answer()
-        return await _start_dialog(update)
-    except Exception:
-        _log_exception("Failed to start Prompt-Master via callback")
-        await _send_error(update)
-        return ConversationHandler.END
+            await _send_request_message(update, context)
+    return _PM_STATE
 
 
-async def prompt_master_start_message(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
-    try:
-        return await _start_dialog(update)
-    except Exception:
-        _log_exception("Failed to start Prompt-Master via reply button")
-        await _send_error(update)
-        return ConversationHandler.END
+async def prompt_master_generate(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    message = update.message
+    if message is None:
+        return _PM_STATE
+
+    topic = (message.text or "").strip()
+    if not topic:
+        await message.reply_text(REQUEST_MESSAGE)
+        return _PM_STATE
+
+    prompt_text = await _generate_prompt(update, context, topic)
+    if not prompt_text:
+        await message.reply_text(ERROR_MESSAGE)
+        return _PM_STATE
+
+    _store_prompt(context, prompt_text)
+    await _update_veo_card_if_visible(update, context)
+
+    await message.reply_html(
+        f"{READY_MESSAGE_PREFIX}\n<pre>{html.escape(prompt_text)}</pre>",
+        reply_markup=_result_keyboard(),
+    )
+    return _PM_STATE
 
 
-async def prompt_master_receive(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
-    try:
-        text = (update.message.text or "").strip()
-        message = update.message
-        if message:
-            await message.reply_text(ACCEPT_TEMPLATE.format(text=text))
-        return ASK_PROMPT
-    except Exception:
-        _log_exception("Failed to process Prompt-Master input")
-        await _send_error(update)
-        return ASK_PROMPT
-
-
-async def prompt_master_cancel(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> int:
-    try:
-        message = _get_reply_target(update)
-        if message is not None:
-            await message.reply_text(CANCEL_MESSAGE)
-    except Exception:
-        _log_exception("Failed to cancel Prompt-Master dialog")
-        await _send_error(update)
+async def prompt_master_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    if update.callback_query:
+        await update.callback_query.answer()
+    message = _effective_message(update)
+    if message is not None:
+        await message.reply_text(CANCEL_MESSAGE)
     return ConversationHandler.END
 
 
 prompt_master_conv = ConversationHandler(
     entry_points=[
-        CommandHandler("promptmaster", prompt_master_start_command),
-        CallbackQueryHandler(
-            prompt_master_start_callback,
-            pattern=r"^(pm:start|prompt_master)$",
-        ),
-        MessageHandler(filters.Regex(r"^🧠 Prompt-Master$"), prompt_master_start_message),
+        CallbackQueryHandler(prompt_master_open, pattern=fr"^{PROMPT_MASTER_OPEN}$"),
     ],
     states={
-        ASK_PROMPT: [
-            MessageHandler(filters.TEXT & ~filters.COMMAND, prompt_master_receive),
+        _PM_STATE: [
+            MessageHandler(filters.TEXT & ~filters.COMMAND, prompt_master_generate),
+            CallbackQueryHandler(prompt_master_reapply, pattern=fr"^{PROMPT_MASTER_OPEN}$"),
+            CallbackQueryHandler(prompt_master_cancel, pattern=fr"^{PROMPT_MASTER_CANCEL}$"),
         ]
     },
-    fallbacks=[CommandHandler("cancel", prompt_master_cancel)],
+    fallbacks=[
+        CommandHandler("cancel", prompt_master_cancel),
+        CallbackQueryHandler(prompt_master_cancel, pattern=fr"^{PROMPT_MASTER_CANCEL}$"),
+    ],
     name="prompt_master",
 )
 
 
-def activate_prompt_master_mode(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> None:
-    """Force Prompt-Master conversation state for the user triggered via inline button."""
-
-    del context  # Context is not used but kept for compatibility.
-
-    try:
-        key = prompt_master_conv._get_key(update)  # type: ignore[attr-defined]
-    except Exception:
-        _log_exception("Failed to compute Prompt-Master conversation key")
-        return
-
-    try:
-        prompt_master_conv._update_state(ASK_PROMPT, key)  # type: ignore[attr-defined]
-    except Exception:
-        _log_exception("Failed to activate Prompt-Master conversation state")
-
-
-__all__ = ["activate_prompt_master_mode", "prompt_master_conv", "PROMPT_MASTER_HINT"]
+__all__ = [
+    "PROMPT_MASTER_OPEN",
+    "PROMPT_MASTER_CANCEL",
+    "PM_WAITING",
+    "prompt_master_conv",
+    "configure_prompt_master",
+]


### PR DESCRIPTION
## Summary
- replace the Prompt-Master stubs with a real conversation handler that talks to OpenAI and stores the generated prompt in chat data
- wire the handler into the bot: update the menu callback data, ignore prompt master callbacks in the generic handler, and hook the VEO card updater into the conversation
- clean up legacy Prompt-Master mode logic that was unreachable and simplify handler exports

## Testing
- python -m compileall handlers bot.py

------
https://chatgpt.com/codex/tasks/task_e_68d29f09b848832286e1b9621963ccfc