### PR TITLE
Ensure VEO results are delivered reliably

### DIFF
--- a/redis_utils.py
+++ b/redis_utils.py
@@ -2,7 +2,9 @@ import json
 import logging
 import os
 import time
-from typing import Any, Dict, Optional
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Any, Dict, Optional, Tuple
 
 import redis
 
@@ -11,36 +13,91 @@ _logger = logging.getLogger("redis-utils")
 _redis_url = os.getenv("REDIS_URL")
 _r = redis.from_url(_redis_url) if _redis_url else None
 _PFX = os.getenv("REDIS_PREFIX", "veo3")
-_TTL = int(os.getenv("TASK_TTL_SECONDS", "86400"))
+_TTL = 24 * 60 * 60
+
+_memory_store: Dict[str, Tuple[float, str]] = {}
+_memory_lock = Lock()
+
+if not _redis_url:
+    _logger.warning(
+        "REDIS_URL is not configured; falling back to in-memory task-meta store"
+    )
 
 
 def task_key(task_id: str) -> str:
     return f"{_PFX}:task:{task_id}"
 
 
-def save_task_meta(task_id: str, chat_id: int, message_id: int, mode: str, user_id: int) -> None:
-    if not _r:
-        _logger.warning("Redis URL is not configured; skipping task-meta save for %s", task_id)
-        return
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _memory_set(key: str, value: str) -> None:
+    expires_at = time.time() + _TTL
+    with _memory_lock:
+        _memory_store[key] = (expires_at, value)
+
+
+def _memory_get(key: str) -> Optional[str]:
+    now = time.time()
+    with _memory_lock:
+        entry = _memory_store.get(key)
+        if not entry:
+            return None
+        expires_at, value = entry
+        if expires_at <= now:
+            _memory_store.pop(key, None)
+            return None
+        return value
+
+
+def _memory_delete(key: str) -> None:
+    with _memory_lock:
+        _memory_store.pop(key, None)
+
+
+def save_task_meta(
+    task_id: str,
+    chat_id: int,
+    message_id: int,
+    mode: str,
+    aspect: str,
+) -> None:
     doc: Dict[str, Any] = {
-        "chat_id": chat_id,
-        "message_id": message_id,
+        "chat_id": int(chat_id),
+        "message_id": int(message_id),
         "mode": mode,
-        "user_id": user_id,
-        "created_at": int(time.time()),
+        "aspect": aspect,
+        "created_at": _now_iso(),
     }
-    _r.setex(task_key(task_id), _TTL, json.dumps(doc, ensure_ascii=False))
+    payload = json.dumps(doc, ensure_ascii=False)
+    key = task_key(task_id)
+    if _r:
+        _r.setex(key, _TTL, payload)
+    else:
+        _memory_set(key, payload)
 
 
 def load_task_meta(task_id: str) -> Optional[Dict[str, Any]]:
-    if not _r:
-        _logger.warning("Redis URL is not configured; cannot load task-meta for %s", task_id)
+    key = task_key(task_id)
+    raw: Optional[str]
+    if _r:
+        redis_raw = _r.get(key)
+        raw = None if redis_raw is None else redis_raw.decode("utf-8") if isinstance(redis_raw, bytes) else str(redis_raw)
+    else:
+        raw = _memory_get(key)
+    if raw is None:
         return None
-    raw = _r.get(task_key(task_id))
-    return None if raw is None else json.loads(raw)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        _logger.exception("Failed to decode task-meta for %s", task_id)
+        return None
 
 
 def clear_task_meta(task_id: str) -> None:
-    if not _r:
-        return
-    _r.delete(task_key(task_id))
+    key = task_key(task_id)
+    if _r:
+        _r.delete(key)
+    else:
+        _memory_delete(key)


### PR DESCRIPTION
## Summary
- persist VEO task metadata in Redis with a 24h TTL and fallback to an in-memory store when Redis is unavailable
- poll KIE record info with exponential backoff, download the rendered video, and deliver it to Telegram with retry-aware messaging

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d2ba8386bc8322b5458fec03d21916