### PR TITLE
Refactor UI cards with reusable helper

### DIFF
--- a/handlers/prompt_master_handler.py
+++ b/handlers/prompt_master_handler.py
@@ -110,7 +110,7 @@ async def _update_veo_card_if_visible(update: Update, context: ContextTypes.DEFA
     chat = update.effective_chat
     if chat is None or not callable(_veo_card_updater):
         return
-    last_ui_msg_id = context.user_data.get("last_ui_msg_id")
+    last_ui_msg_id = context.user_data.get("last_ui_msg_id_veo")
     if not last_ui_msg_id:
         return
     try:

--- a/ui_helpers.py
+++ b/ui_helpers.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from telegram.constants import ParseMode
+
+
+async def upsert_card(
+    ctx: Any,
+    chat_id: int,
+    state_dict: dict[str, Any],
+    state_key: str,
+    text: str,
+    reply_markup: Optional[Any] = None,
+    parse_mode: ParseMode = ParseMode.HTML,
+    disable_web_page_preview: bool = True,
+) -> Optional[int]:
+    """Update an existing UI card or send a new one.
+
+    Returns the message id of the card on success, otherwise ``None``.
+    """
+
+    mid = state_dict.get(state_key)
+    if mid:
+        try:
+            await ctx.bot.edit_message_text(
+                chat_id=chat_id,
+                message_id=mid,
+                text=text,
+                reply_markup=reply_markup,
+                parse_mode=parse_mode,
+                disable_web_page_preview=disable_web_page_preview,
+            )
+            return mid
+        except Exception as exc:  # pragma: no cover - network issues
+            logger = getattr(getattr(ctx, "application", None), "logger", logging.getLogger(__name__))
+            logger.warning("edit %s failed: %s", state_key, exc)
+            state_dict[state_key] = None
+
+    try:
+        msg = await ctx.bot.send_message(
+            chat_id=chat_id,
+            text=text,
+            reply_markup=reply_markup,
+            parse_mode=parse_mode,
+            disable_web_page_preview=disable_web_page_preview,
+        )
+        state_dict[state_key] = msg.message_id
+        return msg.message_id
+    except Exception as exc:  # pragma: no cover - network issues
+        logger = getattr(getattr(ctx, "application", None), "logger", logging.getLogger(__name__))
+        logger.error("send %s failed: %s", state_key, exc)
+        return None


### PR DESCRIPTION
## Summary
- add a reusable `upsert_card` helper to send or edit UI cards and expand the per-user state for caching
- render Banana, VEO and MJ cards in HTML, introduce entry/update helpers, and reuse the helper across mode transitions and message handlers
- adjust Prompt-Master integration and Banana/VEO flows to use the new state keys and helper functions

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d3269eee488322a0f8928a317a8e81