### PR TITLE
Harden Suno client URL building and env handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ KIE_BANANA_MODEL=google/nano-banana-edit
 
 # Suno API
 SUNO_ENABLED=true
-SUNO_API_URL=https://api.kie.ai/suno-api
-SUNO_GEN_PATH=/api/v1/generate
+SUNO_API_BASE=https://api.kie.ai
+SUNO_API_PREFIX=
+SUNO_GEN_PATH=/api/v1/generate/music
 SUNO_STATUS_PATH=/api/v1/generate/record-info
 SUNO_EXTEND_PATH=/api/v1/generate/extend
 SUNO_LYRICS_PATH=/api/v1/lyrics

--- a/suno/service.py
+++ b/suno/service.py
@@ -16,6 +16,18 @@ if TYPE_CHECKING:  # pragma: no cover - only used for typing
 
 logger = logging.getLogger("suno.service")
 
+
+def _warn_env() -> None:
+    base = os.getenv("SUNO_API_BASE", "")
+    gen = os.getenv("SUNO_GEN_PATH", "")
+    if "suno-api" in (base or "") or "suno-api" in (gen or ""):
+        logging.warning(
+            "ENV contains 'suno-api' in BASE or PATH. We normalize it, but please remove the segment from ENV.",
+        )
+
+
+_warn_env()
+
 _DEFAULT_DOWNLOAD_DIR = Path(os.getenv("SUNO_DOWNLOAD_DIR", "downloads"))
 
 


### PR DESCRIPTION
## Summary
- add a safe URL joiner for the Suno client with debug logging and stricter env validation
- normalize bot configuration to use SUNO_API_BASE/SUNO_API_PREFIX and update README defaults
- warn at service startup when legacy `suno-api` segments are still present in env values

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d45f6f721083228b09ae9ac38cbfa7