### PR TITLE
Add callback token validation and health alias

### DIFF
--- a/suno_web.py
+++ b/suno_web.py
@@ -164,17 +164,42 @@ def _tg_send_file(filepath: pathlib.Path, caption: str = "") -> List[str]:
     return statuses
 
 
+def _validate_callback_token(
+    header_token: Optional[str], query_token: Optional[str]
+) -> bool:
+    if not CALLBACK_SECRET:
+        log.info("Callback token accepted")
+        return True
+    if header_token == CALLBACK_SECRET or query_token == CALLBACK_SECRET:
+        log.info("Callback token accepted")
+        return True
+    log.warning("Forbidden: bad callback token")
+    return False
+
+
+@app.get("/health")
+def health() -> Dict[str, bool]:
+    return {"ok": True}
+
+
+@app.get("/suno-callback")
+async def suno_callback_get(
+    token: Optional[str] = None,
+    x_callback_token: Optional[str] = Header(default=None, convert_underscores=False),
+):
+    if not _validate_callback_token(x_callback_token, token):
+        return JSONResponse({"error": "forbidden"}, status_code=403)
+    return {"ok": True, "endpoint": "suno-callback"}
+
+
 @app.post("/suno-callback")
 async def suno_callback(
     request: Request,
+    token: Optional[str] = None,
     x_callback_token: Optional[str] = Header(default=None, convert_underscores=False),
 ):
-    if CALLBACK_SECRET:
-        if not x_callback_token or x_callback_token != CALLBACK_SECRET:
-            log.warning("Forbidden: bad X-Callback-Token")
-            return JSONResponse({"error": "forbidden"}, status_code=403)
-    else:
-        log.warning("SUNO_CALLBACK_SECRET is empty — allowing requests in DEV")
+    if not _validate_callback_token(x_callback_token, token):
+        return JSONResponse({"error": "forbidden"}, status_code=403)
 
     try:
         payload = await request.json()


### PR DESCRIPTION
## Summary
- add shared callback token validator that accepts header or query tokens and logs outcomes
- expose GET /suno-callback health endpoint and /health alias
- reuse the validator in the POST callback flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d50628cbc483229a2755611819a4fc