### PR TITLE
Swap chat and prompt master button labels

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -773,8 +773,8 @@ def main_menu_kb() -> InlineKeyboardMarkup:
         [InlineKeyboardButton(f"🖼️ Генерация изображений (MJ) 💎 {TOKEN_COSTS['mj']}", callback_data="mode:mj_txt")],
         [InlineKeyboardButton(f"🍌 Редактор изображений (Banana) 💎 {TOKEN_COSTS['banana']}", callback_data="mode:banana")],
         [InlineKeyboardButton(f"📸 Оживить изображение (Veo) 💎 {TOKEN_COSTS['veo_photo']}", callback_data="mode:veo_photo")],
-        [InlineKeyboardButton("🧠 Prompt-Master", callback_data=PROMPT_MASTER_OPEN)],
-        [InlineKeyboardButton("💬 Обычный чат (ChatGPT)", callback_data="mode:chat")],
+        [InlineKeyboardButton("💬 Обычный чат (ChatGPT)", callback_data=PROMPT_MASTER_OPEN)],
+        [InlineKeyboardButton("🧠 Prompt-Master", callback_data="mode:chat")],
         [
             InlineKeyboardButton("❓ FAQ", callback_data="faq"),
             InlineKeyboardButton("📈 Канал с промптами", url=PROMPTS_CHANNEL_URL),


### PR DESCRIPTION
## Summary
- swap the labels for the Prompt-Master and regular chat buttons on the main menu to align with their current behaviour

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2af7b3e388322afb417936ba885d9