### PR TITLE
Add Suno integration module

### DIFF
--- a/examples/add_instrumental_demo.py
+++ b/examples/add_instrumental_demo.py
@@ -1,0 +1,33 @@
+"""Simple demo of creating an add-instrumental task."""
+from __future__ import annotations
+
+import os
+
+from dotenv import load_dotenv
+
+from suno.client import SunoClient
+
+
+def main() -> None:
+    load_dotenv()
+    client = SunoClient(
+        base_url=os.environ["SUNO_API_BASE"],
+        token=os.environ["SUNO_API_TOKEN"],
+    )
+    callback_url = os.environ["SUNO_CALLBACK_PUBLIC_URL"] + "/music"
+    payload = {
+        "uploadUrl": os.environ.get("SUNO_SAMPLE_UPLOAD_URL", "https://example.com/sample.mp3"),
+        "model": "V4_5PLUS",
+        "title": "Demo Track",
+        "tags": "demo",
+        "callBackUrl": callback_url,
+    }
+    response = client.add_instrumental(payload)
+    task_id = response.get("data", {}).get("taskId")
+    print("Task response:", response)
+    if task_id:
+        print("Created task", task_id)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual demo
+    main()

--- a/examples/poll_cover.py
+++ b/examples/poll_cover.py
@@ -1,0 +1,32 @@
+"""Polling example for Suno cover generation."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from suno import downloader
+from suno.client import SunoClient
+
+
+def main(task_id: str) -> None:
+    load_dotenv()
+    client = SunoClient(
+        base_url=os.environ["SUNO_API_BASE"],
+        token=os.environ["SUNO_API_TOKEN"],
+    )
+    info = client.cover_record_info(task_id)
+    images = info.get("data", {}).get("response", {}).get("images", [])
+    for idx, url in enumerate(images):
+        dest = Path(task_id) / f"cover_{idx}"
+        saved = downloader.download_file(url, dest)
+        print("Downloaded", saved)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual demo
+    import sys
+
+    if len(sys.argv) != 2:
+        raise SystemExit("Usage: python poll_cover.py <task_id>")
+    main(sys.argv[1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,10 @@
 python-telegram-bot[rate-limiter]==21.6
 requests==2.32.3
 python-dotenv==1.0.1
+Flask>=3.0.3,<4.0
+tenacity>=8.2,<9.0
+pydantic>=2.7,<3.0
+pytest>=8.2,<9.0
 openai==0.28.1
 redis==5.0.7
 aiohttp>=3.9.5,<4.0

--- a/suno/__init__.py
+++ b/suno/__init__.py
@@ -1,0 +1,14 @@
+"""Suno integration module."""
+from .client import SunoClient, SunoAPIError
+from .store import TaskStore, InMemoryTaskStore
+from .service import SunoService
+from .callbacks import suno_bp
+
+__all__ = [
+    "SunoClient",
+    "SunoAPIError",
+    "TaskStore",
+    "InMemoryTaskStore",
+    "SunoService",
+    "suno_bp",
+]

--- a/suno/_retry.py
+++ b/suno/_retry.py
@@ -1,0 +1,80 @@
+"""Utility module providing tenacity-style retry helpers."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable, Iterable, Tuple, Type
+
+try:  # pragma: no cover - prefer real tenacity
+    from tenacity import (  # type: ignore
+        RetryError,
+        Retrying,
+        retry_if_exception_type,
+        stop_after_attempt,
+        wait_exponential,
+    )
+except Exception:  # pragma: no cover - fallback implementation
+    class RetryError(Exception):
+        """Raised when retry attempts are exhausted."""
+
+    @dataclass
+    class _StopConfig:
+        max_attempts: int
+
+    @dataclass
+    class _RetryConfig:
+        exceptions: Tuple[Type[BaseException], ...]
+
+    @dataclass
+    class _WaitConfig:
+        multiplier: float
+        minimum: float
+        maximum: float
+
+    def stop_after_attempt(attempts: int) -> _StopConfig:
+        return _StopConfig(max_attempts=attempts)
+
+    def retry_if_exception_type(exceptions: Iterable[Type[BaseException]] | Type[BaseException]) -> _RetryConfig:
+        if isinstance(exceptions, type) and issubclass(exceptions, BaseException):
+            exc_tuple = (exceptions,)
+        else:
+            exc_tuple = tuple(exceptions)
+        return _RetryConfig(exceptions=exc_tuple)
+
+    def wait_exponential(multiplier: float = 1.0, min: float = 0.0, max: float = 60.0) -> _WaitConfig:
+        return _WaitConfig(multiplier=multiplier, minimum=min, maximum=max)
+
+    class Retrying:
+        def __init__(self, stop: _StopConfig, wait: _WaitConfig, retry: _RetryConfig, reraise: bool = True) -> None:
+            self._max_attempts = max(1, stop.max_attempts)
+            self._exceptions = retry.exceptions or (Exception,)
+            self._wait = wait
+            self._reraise = reraise
+
+        def __call__(self, fn: Callable, *args, **kwargs):
+            delay = self._wait.minimum or 0
+            last_exc: BaseException | None = None
+            for attempt in range(1, self._max_attempts + 1):
+                try:
+                    return fn(*args, **kwargs)
+                except self._exceptions as exc:  # type: ignore[misc]
+                    last_exc = exc
+                    if attempt >= self._max_attempts:
+                        break
+                    delay = delay * 2 if delay else max(self._wait.multiplier, 0.1)
+                    delay = min(delay, self._wait.maximum)
+                    time.sleep(delay)
+            if self._reraise and last_exc:
+                raise last_exc
+            raise RetryError("Maximum retry attempts reached")
+
+        def call(self, fn: Callable, *args, **kwargs):
+            return self.__call__(fn, *args, **kwargs)
+
+__all__ = [
+    "RetryError",
+    "Retrying",
+    "retry_if_exception_type",
+    "stop_after_attempt",
+    "wait_exponential",
+]

--- a/suno/callbacks.py
+++ b/suno/callbacks.py
@@ -1,0 +1,65 @@
+"""Flask blueprint for Suno callbacks."""
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from typing import Any, Dict
+
+from flask import Blueprint, Response, current_app, jsonify, request
+
+from .service import SunoService
+from .store import InMemoryTaskStore, TaskStore
+
+logger = logging.getLogger("suno.callbacks")
+
+suno_bp = Blueprint("suno", __name__)
+
+
+@lru_cache
+def _default_service() -> SunoService:
+    store: TaskStore = InMemoryTaskStore()
+    return SunoService(store=store)
+
+
+def _get_service() -> SunoService:
+    service = current_app.config.get("SUNO_SERVICE") if current_app else None
+    if isinstance(service, SunoService):
+        return service
+    return _default_service()
+
+
+def _handle(service_method: str, payload: Dict[str, Any]) -> Response:
+    service = _get_service()
+    handler = getattr(service, service_method)
+    handler(payload)
+    return jsonify({"status": "received"})
+
+
+@suno_bp.route("/music", methods=["POST"])
+def music_callback() -> Response:
+    payload = request.get_json(silent=True, force=False) or {}
+    return _handle("handle_music_callback", payload)
+
+
+@suno_bp.route("/wav", methods=["POST"])
+def wav_callback() -> Response:
+    payload = request.get_json(silent=True, force=False) or {}
+    return _handle("handle_wav_callback", payload)
+
+
+@suno_bp.route("/cover", methods=["POST"])
+def cover_callback() -> Response:
+    payload = request.get_json(silent=True, force=False) or {}
+    return _handle("handle_cover_callback", payload)
+
+
+@suno_bp.route("/vocal-separation", methods=["POST"])
+def vocal_separation_callback() -> Response:
+    payload = request.get_json(silent=True, force=False) or {}
+    return _handle("handle_vocal_separation_callback", payload)
+
+
+@suno_bp.route("/mp4", methods=["POST"])
+def mp4_callback() -> Response:
+    payload = request.get_json(silent=True, force=False) or {}
+    return _handle("handle_mp4_callback", payload)

--- a/suno/client.py
+++ b/suno/client.py
@@ -1,0 +1,183 @@
+"""HTTP client for interacting with the Suno API."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+from urllib.parse import urljoin
+
+import requests
+from requests import Response, Session
+
+from ._retry import RetryError, Retrying, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+logger = logging.getLogger("suno.client")
+
+
+class SunoAPIError(RuntimeError):
+    """Raised when the Suno API returns an error."""
+
+
+class SunoRetryableError(Exception):
+    """Internal helper to trigger retry for retryable responses."""
+
+
+_DEFAULT_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT_S", "20"))
+
+
+def _should_retry(response: Response) -> bool:
+    if response.status_code >= 500 or response.status_code == 429:
+        return True
+    try:
+        payload = response.json()
+    except ValueError:
+        return False
+    code = payload.get("code")
+    return isinstance(code, int) and code >= 500
+
+
+class SunoClient:
+    """Simple HTTP client for Suno API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str,
+        timeout: int = _DEFAULT_TIMEOUT,
+        session: Optional[Session] = None,
+    ) -> None:
+        if not base_url:
+            raise ValueError("base_url must be provided")
+        if not token:
+            raise ValueError("token must be provided")
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.timeout = timeout
+        self.session = session or requests.Session()
+        self._retryer = Retrying(
+            stop=stop_after_attempt(4),
+            wait=wait_exponential(multiplier=1, min=1, max=10),
+            retry=retry_if_exception_type((requests.RequestException, SunoRetryableError)),
+            reraise=True,
+        )
+
+    def _request(self, method: str, path: str, *, json: Optional[dict] = None, params: Optional[dict] = None) -> dict:
+        if not path.startswith("/"):
+            raise ValueError("path must start with '/'")
+        url = urljoin(self.base_url + "/", path.lstrip("/"))
+        headers = {"Authorization": f"Bearer {self.token}"}
+
+        def _do_request() -> dict:
+            try:
+                response = self.session.request(
+                    method,
+                    url,
+                    json=json,
+                    params=params,
+                    headers=headers,
+                    timeout=self.timeout,
+                )
+            except requests.RequestException as exc:  # pragma: no cover - handled by retryer
+                logger.warning("Request error on %s %s: %s", method, url, exc)
+                raise exc
+            if response.status_code >= 400:
+                if _should_retry(response):
+                    raise SunoRetryableError(f"retryable status {response.status_code}")
+                raise SunoAPIError(f"HTTP {response.status_code}: {response.text}")
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                raise SunoAPIError("invalid JSON response") from exc
+            code = payload.get("code")
+            if isinstance(code, int) and code >= 400:
+                message = payload.get("msg") or "unexpected error"
+                raise SunoAPIError(f"Suno API error {code}: {message}")
+            return payload
+
+        try:
+            return self._retryer(_do_request)
+        except RetryError as exc:  # pragma: no cover - defensive
+            raise SunoAPIError("maximum retries exceeded") from exc
+
+    def post(self, path: str, payload: Dict[str, Any]) -> dict:
+        if not isinstance(payload, dict):
+            raise ValueError("payload must be a dict")
+        return self._request("POST", path, json=payload)
+
+    def get(self, path: str, params: Dict[str, Any]) -> dict:
+        if not isinstance(params, dict):
+            raise ValueError("params must be a dict")
+        return self._request("GET", path, params=params)
+
+    # Specialized wrappers
+    def _ensure_fields(self, payload: Dict[str, Any], required: tuple[str, ...]) -> None:
+        missing = [field for field in required if not payload.get(field)]
+        if missing:
+            raise ValueError(f"missing required fields: {', '.join(missing)}")
+
+    def add_vocals(self, payload: Dict[str, Any]) -> dict:
+        self._ensure_fields(payload, ("uploadUrl", "callBackUrl"))
+        return self.post("/api/v1/generate/add-vocals", payload)
+
+    def add_instrumental(self, payload: Dict[str, Any]) -> dict:
+        self._ensure_fields(payload, ("uploadUrl", "callBackUrl"))
+        return self.post("/api/v1/generate/add-instrumental", payload)
+
+    def upload_extend(self, payload: Dict[str, Any]) -> dict:
+        self._ensure_fields(payload, ("uploadUrl", "callBackUrl"))
+        return self.post("/api/v1/generate/upload-extend", payload)
+
+    def wav_generate(self, payload: Dict[str, Any]) -> dict:
+        self._ensure_fields(payload, ("uploadUrl", "callBackUrl"))
+        return self.post("/api/v1/wav/generate", payload)
+
+    def vocal_removal_generate(self, payload: Dict[str, Any]) -> dict:
+        self._ensure_fields(payload, ("uploadUrl", "callBackUrl"))
+        return self.post("/api/v1/vocal-removal/generate", payload)
+
+    def cover_generate(self, payload: Dict[str, Any]) -> dict:
+        self._ensure_fields(payload, ("callBackUrl",))
+        return self.post("/api/v1/suno/cover/generate", payload)
+
+    def mp4_generate(self, payload: Dict[str, Any]) -> dict:
+        self._ensure_fields(payload, ("callBackUrl",))
+        return self.post("/api/v1/mp4/generate", payload)
+
+    def style_generate(self, content: str) -> dict:
+        if not content or not content.strip():
+            raise ValueError("content must not be empty")
+        return self.post("/api/v1/style/generate", {"content": content})
+
+    # Status endpoints
+    def music_record_info(self, task_id: str) -> dict:
+        if not task_id:
+            raise ValueError("task_id is required")
+        return self.get("/api/v1/generate/record-info", {"taskId": task_id})
+
+    def get_timestamped_lyrics(self, task_id: str, audio_id: str) -> dict:
+        if not task_id or not audio_id:
+            raise ValueError("task_id and audio_id are required")
+        return self.post(
+            "/api/v1/generate/get-timestamped-lyrics",
+            {"taskId": task_id, "audioId": audio_id},
+        )
+
+    def wav_record_info(self, task_id: str) -> dict:
+        if not task_id:
+            raise ValueError("task_id is required")
+        return self.get("/api/v1/wav/record-info", {"taskId": task_id})
+
+    def vocal_removal_record_info(self, task_id: str) -> dict:
+        if not task_id:
+            raise ValueError("task_id is required")
+        return self.get("/api/v1/vocal-removal/record-info", {"taskId": task_id})
+
+    def cover_record_info(self, task_id: str) -> dict:
+        if not task_id:
+            raise ValueError("task_id is required")
+        return self.get("/api/v1/suno/cover/record-info", {"taskId": task_id})
+
+    def mp4_record_info(self, task_id: str) -> dict:
+        if not task_id:
+            raise ValueError("task_id is required")
+        return self.get("/api/v1/mp4/record-info", {"taskId": task_id})

--- a/suno/downloader.py
+++ b/suno/downloader.py
@@ -1,0 +1,92 @@
+"""Utilities for downloading assets from Suno callbacks."""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+import requests
+from requests import Response
+
+from ._retry import RetryError, Retrying, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+
+class DownloadError(RuntimeError):
+    """Raised when a file cannot be downloaded."""
+
+
+_DEFAULT_DOWNLOAD_DIR = Path(os.getenv("SUNO_DOWNLOAD_DIR", "downloads"))
+_REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT_S", "20"))
+
+
+def _sanitize_component(component: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9._-]", "_", component)
+    return safe.strip("._") or "file"
+
+
+def _guess_extension(url: str) -> str:
+    parsed = urlparse(url)
+    path = parsed.path
+    if not path:
+        return ""
+    suffix = Path(path).suffix
+    return suffix
+
+
+def resolve_destination(dest_path: str | Path, url: str, base_dir: Optional[Path] = None) -> Path:
+    """Resolve destination path ensuring it is scoped to the download dir."""
+
+    if base_dir is None:
+        base_dir = _DEFAULT_DOWNLOAD_DIR
+    base_dir = Path(base_dir)
+    relative = Path(dest_path)
+    safe_parts = [_sanitize_component(part) for part in relative.parts if part not in ("", ".")]
+    safe_relative = Path(*safe_parts)
+    target = base_dir.joinpath(safe_relative)
+    if target.is_dir() or not target.suffix:
+        extension = _guess_extension(url)
+        if extension:
+            target = target.with_suffix(extension)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def _is_retryable(response: Response) -> bool:
+    return response.status_code >= 500 or response.status_code == 429
+
+
+def download_file(url: str, dest_path: str | Path, base_dir: Optional[Path] = None) -> Path:
+    """Download a file with retries and return the resulting path."""
+
+    if not url:
+        raise ValueError("download url must be provided")
+
+    destination = resolve_destination(dest_path, url, base_dir=base_dir)
+    retryer = Retrying(
+        stop=stop_after_attempt(4),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception_type((requests.RequestException, DownloadError)),
+        reraise=True,
+    )
+
+    def _perform_download() -> Path:
+        try:
+            response = requests.get(url, stream=True, timeout=_REQUEST_TIMEOUT)
+        except requests.RequestException as exc:  # pragma: no cover - handled via retryer
+            raise exc
+        if response.status_code >= 400:
+            if _is_retryable(response):
+                raise DownloadError(f"temporary error {response.status_code}")
+            raise DownloadError(f"failed with status {response.status_code}")
+        with destination.open("wb") as fh:
+            for chunk in response.iter_content(chunk_size=8192):
+                if chunk:
+                    fh.write(chunk)
+        return destination
+
+    try:
+        return retryer(_perform_download)
+    except RetryError as exc:  # pragma: no cover - defensive
+        raise DownloadError(str(exc)) from exc

--- a/suno/schemas.py
+++ b/suno/schemas.py
@@ -1,0 +1,59 @@
+"""Pydantic schemas for Suno callbacks and responses."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class CallbackResponse(BaseModel):
+    """Arbitrary payload returned inside the callback envelope."""
+
+    model_config = {"extra": "allow"}
+
+
+class CallbackData(BaseModel):
+    """Data field of callback payload."""
+
+    task_id: Optional[str] = Field(default=None, alias="taskId")
+    callback_type: Optional[str] = Field(default=None, alias="callbackType")
+    status: Optional[str] = None
+    response: Optional[CallbackResponse] = None
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class CallbackEnvelope(BaseModel):
+    """Top-level callback payload."""
+
+    code: Optional[int] = 200
+    msg: Optional[str] = None
+    data: Optional[CallbackData] = None
+
+    model_config = {"extra": "allow"}
+
+
+class TaskAsset(BaseModel):
+    """Normalized representation of downloadable asset."""
+
+    task_id: str
+    url: str
+    asset_type: str
+    identifier: Optional[str] = None
+    filename: Optional[str] = None
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class CallbackEvent(BaseModel):
+    """Normalized callback event that service operates with."""
+
+    task_id: str
+    callback_type: str
+    payload: dict[str, Any]
+    assets: list[TaskAsset] = Field(default_factory=list)
+    status: Optional[str] = None
+    code: Optional[int] = None
+    message: Optional[str] = None
+
+    model_config = {"populate_by_name": True, "extra": "allow"}

--- a/suno/service.py
+++ b/suno/service.py
@@ -1,0 +1,169 @@
+"""Business logic for handling Suno callbacks."""
+from __future__ import annotations
+
+import logging
+import os
+from concurrent.futures import Future, ThreadPoolExecutor
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from .downloader import download_file
+from .schemas import CallbackEnvelope, TaskAsset
+from .store import TaskStore
+
+logger = logging.getLogger("suno.service")
+
+_DEFAULT_DOWNLOAD_DIR = Path(os.getenv("SUNO_DOWNLOAD_DIR", "downloads"))
+
+
+class ImmediateFuture(Future):
+    """Future that is resolved immediately for synchronous executors."""
+
+    def __init__(self, result) -> None:  # pragma: no cover - defensive
+        super().__init__()
+        self.set_result(result)
+
+
+class SunoService:
+    """Service orchestrating callback handling and downloads."""
+
+    def __init__(
+        self,
+        store: TaskStore,
+        download_dir: Path | str = _DEFAULT_DOWNLOAD_DIR,
+        executor: Optional[ThreadPoolExecutor] = None,
+        downloader=download_file,
+    ) -> None:
+        self.store = store
+        self.download_dir = Path(download_dir)
+        self.download_dir.mkdir(parents=True, exist_ok=True)
+        self.downloader = downloader
+        self.executor = executor or ThreadPoolExecutor(max_workers=4)
+
+    def handle_music_callback(self, payload: dict) -> None:
+        self._handle_callback("music", payload)
+
+    def handle_wav_callback(self, payload: dict) -> None:
+        self._handle_callback("wav", payload)
+
+    def handle_cover_callback(self, payload: dict) -> None:
+        self._handle_callback("cover", payload)
+
+    def handle_vocal_separation_callback(self, payload: dict) -> None:
+        self._handle_callback("vocal", payload)
+
+    def handle_mp4_callback(self, payload: dict) -> None:
+        self._handle_callback("mp4", payload)
+
+    def _handle_callback(self, task_kind: str, payload: dict) -> None:
+        envelope = self._parse_payload(payload)
+        if envelope is None or envelope.data is None:
+            logger.warning("Received invalid callback payload for %s", task_kind)
+            return
+        task_id = envelope.data.task_id
+        callback_type = (envelope.data.callback_type or "unknown").lower()
+        if not task_id:
+            logger.warning("Callback without task_id for %s", task_kind)
+            return
+        if self.store.is_processed(task_id, callback_type):
+            logger.debug("Duplicate callback %s/%s", task_id, callback_type)
+            return
+        saved = self.store.save_event(task_id, callback_type, payload)
+        if not saved:
+            logger.debug("Callback already saved %s/%s", task_id, callback_type)
+            return
+        if envelope.code and envelope.code >= 400:
+            self.store.record_error(task_id, {"code": envelope.code, "message": envelope.msg})
+            return
+        if callback_type == "error":
+            error_payload = envelope.data.model_dump() if envelope.data else {}
+            self.store.record_error(task_id, error_payload)
+            return
+        assets = self._extract_assets(task_id, envelope)
+        if assets:
+            self.store.upsert_assets(task_id, [asset.model_dump() for asset in assets])
+            self._download_assets(task_id, assets)
+        else:
+            logger.debug("No assets found for callback %s/%s", task_id, callback_type)
+
+    def _parse_payload(self, payload: dict) -> Optional[CallbackEnvelope]:
+        if not isinstance(payload, dict):
+            return None
+        try:
+            return CallbackEnvelope.model_validate(payload)
+        except Exception:  # pragma: no cover - defensive
+            logger.exception("Failed to parse callback payload")
+            return None
+
+    def _extract_assets(self, task_id: str, envelope: CallbackEnvelope) -> List[TaskAsset]:
+        data = envelope.data
+        if data is None or data.response is None:
+            return []
+        response = data.response.model_dump()
+        assets: List[TaskAsset] = []
+        callback_type = (data.callback_type or "").lower()
+        for asset_type, values in self._iter_candidate_assets(response):
+            for idx, item in enumerate(values):
+                asset = self._coerce_asset(task_id, asset_type, item, idx, callback_type)
+                if asset:
+                    assets.append(asset)
+        return assets
+
+    def _iter_candidate_assets(self, response: dict) -> Iterable[tuple[str, List]]:
+        candidates = {
+            "audio": [],
+            "image": [],
+            "video": [],
+            "stem": [],
+        }
+        for key, value in response.items():
+            if value is None:
+                continue
+            key_lower = key.lower()
+            if any(token in key_lower for token in ["audio", "mp3", "wav"]):
+                candidates["audio"].extend(self._normalize_to_list(value))
+            elif any(token in key_lower for token in ["image", "cover"]):
+                candidates["image"].extend(self._normalize_to_list(value))
+            elif any(token in key_lower for token in ["video", "mp4"]):
+                candidates["video"].extend(self._normalize_to_list(value))
+            elif "stem" in key_lower or "vocal" in key_lower:
+                candidates["stem"].extend(self._normalize_to_list(value))
+        return [(kind, values) for kind, values in candidates.items() if values]
+
+    def _normalize_to_list(self, value) -> List:
+        if isinstance(value, list):
+            return value
+        return [value]
+
+    def _coerce_asset(
+        self,
+        task_id: str,
+        asset_type: str,
+        item,
+        index: int,
+        callback_type: str,
+    ) -> Optional[TaskAsset]:
+        if isinstance(item, str):
+            url = item
+            identifier = str(index)
+        elif isinstance(item, dict):
+            url = item.get("url") or item.get("audioUrl") or item.get("imageUrl") or item.get("mp4Url") or item.get("fileUrl")
+            identifier = (
+                item.get("audioId")
+                or item.get("id")
+                or item.get("name")
+                or item.get("stemName")
+                or item.get("stemId")
+                or str(index)
+            )
+        else:
+            return None
+        if not url:
+            return None
+        filename = f"{callback_type or asset_type}_{asset_type}_{identifier}"
+        return TaskAsset(task_id=task_id, url=url, asset_type=asset_type, identifier=str(identifier), filename=filename)
+
+    def _download_assets(self, task_id: str, assets: List[TaskAsset]) -> None:
+        for asset in assets:
+            relative_path = Path(task_id) / asset.filename
+            self.executor.submit(self.downloader, asset.url, relative_path, self.download_dir)

--- a/suno/store.py
+++ b/suno/store.py
@@ -1,0 +1,79 @@
+"""In-memory task store for Suno callbacks."""
+from __future__ import annotations
+
+import threading
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+from .schemas import TaskAsset
+
+
+class TaskStore(ABC):
+    """Interface for callback idempotency and task tracking."""
+
+    @abstractmethod
+    def save_event(self, task_id: str, callback_type: str, payload: dict) -> bool:
+        """Persist callback payload and return True if it is the first time."""
+
+    @abstractmethod
+    def is_processed(self, task_id: str, callback_type: str) -> bool:
+        """Return whether callback with the same type was processed."""
+
+    @abstractmethod
+    def upsert_assets(self, task_id: str, assets: List[dict]) -> None:
+        """Store asset descriptors for a task."""
+
+    @abstractmethod
+    def record_error(self, task_id: str, error: dict) -> None:
+        """Persist error payload for further inspection."""
+
+    @abstractmethod
+    def get_task_summary(self, task_id: str) -> dict:
+        """Return stored events/assets/errors for the task."""
+
+
+class InMemoryTaskStore(TaskStore):
+    """Thread-safe in-memory implementation of :class:`TaskStore`."""
+
+    def __init__(self) -> None:
+        self._events: Dict[Tuple[str, str], dict] = {}
+        self._assets: Dict[str, Dict[str, TaskAsset]] = defaultdict(dict)
+        self._errors: Dict[str, List[dict]] = defaultdict(list)
+        self._lock = threading.RLock()
+
+    def save_event(self, task_id: str, callback_type: str, payload: dict) -> bool:
+        key = (task_id, callback_type)
+        with self._lock:
+            if key in self._events:
+                return False
+            self._events[key] = payload
+            return True
+
+    def is_processed(self, task_id: str, callback_type: str) -> bool:
+        key = (task_id, callback_type)
+        with self._lock:
+            return key in self._events
+
+    def upsert_assets(self, task_id: str, assets: List[dict]) -> None:
+        with self._lock:
+            bucket = self._assets[task_id]
+            for asset in assets:
+                normalized = TaskAsset(**asset)
+                key = f"{normalized.asset_type}:{normalized.identifier or normalized.url}"
+                bucket[key] = normalized
+
+    def record_error(self, task_id: str, error: dict) -> None:
+        with self._lock:
+            self._errors[task_id].append(error)
+
+    def get_task_summary(self, task_id: str) -> dict:
+        with self._lock:
+            events = {
+                ctype: self._events[(task_id, ctype)]
+                for (tid, ctype) in self._events
+                if tid == task_id
+            }
+            assets = [asset.model_dump() for asset in self._assets.get(task_id, {}).values()]
+            errors = list(self._errors.get(task_id, []))
+        return {"events": events, "assets": assets, "errors": errors}

--- a/tests/test_suno_basic.py
+++ b/tests/test_suno_basic.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from suno.client import SunoClient
+from suno.service import SunoService
+from suno.store import InMemoryTaskStore
+
+
+class ImmediateExecutor:
+    def submit(self, fn, *args, **kwargs):
+        fn(*args, **kwargs)
+        return MagicMock()
+
+
+def build_service(tmp_path: Path, collector: List[Tuple[str, Path]]):
+    store = InMemoryTaskStore()
+
+    def fake_downloader(url: str, dest_path, base_dir=None):
+        base_dir = Path(base_dir) if base_dir else Path("downloads")
+        if not isinstance(dest_path, Path):
+            dest_path = Path(dest_path)
+        collector.append((url, base_dir / dest_path))
+        return base_dir / dest_path
+
+    service = SunoService(
+        store=store,
+        download_dir=tmp_path,
+        executor=ImmediateExecutor(),
+        downloader=fake_downloader,
+    )
+    return service, store
+
+
+def test_music_callback_extracts_assets(tmp_path):
+    collected: List[Tuple[str, Path]] = []
+    service, store = build_service(tmp_path, collected)
+    payload = {
+        "code": 200,
+        "data": {
+            "taskId": "task123",
+            "callbackType": "first",
+            "response": {
+                "audios": [
+                    {"audioId": "a1", "audioUrl": "https://cdn.example.com/a1.mp3"},
+                    {"audioId": "a2", "audioUrl": "https://cdn.example.com/a2.wav"},
+                ],
+                "images": ["https://cdn.example.com/cover.png"],
+            },
+        },
+    }
+    service.handle_music_callback(payload)
+    assert store.is_processed("task123", "first")
+    assert len(collected) == 3
+    urls = {item[0] for item in collected}
+    assert "https://cdn.example.com/a1.mp3" in urls
+    assert all(path.parent == tmp_path / "task123" for _, path in collected)
+
+
+def test_duplicate_callback_is_ignored(tmp_path):
+    collected: List[Tuple[str, Path]] = []
+    service, store = build_service(tmp_path, collected)
+    payload = {
+        "code": 200,
+        "data": {
+            "taskId": "task123",
+            "callbackType": "text",
+            "response": {},
+        },
+    }
+    service.handle_music_callback(payload)
+    service.handle_music_callback(payload)
+    assert len(collected) == 0
+    assert store.is_processed("task123", "text")
+
+
+def test_suno_client_requires_content():
+    client = SunoClient(base_url="https://api.example.com", token="token", session=MagicMock())
+    with pytest.raises(ValueError):
+        client.style_generate("")
+
+
+def test_client_post_includes_auth(monkeypatch):
+    session = MagicMock()
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"code": 200, "data": {}}
+    session.request.return_value = response
+    client = SunoClient(base_url="https://api.example.com", token="secret", session=session)
+    client.add_instrumental({"uploadUrl": "x", "callBackUrl": "cb"})
+    args, kwargs = session.request.call_args
+    assert kwargs["headers"]["Authorization"] == "Bearer secret"


### PR DESCRIPTION
## Summary
- add a dedicated `suno` package with client, service, downloader, store, and callback blueprint for Suno API integration
- include minimal Pydantic schemas, retry helpers, and example scripts for task submission and cover polling
- provide pytest coverage for callback parsing and idempotent downloads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d43e6c7f308322ae27a77f15dc9c84