### PR TITLE
Implement FastAPI Suno callback endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 python-telegram-bot[rate-limiter]==21.6
 requests==2.32.3
 python-dotenv==1.0.1
+fastapi>=0.111,<0.112
+uvicorn[standard]>=0.30,<0.31
 Flask>=3.0.3,<4.0
 gunicorn>=21.2,<22.0
 tenacity>=8.2,<9.0

--- a/suno_web.py
+++ b/suno_web.py
@@ -1,69 +1,254 @@
 from __future__ import annotations
-from typing import Any, Dict, List
-import os
-import json
-import datetime as dt
 
-from flask import Flask, request, jsonify, abort
+import json
+import logging
+import os
+import pathlib
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+import requests
+from fastapi import FastAPI, Header, Request
+from fastapi.responses import JSONResponse
+
+# redis optional
+try:
+    import redis  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    redis = None  # type: ignore
 
 try:
-    from suno.store import SunoStore  # типовой наш слой хранения
-except Exception:
-    SunoStore = None  # веб будет работать даже если store недоступен
+    from suno.downloader import download_file as suno_download_file
+except Exception:  # pragma: no cover - optional helper
+    suno_download_file = None  # type: ignore
 
-app = Flask(__name__)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s | suno-web | %(message)s")
+log = logging.getLogger("suno-web")
+
+app = FastAPI(title="Suno Callback Web")
+
+REDIS_URL = os.getenv("REDIS_URL")
+TG_TOKEN = os.getenv("TELEGRAM_TOKEN", "")
+ADMIN_IDS = [item.strip() for item in os.getenv("ADMIN_IDS", "").split(",") if item.strip()]
+CALLBACK_SECRET = os.getenv("SUNO_CALLBACK_SECRET", "")
+
+rds = None
+if REDIS_URL and redis is not None:
+    try:
+        rds = redis.Redis.from_url(REDIS_URL, decode_responses=True)
+        rds.ping()
+        log.info("Redis connected")
+    except Exception as exc:  # pragma: no cover - best effort
+        log.warning(f"Redis unavailable: {exc}")
+
+
+_seen: set[str] = set()
 
 
 @app.get("/healthz")
-def healthz():
-    return {"status": "ok", "time": dt.datetime.utcnow().isoformat()}, 200
+def healthz() -> Dict[str, bool]:
+    return {"ok": True}
+
+
+def _idem_key(task_id: str, cb_type: str) -> str:
+    return f"suno:cb:{task_id}:{cb_type}"
+
+
+def _idem_check_and_mark(key: str) -> bool:
+    """Return True if key already processed."""
+
+    try:
+        if rds is not None:
+            added = rds.setnx(key, "1")
+            if not added:
+                return True
+            rds.expire(key, 86400)
+            return False
+    except Exception as exc:  # pragma: no cover - network/cache issue
+        log.warning(f"Redis idempotency failed: {exc}")
+
+    if key in _seen:
+        return True
+    _seen.add(key)
+    return False
+
+
+def _ensure_dir(path: pathlib.Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _download(url: str, destination: pathlib.Path) -> Optional[pathlib.Path]:
+    if not url:
+        return None
+
+    target = destination
+    if not target.suffix:
+        ext = pathlib.Path(urlparse(url).path).suffix
+        if ext:
+            target = target.with_suffix(ext)
+
+    try:
+        if suno_download_file is not None:
+            _ensure_dir(target.parent)
+            downloaded = suno_download_file(url, target.name, base_dir=target.parent)
+            return pathlib.Path(downloaded)
+
+        with requests.get(url, stream=True, timeout=60) as resp:
+            resp.raise_for_status()
+            _ensure_dir(target.parent)
+            with target.open("wb") as file_handle:
+                for chunk in resp.iter_content(chunk_size=8192):
+                    if chunk:
+                        file_handle.write(chunk)
+        return target
+    except Exception as exc:  # pragma: no cover - external IO failures
+        log.warning(f"Download failed {url} -> {destination}: {exc}")
+        return None
+
+
+def _tg_send_message(text: str) -> List[str]:
+    statuses: List[str] = []
+    if not TG_TOKEN or not ADMIN_IDS:
+        log.warning("No TELEGRAM_TOKEN/ADMIN_IDS; skip Telegram notify")
+        return ["skipped"]
+
+    for chat_id in ADMIN_IDS:
+        try:
+            response = requests.post(
+                f"https://api.telegram.org/bot{TG_TOKEN}/sendMessage",
+                json={"chat_id": chat_id, "text": text},
+                timeout=20,
+            )
+            if response.ok:
+                statuses.append(f"{chat_id}:ok")
+            else:
+                statuses.append(f"{chat_id}:http{response.status_code}")
+        except Exception as exc:  # pragma: no cover - network issues
+            statuses.append(f"{chat_id}:error")
+            log.warning(f"sendMessage failed for {chat_id}: {exc}")
+    return statuses
+
+
+def _tg_send_file(filepath: pathlib.Path, caption: str = "") -> List[str]:
+    statuses: List[str] = []
+    if not TG_TOKEN or not ADMIN_IDS:
+        return ["skipped"]
+
+    suffix = filepath.suffix.lower()
+    mime = "audio/mpeg" if suffix in {".mp3", ".wav"} else None
+    method = "sendDocument"
+    field_name = "document"
+    if suffix in {".jpg", ".jpeg", ".png"}:
+        method = "sendPhoto"
+        field_name = "photo"
+
+    for chat_id in ADMIN_IDS:
+        try:
+            with filepath.open("rb") as fh:
+                files = {field_name: (filepath.name, fh, mime or "application/octet-stream")}
+                data = {"chat_id": chat_id, "caption": caption}
+                response = requests.post(
+                    f"https://api.telegram.org/bot{TG_TOKEN}/{method}",
+                    data=data,
+                    files=files,
+                    timeout=60,
+                )
+            if response.ok:
+                statuses.append(f"{chat_id}:ok")
+            else:
+                statuses.append(f"{chat_id}:http{response.status_code}")
+        except Exception as exc:  # pragma: no cover - network issues
+            statuses.append(f"{chat_id}:error")
+            log.warning(f"sendFile failed for {chat_id}: {exc}")
+    return statuses
 
 
 @app.post("/suno-callback")
-def suno_callback():
-    if not request.is_json:
-        abort(400, "JSON body required")
-
-    payload = request.get_json(force=True)
-    code: int = payload.get("code", 0)
-    msg: str = payload.get("msg", "")
-    data: Dict[str, Any] = payload.get("data", {}) or {}
-    cb_type: str = data.get("callbackType", "")
-    task_id: str = data.get("task_id", "") or data.get("taskId", "")
-    tracks: List[Dict[str, Any]] = data.get("data", []) or []
-
-    app.logger.info(
-        "[SUNO] callback code=%s type=%s task_id=%s msg=%s",
-        code,
-        cb_type,
-        task_id,
-        msg,
-    )
+async def suno_callback(
+    request: Request,
+    x_callback_token: Optional[str] = Header(default=None, convert_underscores=False),
+):
+    if CALLBACK_SECRET:
+        if not x_callback_token or x_callback_token != CALLBACK_SECRET:
+            log.warning("Forbidden: bad X-Callback-Token")
+            return JSONResponse({"error": "forbidden"}, status_code=403)
+    else:
+        log.warning("SUNO_CALLBACK_SECRET is empty — allowing requests in DEV")
 
     try:
-        os.makedirs("/tmp/suno", exist_ok=True)
-        stamp = dt.datetime.utcnow().strftime("%Y%m%dT%H%M%S")
-        with open(f"/tmp/suno/{stamp}_{task_id or 'no-task'}.json", "w") as f:
-            json.dump(payload, f, ensure_ascii=False, indent=2)
-    except Exception as e:  # pragma: no cover - best effort logging
-        app.logger.warning("Failed to write temp file: %s", e)
+        payload = await request.json()
+    except json.JSONDecodeError as exc:
+        body = await request.body()
+        log.error(f"Invalid JSON payload: {exc}; body={body!r}")
+        return {"status": "received"}
 
-    if SunoStore:
-        try:
-            store = SunoStore()
-            store.save_callback(
-                task_id=task_id,
-                callback_type=cb_type,
-                code=code,
-                message=msg,
-                payload=payload,
-                tracks=tracks,
-            )
-        except Exception as e:  # pragma: no cover - best effort logging
-            app.logger.error("Store save failed: %s", e)
+    if not isinstance(payload, dict):
+        log.error(f"Unexpected payload type: {type(payload)!r}")
+        return {"status": "received"}
 
-    return jsonify({"status": "received"}), 200
+    code: Optional[int] = payload.get("code")
+    msg: Optional[str] = payload.get("msg")
+    data: Dict[str, Any] = payload.get("data") or {}
+    cb_type_raw = data.get("callbackType") or data.get("callback_type") or ""
+    cb_type = str(cb_type_raw).lower() or "unknown"
+    task_id = data.get("task_id") or data.get("taskId") or "unknown"
+    items: List[Dict[str, Any]] = data.get("data") or []
 
+    idem_key = _idem_key(task_id, cb_type)
+    if _idem_check_and_mark(idem_key):
+        log.info(f"duplicate callback dropped | task={task_id} type={cb_type}")
+        return {"status": "received"}
 
-if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))
+    downloaded_assets: List[str] = []
+    tg_statuses: List[str] = []
+
+    log.info(
+        f"callback received | code={code} task={task_id} type={cb_type} items={len(items)}"
+    )
+
+    tg_statuses.extend(_tg_send_message(f"Suno: этап {cb_type}, task={task_id}"))
+
+    if cb_type in {"first", "complete"} and items:
+        base_dir = pathlib.Path("/tmp/suno") / task_id
+        for idx, track in enumerate(items, start=1):
+            track_id = str(track.get("id") or idx)
+            title = track.get("title") or "track"
+            audio_url = track.get("audio_url") or track.get("audioUrl")
+            image_url = track.get("image_url") or track.get("imageUrl")
+
+            if audio_url:
+                dest = base_dir / track_id
+                downloaded = _download(audio_url, dest)
+                if downloaded and downloaded.exists():
+                    size = downloaded.stat().st_size
+                    downloaded_assets.append(f"audio:{downloaded.name}:{size}")
+                    tg_statuses.extend(
+                        _tg_send_file(downloaded, caption=f"{title} (audio)")
+                    )
+                else:
+                    downloaded_assets.append(f"audio-link:{audio_url}")
+
+            if image_url:
+                dest = base_dir / f"{track_id}_cover"
+                downloaded = _download(image_url, dest)
+                if downloaded and downloaded.exists():
+                    size = downloaded.stat().st_size
+                    downloaded_assets.append(f"image:{downloaded.name}:{size}")
+                    tg_statuses.extend(
+                        _tg_send_file(downloaded, caption=f"{title} (cover)")
+                    )
+                else:
+                    downloaded_assets.append(f"image-link:{image_url}")
+
+    log_line = {
+        "task_id": task_id,
+        "callbackType": cb_type,
+        "code": code,
+        "assets": downloaded_assets,
+        "telegram": tg_statuses or ["not-sent"],
+        "message": msg,
+    }
+    log.info(f"processed | {json.dumps(log_line, ensure_ascii=False)}")
+
+    return {"status": "received"}


### PR DESCRIPTION
## Summary
- replace the legacy Flask stub with a FastAPI service exposing the /suno-callback and /healthz routes
- validate callback tokens, ensure idempotent processing with Redis or in-memory fallback, download assets, and send Telegram notifications with structured logging
- add FastAPI and Uvicorn dependencies for the new ASGI entrypoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4fb85c3208322ba756affc39a133e