### PR TITLE
Configure uvicorn web service and harden callback endpoints

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,4 +1,13 @@
 services:
+  - type: web
+    name: shubinfilms-best-veo3-bot
+    env: python
+    region: frankfurt
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn suno_web:app --host 0.0.0.0 --port $PORT
+    envVars:
+      - key: PYTHONUNBUFFERED
+        value: "1"
   - type: worker
     name: best-veo3-bot
     env: python


### PR DESCRIPTION
## Summary
- add Render web service configuration that launches uvicorn for the FastAPI app
- expose health and root endpoints and tighten callback token validation in suno_web

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d510709c24832294d18fffcb54b4b7