### PR TITLE
Add Suno callback web service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ python-telegram-bot[rate-limiter]==21.6
 requests==2.32.3
 python-dotenv==1.0.1
 Flask>=3.0.3,<4.0
+gunicorn>=21.2,<22.0
 tenacity>=8.2,<9.0
 pydantic>=2.7,<3.0
 pytest>=8.2,<9.0

--- a/suno_web.py
+++ b/suno_web.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+from typing import Any, Dict, List
+import os
+import json
+import datetime as dt
+
+from flask import Flask, request, jsonify, abort
+
+try:
+    from suno.store import SunoStore  # типовой наш слой хранения
+except Exception:
+    SunoStore = None  # веб будет работать даже если store недоступен
+
+app = Flask(__name__)
+
+
+@app.get("/healthz")
+def healthz():
+    return {"status": "ok", "time": dt.datetime.utcnow().isoformat()}, 200
+
+
+@app.post("/suno-callback")
+def suno_callback():
+    if not request.is_json:
+        abort(400, "JSON body required")
+
+    payload = request.get_json(force=True)
+    code: int = payload.get("code", 0)
+    msg: str = payload.get("msg", "")
+    data: Dict[str, Any] = payload.get("data", {}) or {}
+    cb_type: str = data.get("callbackType", "")
+    task_id: str = data.get("task_id", "") or data.get("taskId", "")
+    tracks: List[Dict[str, Any]] = data.get("data", []) or []
+
+    app.logger.info(
+        "[SUNO] callback code=%s type=%s task_id=%s msg=%s",
+        code,
+        cb_type,
+        task_id,
+        msg,
+    )
+
+    try:
+        os.makedirs("/tmp/suno", exist_ok=True)
+        stamp = dt.datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+        with open(f"/tmp/suno/{stamp}_{task_id or 'no-task'}.json", "w") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+    except Exception as e:  # pragma: no cover - best effort logging
+        app.logger.warning("Failed to write temp file: %s", e)
+
+    if SunoStore:
+        try:
+            store = SunoStore()
+            store.save_callback(
+                task_id=task_id,
+                callback_type=cb_type,
+                code=code,
+                message=msg,
+                payload=payload,
+                tracks=tracks,
+            )
+        except Exception as e:  # pragma: no cover - best effort logging
+            app.logger.error("Store save failed: %s", e)
+
+    return jsonify({"status": "received"}), 200
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))


### PR DESCRIPTION
## Summary
- add a standalone Flask application for handling Suno callbacks with health and callback endpoints
- persist raw callback payloads to /tmp/suno and optionally store normalized data using SunoStore
- include gunicorn in requirements for deployment via gunicorn

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d45a159c108322a0dfd43b16c4ddd4