### PR TITLE
Fix Suno generate music flow and normalize callbacks

### DIFF
--- a/examples/add_instrumental_demo.py
+++ b/examples/add_instrumental_demo.py
@@ -11,7 +11,7 @@ from suno.client import SunoClient
 def main() -> None:
     load_dotenv()
     client = SunoClient(
-        base_url=os.environ["SUNO_API_BASE"],
+        base_url=os.environ.get("SUNO_API_BASE"),
         token=os.environ["SUNO_API_TOKEN"],
     )
     callback_url = os.environ["SUNO_CALLBACK_PUBLIC_URL"] + "/music"
@@ -26,7 +26,9 @@ def main() -> None:
     task_id = response.get("data", {}).get("taskId")
     print("Task response:", response)
     if task_id:
-        print("Created task", task_id)
+        print("taskId:", task_id)
+    else:
+        print("No taskId returned")
 
 
 if __name__ == "__main__":  # pragma: no cover - manual demo

--- a/examples/generate_music_demo.py
+++ b/examples/generate_music_demo.py
@@ -1,0 +1,42 @@
+"""Minimal generate-music demo hitting the official Suno endpoints."""
+from __future__ import annotations
+
+import os
+import time
+
+from dotenv import load_dotenv
+
+from suno.client import SunoClient
+
+
+def main() -> None:
+    load_dotenv()
+    client = SunoClient(
+        base_url=os.environ.get("SUNO_API_BASE"),
+        token=os.environ["SUNO_API_TOKEN"],
+    )
+    callback_url = os.environ["SUNO_CALLBACK_PUBLIC_URL"].rstrip("/") + "/music"
+    response = client.generate_music(
+        prompt="Dreamy synthwave at night city lights",
+        model="V4_5PLUS",
+        title="Neon Drive",
+        style="Synthwave",
+        callBackUrl=callback_url,
+        instrumental=False,
+        negativeTags="heavy metal, blast beats",
+    )
+    task_id = response.get("data", {}).get("taskId")
+    print("Task response:", response)
+    if not task_id:
+        print("No taskId returned")
+        return
+    print("taskId:", task_id)
+
+    # Simple polling example for status debugging.
+    time.sleep(1)
+    status = client.record_info(task_id)
+    print("record_info:", status)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual demo
+    main()

--- a/suno/callbacks.py
+++ b/suno/callbacks.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, List, Literal, Optional
 
 from flask import Blueprint, Response, current_app, jsonify, request
 
@@ -13,6 +14,155 @@ from .store import InMemoryTaskStore, TaskStore
 logger = logging.getLogger("suno.callbacks")
 
 suno_bp = Blueprint("suno", __name__)
+
+
+@dataclass(slots=True)
+class Track:
+    """Normalized representation of a track returned in callbacks."""
+
+    audio_id: str
+    audio_url: Optional[str] = None
+    image_url: Optional[str] = None
+    video_url: Optional[str] = None
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class MusicCallback:
+    """Structured payload for music callbacks."""
+
+    task_id: str
+    type: Literal["text", "first", "complete", "error"]
+    code: int
+    msg: str
+    tracks: List[Track] = field(default_factory=list)
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+
+_KNOWN_TYPES = {"text", "first", "complete", "error"}
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _ensure_list(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _extract_url(item: Any, keys: Iterable[str]) -> Optional[str]:
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        for key in keys:
+            maybe = item.get(key)
+            if maybe:
+                return str(maybe)
+    return None
+
+
+def _coerce_track(item: Any, index: int) -> Optional[Track]:
+    if isinstance(item, dict):
+        audio_id = str(
+            item.get("audioId")
+            or item.get("id")
+            or item.get("name")
+            or item.get("trackId")
+            or index
+        )
+        audio_url = _extract_url(item, ("audioUrl", "url", "fileUrl"))
+        image_url = _extract_url(item, ("imageUrl", "coverUrl", "imgUrl"))
+        video_url = _extract_url(item, ("videoUrl", "mp4Url"))
+        return Track(audio_id=audio_id, audio_url=audio_url, image_url=image_url, video_url=video_url, raw=item)
+    if isinstance(item, str):
+        return Track(audio_id=str(index), audio_url=item, raw={"audioUrl": item})
+    return None
+
+
+def _merge_additional_assets(tracks: List[Track], candidates: List[Any], kind: str) -> None:
+    if not candidates:
+        return
+    by_id = {track.audio_id: track for track in tracks}
+    unmatched = []
+    for entry in candidates:
+        if isinstance(entry, dict):
+            audio_id = entry.get("audioId") or entry.get("id") or entry.get("name")
+            url = _extract_url(entry, ("imageUrl", "coverUrl", "url", "fileUrl", "mp4Url"))
+            if audio_id and url and str(audio_id) in by_id:
+                track = by_id[str(audio_id)]
+                if kind == "image" and not track.image_url:
+                    track.image_url = url
+                    continue
+                if kind == "video" and not track.video_url:
+                    track.video_url = url
+                    continue
+            if url:
+                unmatched.append(url)
+        else:
+            url = _extract_url(entry, ("",))
+            if url:
+                unmatched.append(url)
+    for track, url in zip([t for t in tracks if (kind == "image" and not t.image_url) or (kind == "video" and not t.video_url)], unmatched):
+        if kind == "image":
+            track.image_url = url
+        else:
+            track.video_url = url
+
+
+def _parse_tracks(response: Dict[str, Any]) -> List[Track]:
+    if not isinstance(response, dict):
+        return []
+    tracks_field = _ensure_list(response.get("tracks"))
+    tracks: List[Track] = []
+    if tracks_field:
+        for idx, item in enumerate(tracks_field):
+            track = _coerce_track(item, idx)
+            if track:
+                tracks.append(track)
+        return tracks
+
+    audio_candidates: List[Any] = []
+    image_candidates: List[Any] = []
+    video_candidates: List[Any] = []
+    for key, value in response.items():
+        key_lower = str(key).lower()
+        values = _ensure_list(value)
+        if any(token in key_lower for token in ("audio", "mp3", "wav", "song")):
+            audio_candidates.extend(values)
+        elif any(token in key_lower for token in ("image", "cover", "thumbnail")):
+            image_candidates.extend(values)
+        elif any(token in key_lower for token in ("video", "mp4")):
+            video_candidates.extend(values)
+
+    for idx, item in enumerate(audio_candidates):
+        track = _coerce_track(item, idx)
+        if track:
+            tracks.append(track)
+
+    _merge_additional_assets(tracks, image_candidates, "image")
+    _merge_additional_assets(tracks, video_candidates, "video")
+    return tracks
+
+
+def parse_music_callback(payload: Dict[str, Any]) -> MusicCallback:
+    if not isinstance(payload, dict):
+        return MusicCallback(task_id="", type="error", code=0, msg="invalid payload", tracks=[], raw={})
+    data = payload.get("data") or {}
+    task_id = str(data.get("taskId") or "")
+    callback_type = str(data.get("callbackType") or "text").lower()
+    code = _as_int(payload.get("code"), default=0)
+    msg = str(payload.get("msg") or "")
+    if callback_type not in _KNOWN_TYPES:
+        callback_type = "error" if code and code != 200 else "text"
+    tracks = _parse_tracks(data.get("response") or {})
+    return MusicCallback(task_id=task_id, type=callback_type, code=code or 0, msg=msg, tracks=tracks, raw=payload)
 
 
 @lru_cache
@@ -28,7 +178,7 @@ def _get_service() -> SunoService:
     return _default_service()
 
 
-def _handle(service_method: str, payload: Dict[str, Any]) -> Response:
+def _handle(service_method: str, payload: Any) -> Response:
     service = _get_service()
     handler = getattr(service, service_method)
     handler(payload)
@@ -38,7 +188,8 @@ def _handle(service_method: str, payload: Dict[str, Any]) -> Response:
 @suno_bp.route("/music", methods=["POST"])
 def music_callback() -> Response:
     payload = request.get_json(silent=True, force=False) or {}
-    return _handle("handle_music_callback", payload)
+    callback = parse_music_callback(payload)
+    return _handle("handle_music_callback", callback)
 
 
 @suno_bp.route("/wav", methods=["POST"])

--- a/suno/client.py
+++ b/suno/client.py
@@ -13,6 +13,29 @@ from ._retry import RetryError, Retrying, retry_if_exception_type, stop_after_at
 
 logger = logging.getLogger("suno.client")
 
+BASE = os.getenv("SUNO_API_BASE", "https://api.kie.ai")
+
+ENDPOINTS: dict[str, str] = {
+    "generate_music": "/api/v1/generate/music",
+    "extend_music": "/api/v1/generate/extend",
+    "upload_extend": "/api/v1/generate/upload-extend",
+    "add_instrumental": "/api/v1/generate/add-instrumental",
+    "add_vocals": "/api/v1/generate/add-vocals",
+    "record_info": "/api/v1/generate/record-info",
+    "timestamped_lyrics": "/api/v1/generate/get-timestamped-lyrics",
+    "style_generate": "/api/v1/style/generate",
+    "cover_generate": "/api/v1/suno/cover/generate",
+    "cover_record_info": "/api/v1/suno/cover/record-info",
+    "wav_generate": "/api/v1/wav/generate",
+    "wav_record_info": "/api/v1/wav/record-info",
+    "vocal_sep_generate": "/api/v1/vocal-removal/generate",
+    "vocal_sep_record_info": "/api/v1/vocal-removal/record-info",
+    "mp4_generate": "/api/v1/mp4/generate",
+    "mp4_record_info": "/api/v1/mp4/record-info",
+}
+
+_RETRYABLE_CODES = {408, 429, 455, 500}
+
 
 class SunoAPIError(RuntimeError):
     """Raised when the Suno API returns an error."""
@@ -26,14 +49,14 @@ _DEFAULT_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT_S", "20"))
 
 
 def _should_retry(response: Response) -> bool:
-    if response.status_code >= 500 or response.status_code == 429:
+    if response.status_code in _RETRYABLE_CODES:
         return True
     try:
         payload = response.json()
     except ValueError:
         return False
     code = payload.get("code")
-    return isinstance(code, int) and code >= 500
+    return isinstance(code, int) and code in _RETRYABLE_CODES
 
 
 class SunoClient:
@@ -41,16 +64,17 @@ class SunoClient:
 
     def __init__(
         self,
-        base_url: str,
-        token: str,
+        base_url: Optional[str] = None,
+        token: str = "",
         timeout: int = _DEFAULT_TIMEOUT,
         session: Optional[Session] = None,
     ) -> None:
-        if not base_url:
+        resolved_base = (base_url or BASE or "").strip()
+        if not resolved_base:
             raise ValueError("base_url must be provided")
         if not token:
             raise ValueError("token must be provided")
-        self.base_url = base_url.rstrip("/")
+        self.base_url = resolved_base.rstrip("/")
         self.token = token
         self.timeout = timeout
         self.session = session or requests.Session()
@@ -61,11 +85,32 @@ class SunoClient:
             reraise=True,
         )
 
-    def _request(self, method: str, path: str, *, json: Optional[dict] = None, params: Optional[dict] = None) -> dict:
+    def _resolve_path(self, endpoint: str) -> str:
+        if not endpoint:
+            raise ValueError("endpoint must be provided")
+        path = ENDPOINTS.get(endpoint, endpoint)
         if not path.startswith("/"):
             raise ValueError("path must start with '/'")
+        return path
+
+    def _url_for(self, endpoint: str) -> str:
+        path = self._resolve_path(endpoint)
+        return urljoin(self.base_url + "/", path.lstrip("/"))
+
+    def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        json: Optional[dict] = None,
+        params: Optional[dict] = None,
+    ) -> dict:
+        path = self._resolve_path(endpoint)
         url = urljoin(self.base_url + "/", path.lstrip("/"))
-        headers = {"Authorization": f"Bearer {self.token}"}
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+        }
 
         def _do_request() -> dict:
             try:
@@ -80,7 +125,14 @@ class SunoClient:
             except requests.RequestException as exc:  # pragma: no cover - handled by retryer
                 logger.warning("Request error on %s %s: %s", method, url, exc)
                 raise exc
-            if response.status_code >= 400:
+            if response.status_code != 200:
+                logger.warning(
+                    "Suno API HTTP error %s on %s %s: %s",
+                    response.status_code,
+                    method,
+                    path,
+                    response.text,
+                )
                 if _should_retry(response):
                     raise SunoRetryableError(f"retryable status {response.status_code}")
                 raise SunoAPIError(f"HTTP {response.status_code}: {response.text}")
@@ -89,8 +141,18 @@ class SunoClient:
             except ValueError as exc:
                 raise SunoAPIError("invalid JSON response") from exc
             code = payload.get("code")
-            if isinstance(code, int) and code >= 400:
+            if isinstance(code, int) and code != 200:
                 message = payload.get("msg") or "unexpected error"
+                logger.warning(
+                    "Suno API logical error on %s %s: code=%s msg=%s payload=%s",
+                    method,
+                    path,
+                    code,
+                    message,
+                    payload,
+                )
+                if code in _RETRYABLE_CODES:
+                    raise SunoRetryableError(f"retryable code {code}")
                 raise SunoAPIError(f"Suno API error {code}: {message}")
             return payload
 
@@ -99,15 +161,15 @@ class SunoClient:
         except RetryError as exc:  # pragma: no cover - defensive
             raise SunoAPIError("maximum retries exceeded") from exc
 
-    def post(self, path: str, payload: Dict[str, Any]) -> dict:
+    def post(self, endpoint: str, payload: Dict[str, Any]) -> dict:
         if not isinstance(payload, dict):
             raise ValueError("payload must be a dict")
-        return self._request("POST", path, json=payload)
+        return self._request("POST", endpoint, json=payload)
 
-    def get(self, path: str, params: Dict[str, Any]) -> dict:
+    def get(self, endpoint: str, params: Dict[str, Any]) -> dict:
         if not isinstance(params, dict):
             raise ValueError("params must be a dict")
-        return self._request("GET", path, params=params)
+        return self._request("GET", endpoint, params=params)
 
     # Specialized wrappers
     def _ensure_fields(self, payload: Dict[str, Any], required: tuple[str, ...]) -> None:
@@ -115,69 +177,110 @@ class SunoClient:
         if missing:
             raise ValueError(f"missing required fields: {', '.join(missing)}")
 
+    def generate_music(
+        self,
+        *,
+        prompt: str,
+        model: str,
+        title: str,
+        style: str,
+        callBackUrl: str,
+        instrumental: bool = True,
+        negativeTags: Optional[str] = None,
+        vocalGender: Optional[str] = None,
+        styleWeight: Optional[float] = None,
+        weirdnessConstraint: Optional[float] = None,
+        audioWeight: Optional[float] = None,
+    ) -> dict:
+        """Submit a generate music task."""
+
+        payload: Dict[str, Any] = {
+            "prompt": prompt,
+            "model": model,
+            "title": title,
+            "style": style,
+            "callBackUrl": callBackUrl,
+            "instrumental": instrumental,
+        }
+        self._ensure_fields(
+            payload,
+            ("prompt", "model", "title", "style", "callBackUrl"),
+        )
+        optional_fields = {
+            "negativeTags": negativeTags,
+            "vocalGender": vocalGender,
+            "styleWeight": styleWeight,
+            "weirdnessConstraint": weirdnessConstraint,
+            "audioWeight": audioWeight,
+        }
+        for key, value in optional_fields.items():
+            if value is not None:
+                payload[key] = value
+        return self.post("generate_music", payload)
+
     def add_vocals(self, payload: Dict[str, Any]) -> dict:
         self._ensure_fields(payload, ("uploadUrl", "callBackUrl"))
-        return self.post("/api/v1/generate/add-vocals", payload)
+        return self.post("add_vocals", payload)
 
     def add_instrumental(self, payload: Dict[str, Any]) -> dict:
         self._ensure_fields(payload, ("uploadUrl", "callBackUrl"))
-        return self.post("/api/v1/generate/add-instrumental", payload)
+        return self.post("add_instrumental", payload)
 
     def upload_extend(self, payload: Dict[str, Any]) -> dict:
         self._ensure_fields(payload, ("uploadUrl", "callBackUrl"))
-        return self.post("/api/v1/generate/upload-extend", payload)
+        return self.post("upload_extend", payload)
 
     def wav_generate(self, payload: Dict[str, Any]) -> dict:
         self._ensure_fields(payload, ("uploadUrl", "callBackUrl"))
-        return self.post("/api/v1/wav/generate", payload)
+        return self.post("wav_generate", payload)
 
     def vocal_removal_generate(self, payload: Dict[str, Any]) -> dict:
         self._ensure_fields(payload, ("uploadUrl", "callBackUrl"))
-        return self.post("/api/v1/vocal-removal/generate", payload)
+        return self.post("vocal_sep_generate", payload)
 
     def cover_generate(self, payload: Dict[str, Any]) -> dict:
         self._ensure_fields(payload, ("callBackUrl",))
-        return self.post("/api/v1/suno/cover/generate", payload)
+        return self.post("cover_generate", payload)
 
     def mp4_generate(self, payload: Dict[str, Any]) -> dict:
         self._ensure_fields(payload, ("callBackUrl",))
-        return self.post("/api/v1/mp4/generate", payload)
+        return self.post("mp4_generate", payload)
 
     def style_generate(self, content: str) -> dict:
         if not content or not content.strip():
             raise ValueError("content must not be empty")
-        return self.post("/api/v1/style/generate", {"content": content})
+        return self.post("style_generate", {"content": content})
 
     # Status endpoints
-    def music_record_info(self, task_id: str) -> dict:
+    def record_info(self, task_id: str) -> dict:
         if not task_id:
             raise ValueError("task_id is required")
-        return self.get("/api/v1/generate/record-info", {"taskId": task_id})
+        return self.get("record_info", {"taskId": task_id})
 
     def get_timestamped_lyrics(self, task_id: str, audio_id: str) -> dict:
         if not task_id or not audio_id:
             raise ValueError("task_id and audio_id are required")
         return self.post(
-            "/api/v1/generate/get-timestamped-lyrics",
+            "timestamped_lyrics",
             {"taskId": task_id, "audioId": audio_id},
         )
 
     def wav_record_info(self, task_id: str) -> dict:
         if not task_id:
             raise ValueError("task_id is required")
-        return self.get("/api/v1/wav/record-info", {"taskId": task_id})
+        return self.get("wav_record_info", {"taskId": task_id})
 
     def vocal_removal_record_info(self, task_id: str) -> dict:
         if not task_id:
             raise ValueError("task_id is required")
-        return self.get("/api/v1/vocal-removal/record-info", {"taskId": task_id})
+        return self.get("vocal_sep_record_info", {"taskId": task_id})
 
     def cover_record_info(self, task_id: str) -> dict:
         if not task_id:
             raise ValueError("task_id is required")
-        return self.get("/api/v1/suno/cover/record-info", {"taskId": task_id})
+        return self.get("cover_record_info", {"taskId": task_id})
 
     def mp4_record_info(self, task_id: str) -> dict:
         if not task_id:
             raise ValueError("task_id is required")
-        return self.get("/api/v1/mp4/record-info", {"taskId": task_id})
+        return self.get("mp4_record_info", {"taskId": task_id})

--- a/tests/test_suno_basic.py
+++ b/tests/test_suno_basic.py
@@ -10,7 +10,8 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from suno.client import SunoClient
+from suno.callbacks import MusicCallback, parse_music_callback
+from suno.client import ENDPOINTS, SunoClient
 from suno.service import SunoService
 from suno.store import InMemoryTaskStore
 
@@ -38,6 +39,17 @@ def build_service(tmp_path: Path, collector: List[Tuple[str, Path]]):
         downloader=fake_downloader,
     )
     return service, store
+
+
+def test_endpoint_url_building():
+    session = MagicMock()
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"code": 200}
+    session.request.return_value = response
+    client = SunoClient(base_url="https://api.example.com", token="token", session=session)
+    expected = "https://api.example.com" + ENDPOINTS["generate_music"]
+    assert client._url_for("generate_music") == expected
 
 
 def test_music_callback_extracts_assets(tmp_path):
@@ -88,6 +100,42 @@ def test_suno_client_requires_content():
         client.style_generate("")
 
 
+def test_generate_music_requires_prompt():
+    client = SunoClient(base_url="https://api.example.com", token="token", session=MagicMock())
+    with pytest.raises(ValueError):
+        client.generate_music(
+            prompt="",
+            model="model",
+            title="title",
+            style="style",
+            callBackUrl="https://callback",
+        )
+
+
+def test_parse_music_callback_normalizes_type():
+    payload = {
+        "code": 200,
+        "data": {
+            "taskId": "abc",
+            "callbackType": "FIRST",
+            "response": {
+                "tracks": [
+                    {
+                        "audioId": "track1",
+                        "audioUrl": "https://cdn.example.com/track1.mp3",
+                        "imageUrl": "https://cdn.example.com/track1.jpg",
+                    }
+                ]
+            },
+        },
+    }
+    callback = parse_music_callback(payload)
+    assert isinstance(callback, MusicCallback)
+    assert callback.type == "first"
+    assert callback.task_id == "abc"
+    assert callback.tracks and callback.tracks[0].audio_id == "track1"
+
+
 def test_client_post_includes_auth(monkeypatch):
     session = MagicMock()
     response = MagicMock()
@@ -98,3 +146,58 @@ def test_client_post_includes_auth(monkeypatch):
     client.add_instrumental({"uploadUrl": "x", "callBackUrl": "cb"})
     args, kwargs = session.request.call_args
     assert kwargs["headers"]["Authorization"] == "Bearer secret"
+    assert kwargs["headers"]["Content-Type"] == "application/json"
+
+
+def test_generate_music_retries_on_429():
+    session = MagicMock()
+    first = MagicMock()
+    first.status_code = 429
+    first.text = "rate limit"
+    first.json.return_value = {"code": 429, "msg": "rate"}
+    second = MagicMock()
+    second.status_code = 200
+    second.json.return_value = {"code": 200, "data": {"taskId": "xyz"}}
+    session.request.side_effect = [first, second]
+    client = SunoClient(base_url="https://api.example.com", token="token", session=session)
+    result = client.generate_music(
+        prompt="melody",
+        model="model",
+        title="title",
+        style="style",
+        callBackUrl="https://callback",
+    )
+    assert result["data"]["taskId"] == "xyz"
+    assert session.request.call_count == 2
+
+
+def test_music_callback_deduplicates_audio_across_types(tmp_path):
+    collected: List[Tuple[str, Path]] = []
+    service, store = build_service(tmp_path, collected)
+    base_payload = {
+        "code": 200,
+        "data": {
+            "taskId": "task777",
+            "callbackType": "first",
+            "response": {
+                "tracks": [
+                    {
+                        "audioId": "songA",
+                        "audioUrl": "https://cdn.example.com/songA.mp3",
+                        "imageUrl": "https://cdn.example.com/songA.jpg",
+                    }
+                ]
+            },
+        },
+    }
+    service.handle_music_callback(parse_music_callback(base_payload))
+    follow_up = base_payload.copy()
+    follow_up["data"] = dict(base_payload["data"])
+    follow_up["data"]["callbackType"] = "complete"
+    service.handle_music_callback(parse_music_callback(follow_up))
+    assert store.is_processed("task777", "first")
+    assert store.is_processed("task777", "complete")
+    assert len(collected) == 2  # audio + image only once
+    saved_paths = {path for _, path in collected}
+    assert tmp_path / "task777" / "songA.mp3" in saved_paths
+    assert tmp_path / "task777" / "songA.jpeg" in saved_paths


### PR DESCRIPTION
## Summary
- centralize Suno API endpoint constants and add a validated generate_music helper
- normalize music callbacks into typed DTOs and deduplicate audio downloads while saving assets deterministically
- harden downloader paths/timeouts, refresh demos, and add pytest coverage for URLs, retries, parsing, and idempotency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4442800a48322ad0955e1b87f26f1