### PR TITLE
Centralize Redis prefix constants and soften edit retries

### DIFF
--- a/redis_utils.py
+++ b/redis_utils.py
@@ -19,12 +19,14 @@ else:  # pragma: no cover - fallback alias to avoid runtime dependency
 
 import redis
 
+from settings import REDIS_PREFIX
+
 _logger = logging.getLogger("redis-utils")
 
 _redis_url = os.getenv("REDIS_URL")
 _r = redis.from_url(_redis_url) if _redis_url else None
 rds = _r
-_PFX = os.getenv("REDIS_PREFIX", "veo3")
+_PFX = REDIS_PREFIX
 _TTL = 24 * 60 * 60
 
 _USERS_SET_KEY = f"{_PFX}:users"

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,12 @@
+"""Shared configuration constants for Redis and logging keys."""
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+_default_prefix = "veo3:prod"
+_env_prefix = (os.getenv("REDIS_PREFIX") or "").strip()
+REDIS_PREFIX = _env_prefix or _default_prefix
+
+SUNO_LOG_KEY = f"{REDIS_PREFIX}:suno:logs"


### PR DESCRIPTION
## Summary
- load the Redis prefix and Suno log key from a shared settings module to avoid NameError during startup
- switch Redis helpers to consume the shared prefix constant for consistent key names
- add a safe edit_message_text wrapper that logs HTTP 400 responses as warnings and update Telegram edit call sites to use it

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d3f563e498832288778d42977accb8