### PR TITLE
Fix Suno integration and UI labels

### DIFF
--- a/ui_helpers.py
+++ b/ui_helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import os
 from typing import Any, Optional, Tuple
 
 from urllib.parse import quote_plus
@@ -12,6 +13,9 @@ from telegram.constants import ParseMode
 from redis_utils import get_balance
 
 import html
+
+_SUNO_MODEL_RAW = (os.getenv("SUNO_MODEL") or "v5").strip()
+_SUNO_MODEL_LABEL = _SUNO_MODEL_RAW.upper() if _SUNO_MODEL_RAW else "V5"
 
 _COPY_TEXT_SUPPORTED = "copy_text" in inspect.signature(InlineKeyboardButton.__init__).parameters
 
@@ -163,7 +167,7 @@ def render_suno_card(state: dict[str, Any], *, price: int) -> Tuple[str, InlineK
     mode_label = "Инструментал" if instrumental else "Со словами"
 
     lines = [
-        "🎵 <b>Генерация музыки — Suno V5</b>",
+        f"🎵 <b>Генерация музыки — Suno {html.escape(_SUNO_MODEL_LABEL)}</b>",
         f"• Название: <b>{safe_title}</b>",
         f"• Стиль: <b>{safe_style}</b>",
         f"• Режим: <b>{mode_label}</b>",


### PR DESCRIPTION
## Summary
- load Suno configuration from environment (base URL, paths, model, price, timeout) and expose helpers for consistent checks and ledger meta updates
- charge users before API submission, issue refunds with `suno:refund`, poll the new endpoints, and surface standardized success/error messages while updating balances
- refresh music generation UI text to drop the “(Suno)” suffix and render the configured model name

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d3e771629083229c8f6ccaefeb8530