### PR TITLE
Refactor Suno client/service with env-configured retries

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1,12 +1,55 @@
-"""Shared configuration constants for Redis and logging keys."""
+"""Shared configuration constants for Redis and Suno integrations."""
+
+from __future__ import annotations
+
 import os
+from typing import Optional
 
 from dotenv import load_dotenv
 
 load_dotenv()
 
-_default_prefix = "veo3:prod"
-_env_prefix = (os.getenv("REDIS_PREFIX") or "").strip()
-REDIS_PREFIX = _env_prefix or _default_prefix
 
+def _get_env(name: str, default: Optional[str] = None) -> Optional[str]:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    value = value.strip()
+    return value or default
+
+
+def _parse_timeout(raw: Optional[str]) -> int:
+    if not raw:
+        return 45
+    try:
+        value = int(float(raw))
+    except (TypeError, ValueError):
+        return 45
+    return max(1, min(value, 300))
+
+
+_default_prefix = "veo3:prod"
+_env_prefix = _get_env("REDIS_PREFIX", "") or ""
+REDIS_PREFIX = _env_prefix or _default_prefix
 SUNO_LOG_KEY = f"{REDIS_PREFIX}:suno:logs"
+
+# Suno HTTP configuration --------------------------------------------------
+SUNO_API_BASE = _get_env("SUNO_API_BASE")
+SUNO_API_TOKEN = _get_env("SUNO_API_TOKEN")
+
+SUNO_GEN_PATH = _get_env("SUNO_GEN_PATH")
+SUNO_INSTR_PATH = _get_env("SUNO_INSTR_PATH")
+SUNO_UPLOAD_EXTEND_PATH = _get_env("SUNO_UPLOAD_EXTEND_PATH")
+SUNO_TASK_STATUS_PATH = _get_env("SUNO_TASK_STATUS_PATH")
+SUNO_LYRICS_PATH = _get_env("SUNO_LYRICS_PATH")
+SUNO_WAV_PATH = _get_env("SUNO_WAV_PATH")
+SUNO_WAV_INFO_PATH = _get_env("SUNO_WAV_INFO_PATH")
+SUNO_MP4_PATH = _get_env("SUNO_MP4_PATH")
+SUNO_MP4_INFO_PATH = _get_env("SUNO_MP4_INFO_PATH")
+SUNO_STEM_PATH = _get_env("SUNO_STEM_PATH")
+SUNO_STEM_INFO_PATH = _get_env("SUNO_STEM_INFO_PATH")
+
+SUNO_MODEL = _get_env("SUNO_MODEL")
+SUNO_TIMEOUT_SEC = _parse_timeout(os.getenv("SUNO_TIMEOUT_SEC"))
+SUNO_CALLBACK_URL = _get_env("SUNO_CALLBACK_URL")
+SUNO_CALLBACK_SECRET = _get_env("SUNO_CALLBACK_SECRET")

--- a/suno/client.py
+++ b/suno/client.py
@@ -1,351 +1,399 @@
 """HTTP client for interacting with the Suno API."""
 from __future__ import annotations
 
+import json
 import logging
-import os
-from typing import Any, Dict, Optional
-from urllib.parse import urlparse, urlunparse
+import random
+import time
+from typing import Any, Dict, Mapping, Optional
 
 import requests
 from requests import Response, Session
 
-from ._retry import RetryError, Retrying, retry_if_exception_type, stop_after_attempt, wait_exponential
+from settings import (
+    SUNO_API_BASE,
+    SUNO_API_TOKEN,
+    SUNO_CALLBACK_SECRET,
+    SUNO_TIMEOUT_SEC,
+)
 
-log = logging.getLogger("suno")
-
-
-def _join_url(*parts: str) -> str:
-    """Join URL parts safely, normalizing duplicate segments."""
-
-    cleaned: list[str] = []
-    for part in parts:
-        if not part:
-            continue
-        cleaned.append(part.strip().replace("\\", "/"))
-
-    if not cleaned:
-        return ""
-
-    joined = "/".join(segment.strip("/") for segment in cleaned)
-
-    # Ensure we have a scheme for urlparse to work reliably
-    if "://" not in joined:
-        joined = f"https://{joined}"
-
-    parsed = urlparse(joined)
-    scheme = parsed.scheme or "https"
-    if parsed.netloc:
-        netloc = parsed.netloc
-        path = parsed.path
-    else:
-        # Recover netloc from the first cleaned part when scheme was missing
-        first = cleaned[0]
-        if "://" in first:
-            first_parsed = urlparse(first)
-            netloc = first_parsed.netloc
-            path_prefix = first_parsed.path
-        else:
-            netloc = first.split("/", 1)[0]
-            path_prefix = "/" + first[len(netloc):]
-        path = (path_prefix.rstrip("/") + "/" + parsed.path.lstrip("/")).replace("//", "/")
-
-    # Normalize path and drop duplicate "suno-api" prefixes
-    path = path.replace("//", "/")
-    path = path.replace("/suno-api/api/", "/api/")
-    path = path.replace("/suno-api/v1/", "/api/v1/")
-
-    return urlunparse((scheme, netloc, path, "", "", ""))
+log = logging.getLogger("suno.http")
 
 
-BASE = os.getenv("SUNO_API_BASE", "https://api.kie.ai")
-
-ENDPOINTS: dict[str, str] = {
-    "generate_music": "/api/v1/generate/music",
-    "extend_music": "/api/v1/generate/extend",
-    "upload_extend": "/api/v1/generate/upload-extend",
-    "add_instrumental": "/api/v1/generate/add-instrumental",
-    "add_vocals": "/api/v1/generate/add-vocals",
-    "record_info": "/api/v1/generate/record-info",
-    "timestamped_lyrics": "/api/v1/generate/get-timestamped-lyrics",
-    "style_generate": "/api/v1/style/generate",
-    "cover_generate": "/api/v1/suno/cover/generate",
-    "cover_record_info": "/api/v1/suno/cover/record-info",
-    "wav_generate": "/api/v1/wav/generate",
-    "wav_record_info": "/api/v1/wav/record-info",
-    "vocal_sep_generate": "/api/v1/vocal-removal/generate",
-    "vocal_sep_record_info": "/api/v1/vocal-removal/record-info",
-    "mp4_generate": "/api/v1/mp4/generate",
-    "mp4_record_info": "/api/v1/mp4/record-info",
-}
-
-_RETRYABLE_CODES = {408, 429, 455, 500}
-
-
-class SunoAPIError(RuntimeError):
-    """Raised when the Suno API returns an error."""
-
-
-class SunoRetryableError(Exception):
-    """Internal helper to trigger retry for retryable responses."""
-
-
-_DEFAULT_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT_S", "20"))
-
-
-def _should_retry(response: Response) -> bool:
-    if response.status_code in _RETRYABLE_CODES:
-        return True
-    try:
-        payload = response.json()
-    except ValueError:
-        return False
-    code = payload.get("code")
-    return isinstance(code, int) and code in _RETRYABLE_CODES
-
-
-class SunoClient:
-    """Simple HTTP client for Suno API."""
+class SunoError(RuntimeError):
+    """Base class for all Suno HTTP errors."""
 
     def __init__(
         self,
-        base_url: Optional[str] = None,
-        token: Optional[str] = None,
-        timeout: int = _DEFAULT_TIMEOUT,
-        session: Optional[Session] = None,
+        message: str,
+        *,
+        safe_message: Optional[str] = None,
+        details: Optional[Mapping[str, Any]] = None,
+        status: Optional[int] = None,
     ) -> None:
-        env_base = (os.environ.get("SUNO_API_BASE") or BASE or "").strip()
-        env_token = (os.environ.get("SUNO_API_TOKEN") or "").strip()
-        self._prefix = (os.environ.get("SUNO_API_PREFIX") or "").strip()
+        super().__init__(message)
+        self.message = message
+        self.safe_message = safe_message or message or "Suno service error"
+        self.details: Mapping[str, Any] = details or {}
+        self.status = status
 
-        resolved_base = (base_url or env_base or "").strip()
-        if base_url is None:
-            if not resolved_base or not resolved_base.startswith("http"):
-                raise RuntimeError(f"Invalid SUNO_API_BASE: {resolved_base!r}")
-        else:
-            if not resolved_base:
-                raise ValueError("base_url must be provided")
-            if not resolved_base.startswith("http"):
-                raise ValueError("base_url must start with 'http'")
 
-        resolved_token = token if token is not None else env_token
-        if token is None:
-            if not resolved_token:
-                raise RuntimeError("SUNO_API_TOKEN is empty")
-        elif not resolved_token:
-            raise ValueError("token must be provided")
-
-        self.base_url = resolved_base.rstrip("/")
-        self.token = resolved_token
-        self.timeout = timeout
-        self.session = session or requests.Session()
-        self._retryer = Retrying(
-            stop=stop_after_attempt(4),
-            wait=wait_exponential(multiplier=1, min=1, max=10),
-            retry=retry_if_exception_type((requests.RequestException, SunoRetryableError)),
-            reraise=True,
+class SunoBadRequest(SunoError):
+    def __init__(self, message: str, *, details: Optional[Mapping[str, Any]] = None) -> None:
+        super().__init__(
+            message or "Bad request to Suno",
+            safe_message="Запрос к Suno отклонён. Проверьте параметры.",
+            details=details,
+            status=400,
         )
 
-    def _resolve_path(self, endpoint: str) -> str:
-        if not endpoint:
-            raise ValueError("endpoint must be provided")
-        path = ENDPOINTS.get(endpoint, endpoint)
-        if not path.startswith("/"):
-            raise ValueError("path must start with '/'")
-        return path
 
-    def _url(self, path: str) -> str:
-        url = _join_url(self.base_url, self._prefix, path)
-        log.debug("Suno request → %s", url)
-        return url
+class SunoAuthError(SunoError):
+    def __init__(self, message: str, status: int = 401) -> None:
+        super().__init__(
+            message or "Authentication failed for Suno API",
+            safe_message="Не удалось авторизоваться в Suno. Проверьте токен.",
+            status=status,
+        )
 
-    def _url_for(self, endpoint: str) -> str:
-        path = self._resolve_path(endpoint)
-        return self._url(path)
 
-    def _request(
+class SunoNotFound(SunoError):
+    def __init__(self, message: str, path: str) -> None:
+        super().__init__(
+            message or "Resource not found at Suno",
+            safe_message="Не удалось найти задачу в Suno.",
+            details={"path": path},
+            status=404,
+        )
+        self.path = path
+
+
+class SunoConflict(SunoError):
+    def __init__(self, message: str, status: int) -> None:
+        super().__init__(
+            message or "Conflict while calling Suno",
+            safe_message="Запрос конфликтует с текущим состоянием Suno.",
+            status=status,
+        )
+
+
+class SunoUnprocessable(SunoError):
+    def __init__(self, message: str, status: int) -> None:
+        super().__init__(
+            message or "Unprocessable request for Suno",
+            safe_message="Suno не смог обработать запрос.",
+            status=status,
+        )
+
+
+class SunoRateLimited(SunoError):
+    def __init__(self, message: str, retry_after: Optional[float]) -> None:
+        safe = "Слишком много запросов к Suno. Попробуйте позже."
+        details: Dict[str, Any] = {}
+        if retry_after is not None:
+            details["retry_after"] = retry_after
+        super().__init__(
+            message or "Rate limited by Suno",
+            safe_message=safe,
+            details=details,
+            status=429,
+        )
+        self.retry_after = retry_after
+
+
+class SunoServerError(SunoError):
+    def __init__(self, message: str, *, status: Optional[int] = None) -> None:
+        super().__init__(
+            message or "Suno server error",
+            safe_message="Suno временно недоступен. Попробуйте ещё раз позже.",
+            status=status or 503,
+        )
+
+
+def _validate_base_url(base_url: Optional[str]) -> str:
+    if not base_url:
+        raise RuntimeError("SUNO_API_BASE is not configured")
+    normalized = base_url.rstrip("/")
+    if not normalized.startswith("http"):
+        raise RuntimeError("SUNO_API_BASE must start with http/https")
+    return normalized
+
+
+def _validate_token(token: Optional[str]) -> str:
+    if not token:
+        raise RuntimeError("SUNO_API_TOKEN is not configured")
+    return token
+
+
+class SunoHttp:
+    """Low level HTTP client with retry and error mapping."""
+
+    _max_attempts = 3
+    _base_delay = 0.5
+    _jitter_max = 0.25
+
+    def __init__(
         self,
-        method: str,
-        endpoint: str,
         *,
-        json: Optional[dict] = None,
-        params: Optional[dict] = None,
-    ) -> dict:
-        path = self._resolve_path(endpoint)
-        url = self._url(path)
+        base_url: Optional[str] = None,
+        token: Optional[str] = None,
+        timeout: Optional[int] = None,
+        session: Optional[Session] = None,
+        callback_secret: Optional[str] = None,
+    ) -> None:
+        self.base_url = _validate_base_url(base_url or SUNO_API_BASE)
+        self.token = _validate_token(token or SUNO_API_TOKEN)
+        self.timeout = timeout or SUNO_TIMEOUT_SEC or 45
+        self.session = session or requests.Session()
+        self.callback_secret = callback_secret or SUNO_CALLBACK_SECRET or None
+
+    # ------------------------------------------------------------------ utils
+    def _full_url(self, path: str) -> str:
+        if not path:
+            raise ValueError("path must be provided")
+        if not path.startswith("/"):
+            path = "/" + path
+        return f"{self.base_url}{path}"
+
+    def _build_headers(self, *, has_files: bool, extra: Optional[Mapping[str, str]]) -> Dict[str, str]:
         headers = {
             "Authorization": f"Bearer {self.token}",
-            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "best-veo3-bot/1.0 (+render)",
         }
+        if not has_files:
+            headers["Content-Type"] = "application/json"
+        if self.callback_secret:
+            headers["X-Callback-Token"] = self.callback_secret
+        if extra:
+            headers.update(extra)
+        if has_files:
+            headers.pop("Content-Type", None)
+        return headers
 
-        def _do_request() -> dict:
+    def _should_retry(self, status: Optional[int]) -> bool:
+        if status is None:
+            return True
+        if status == 429:
+            return True
+        return 500 <= status < 600
+
+    def _sleep(self, attempt: int) -> None:
+        delay = self._base_delay * (2 ** attempt)
+        delay += random.random() * self._jitter_max
+        time.sleep(delay)
+
+    def _extract_task_id(self, payload: Any) -> Optional[str]:
+        if not isinstance(payload, Mapping):
+            return None
+        data = payload.get("data")
+        if isinstance(data, Mapping):
+            task_id = data.get("taskId") or data.get("task_id")
+            if task_id:
+                return str(task_id)
+        task_id = payload.get("taskId") or payload.get("task_id")
+        if task_id:
+            return str(task_id)
+        return None
+
+    def _parse_json(self, response: Response) -> Optional[Dict[str, Any]]:
+        if response.content is None or not response.content:
+            return None
+        try:
+            parsed = response.json()
+        except json.JSONDecodeError as exc:
+            raise SunoServerError("Invalid JSON returned by Suno", status=response.status_code) from exc
+        if isinstance(parsed, dict):
+            return parsed
+        return {"data": parsed}
+
+    def _error_message(self, payload: Optional[Mapping[str, Any]]) -> str:
+        if not payload:
+            return ""
+        for key in ("message", "msg", "error", "detail"):
+            value = payload.get(key)
+            if isinstance(value, str):
+                return value
+        return ""
+
+    def _map_error(
+        self,
+        status: int,
+        path: str,
+        payload: Optional[Mapping[str, Any]],
+        response: Optional[Response] = None,
+    ) -> SunoError:
+        message = self._error_message(payload) or f"HTTP {status}"
+        if status == 400:
+            return SunoBadRequest(message, details=payload)
+        if status in (401, 403):
+            return SunoAuthError(message, status=status)
+        if status == 404:
+            return SunoNotFound(message, path)
+        if status in (409,):
+            return SunoConflict(message, status)
+        if status in (422,):
+            return SunoUnprocessable(message, status)
+        if status == 429:
+            retry_after: Optional[float] = None
+            if response is not None:
+                raw = response.headers.get("Retry-After") if response.headers else None
+                if raw:
+                    try:
+                        retry_after = float(raw)
+                    except ValueError:
+                        retry_after = None
+            if payload:
+                retry_after_payload = payload.get("retry_after")
+                if retry_after is None and isinstance(retry_after_payload, (int, float)):
+                    retry_after = float(retry_after_payload)
+            return SunoRateLimited(message, retry_after)
+        if status >= 500:
+            return SunoServerError(message, status=status)
+        return SunoError(message, status=status, safe_message="Неизвестная ошибка Suno", details=payload)
+
+    # ---------------------------------------------------------------- requests
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: Optional[Mapping[str, Any]] = None,
+        params: Optional[Mapping[str, Any]] = None,
+        data: Optional[Mapping[str, Any]] = None,
+        files: Optional[Mapping[str, Any]] = None,
+        headers: Optional[Mapping[str, str]] = None,
+        timeout: Optional[int] = None,
+        op: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        url = self._full_url(path)
+        payload_keys = list(json.keys()) if isinstance(json, Mapping) else []
+        attempt_error: Optional[Exception] = None
+        for attempt in range(1, self._max_attempts + 1):
+            start = time.perf_counter()
+            status: Optional[int] = None
+            task_id: Optional[str] = None
             try:
                 response = self.session.request(
                     method,
                     url,
                     json=json,
                     params=params,
-                    headers=headers,
-                    timeout=self.timeout,
+                    data=data,
+                    files=files,
+                    headers=self._build_headers(has_files=files is not None, extra=headers),
+                    timeout=timeout or self.timeout,
                 )
-            except requests.RequestException as exc:  # pragma: no cover - handled by retryer
-                log.warning("Request error on %s %s: %s", method, url, exc)
-                raise exc
-            if response.status_code != 200:
-                log.warning(
-                    "Suno API HTTP error %s on %s %s: %s",
-                    response.status_code,
-                    method,
-                    path,
-                    response.text,
-                )
-                if _should_retry(response):
-                    raise SunoRetryableError(f"retryable status {response.status_code}")
-                raise SunoAPIError(f"HTTP {response.status_code}: {response.text}")
-            try:
-                payload = response.json()
-            except ValueError as exc:
-                raise SunoAPIError("invalid JSON response") from exc
-            code = payload.get("code")
-            if isinstance(code, int) and code != 200:
-                message = payload.get("msg") or "unexpected error"
-                log.warning(
-                    "Suno API logical error on %s %s: code=%s msg=%s payload=%s",
-                    method,
-                    path,
-                    code,
-                    message,
-                    payload,
-                )
-                if code in _RETRYABLE_CODES:
-                    raise SunoRetryableError(f"retryable code {code}")
-                raise SunoAPIError(f"Suno API error {code}: {message}")
-            return payload
+                status = response.status_code
+                payload = None
+                if status != 204:
+                    try:
+                        payload = self._parse_json(response)
+                    except SunoError as exc:
+                        attempt_error = exc
+                        if attempt >= self._max_attempts:
+                            raise
+                        self._log_attempt(op or method.upper(), path, "invalid_json", attempt, time.perf_counter() - start, task_id, payload_keys)
+                        self._sleep(attempt)
+                        continue
+                task_id = self._extract_task_id(payload)
+                elapsed = time.perf_counter() - start
+                self._log_attempt(op or method.upper(), path, status, attempt, elapsed, task_id, payload_keys)
+                if self._should_retry(status):
+                    if attempt >= self._max_attempts:
+                        raise self._map_error(status or 503, path, payload, response)
+                    self._sleep(attempt)
+                    continue
+                if status and status >= 400:
+                    raise self._map_error(status, path, payload, response)
+                if isinstance(payload, Mapping):
+                    code = payload.get("code")
+                    if isinstance(code, int) and code >= 400:
+                        raise self._map_error(code, path, payload, response)
+                    return dict(payload)
+                return {}
+            except requests.RequestException as exc:
+                elapsed = time.perf_counter() - start
+                attempt_error = exc
+                self._log_attempt(op or method.upper(), path, "network_error", attempt, elapsed, task_id, payload_keys)
+                if attempt >= self._max_attempts:
+                    raise SunoServerError("Network error talking to Suno") from exc
+                self._sleep(attempt)
+                continue
+        if attempt_error:
+            raise SunoServerError(str(attempt_error)) from attempt_error
+        raise SunoServerError("Unknown error calling Suno")
 
-        try:
-            return self._retryer(_do_request)
-        except RetryError as exc:  # pragma: no cover - defensive
-            raise SunoAPIError("maximum retries exceeded") from exc
-
-    def post(self, endpoint: str, payload: Dict[str, Any]) -> dict:
-        if not isinstance(payload, dict):
-            raise ValueError("payload must be a dict")
-        return self._request("POST", endpoint, json=payload)
-
-    def get(self, endpoint: str, params: Dict[str, Any]) -> dict:
-        if not isinstance(params, dict):
-            raise ValueError("params must be a dict")
-        return self._request("GET", endpoint, params=params)
-
-    # Specialized wrappers
-    def _ensure_fields(self, payload: Dict[str, Any], required: tuple[str, ...]) -> None:
-        missing = [field for field in required if not payload.get(field)]
-        if missing:
-            raise ValueError(f"missing required fields: {', '.join(missing)}")
-
-    def generate_music(
+    def get(
         self,
+        path: str,
         *,
-        prompt: str,
-        model: str,
-        title: str,
-        style: str,
-        callBackUrl: str,
-        instrumental: bool = True,
-        negativeTags: Optional[str] = None,
-        vocalGender: Optional[str] = None,
-        styleWeight: Optional[float] = None,
-        weirdnessConstraint: Optional[float] = None,
-        audioWeight: Optional[float] = None,
-    ) -> dict:
-        """Submit a generate music task."""
+        params: Optional[Mapping[str, Any]] = None,
+        headers: Optional[Mapping[str, str]] = None,
+        op: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        return self.request("GET", path, params=params, headers=headers, op=op)
 
-        payload: Dict[str, Any] = {
-            "prompt": prompt,
-            "model": model,
-            "title": title,
-            "style": style,
-            "callBackUrl": callBackUrl,
-            "instrumental": instrumental,
+    def post(
+        self,
+        path: str,
+        *,
+        json: Optional[Mapping[str, Any]] = None,
+        headers: Optional[Mapping[str, str]] = None,
+        op: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        return self.request("POST", path, json=json, headers=headers, op=op)
+
+    # ---------------------------------------------------------------- logging
+    def _log_attempt(
+        self,
+        op: str,
+        path: str,
+        status: Any,
+        attempt: int,
+        elapsed: float,
+        task_id: Optional[str],
+        payload_keys: Optional[list[str]],
+    ) -> None:
+        elapsed_ms = round(elapsed * 1000, 1)
+        extra = {
+            "op": op,
+            "path": path,
+            "status": status,
+            "elapsed_ms": elapsed_ms,
+            "try": attempt,
         }
-        self._ensure_fields(
-            payload,
-            ("prompt", "model", "title", "style", "callBackUrl"),
-        )
-        optional_fields = {
-            "negativeTags": negativeTags,
-            "vocalGender": vocalGender,
-            "styleWeight": styleWeight,
-            "weirdnessConstraint": weirdnessConstraint,
-            "audioWeight": audioWeight,
-        }
-        for key, value in optional_fields.items():
-            if value is not None:
-                payload[key] = value
-        return self.post("generate_music", payload)
-
-    def add_vocals(self, payload: Dict[str, Any]) -> dict:
-        self._ensure_fields(payload, ("uploadUrl", "callBackUrl"))
-        return self.post("add_vocals", payload)
-
-    def add_instrumental(self, payload: Dict[str, Any]) -> dict:
-        self._ensure_fields(payload, ("uploadUrl", "callBackUrl"))
-        return self.post("add_instrumental", payload)
-
-    def upload_extend(self, payload: Dict[str, Any]) -> dict:
-        self._ensure_fields(payload, ("uploadUrl", "callBackUrl"))
-        return self.post("upload_extend", payload)
-
-    def wav_generate(self, payload: Dict[str, Any]) -> dict:
-        self._ensure_fields(payload, ("uploadUrl", "callBackUrl"))
-        return self.post("wav_generate", payload)
-
-    def vocal_removal_generate(self, payload: Dict[str, Any]) -> dict:
-        self._ensure_fields(payload, ("uploadUrl", "callBackUrl"))
-        return self.post("vocal_sep_generate", payload)
-
-    def cover_generate(self, payload: Dict[str, Any]) -> dict:
-        self._ensure_fields(payload, ("callBackUrl",))
-        return self.post("cover_generate", payload)
-
-    def mp4_generate(self, payload: Dict[str, Any]) -> dict:
-        self._ensure_fields(payload, ("callBackUrl",))
-        return self.post("mp4_generate", payload)
-
-    def style_generate(self, content: str) -> dict:
-        if not content or not content.strip():
-            raise ValueError("content must not be empty")
-        return self.post("style_generate", {"content": content})
-
-    # Status endpoints
-    def record_info(self, task_id: str) -> dict:
-        if not task_id:
-            raise ValueError("task_id is required")
-        return self.get("record_info", {"taskId": task_id})
-
-    def get_timestamped_lyrics(self, task_id: str, audio_id: str) -> dict:
-        if not task_id or not audio_id:
-            raise ValueError("task_id and audio_id are required")
-        return self.post(
-            "timestamped_lyrics",
-            {"taskId": task_id, "audioId": audio_id},
+        if task_id:
+            extra["task_id"] = task_id
+        if payload_keys:
+            extra["payload_keys"] = payload_keys
+        log.info(
+            "suno request op=%s path=%s status=%s elapsed_ms=%.1f try=%s task_id=%s keys=%s",
+            op,
+            path,
+            status,
+            elapsed_ms,
+            attempt,
+            task_id or "-",
+            ",".join(payload_keys or []),
+            extra=extra,
         )
 
-    def wav_record_info(self, task_id: str) -> dict:
-        if not task_id:
-            raise ValueError("task_id is required")
-        return self.get("wav_record_info", {"taskId": task_id})
 
-    def vocal_removal_record_info(self, task_id: str) -> dict:
-        if not task_id:
-            raise ValueError("task_id is required")
-        return self.get("vocal_sep_record_info", {"taskId": task_id})
+# Backwards compatibility ----------------------------------------------------
+SunoClient = SunoHttp
+SunoAPIError = SunoError
 
-    def cover_record_info(self, task_id: str) -> dict:
-        if not task_id:
-            raise ValueError("task_id is required")
-        return self.get("cover_record_info", {"taskId": task_id})
-
-    def mp4_record_info(self, task_id: str) -> dict:
-        if not task_id:
-            raise ValueError("task_id is required")
-        return self.get("mp4_record_info", {"taskId": task_id})
+__all__ = [
+    "SunoHttp",
+    "SunoClient",
+    "SunoError",
+    "SunoAPIError",
+    "SunoBadRequest",
+    "SunoAuthError",
+    "SunoNotFound",
+    "SunoConflict",
+    "SunoUnprocessable",
+    "SunoRateLimited",
+    "SunoServerError",
+]

--- a/suno/schemas.py
+++ b/suno/schemas.py
@@ -1,9 +1,32 @@
 """Pydantic schemas for Suno callbacks and responses."""
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from pydantic import BaseModel, Field
+
+
+class SunoTrack(BaseModel):
+    """Normalized representation of an item returned by the Suno API."""
+
+    id: Optional[str] = None
+    title: Optional[str] = None
+    audio_url: Optional[str] = Field(default=None, alias="audioUrl")
+    image_url: Optional[str] = Field(default=None, alias="imageUrl")
+    duration_ms: Optional[int] = Field(default=None, alias="durationMs")
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class SunoTask(BaseModel):
+    """Normalized task response returned by :class:`SunoService`."""
+
+    code: int = 0
+    message: Optional[str] = None
+    task_id: Optional[str] = Field(default=None, alias="taskId")
+    items: List[SunoTrack] = Field(default_factory=list)
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class CallbackResponse(BaseModel):

--- a/tests/test_suno_basic.py
+++ b/tests/test_suno_basic.py
@@ -1,203 +1,145 @@
 from __future__ import annotations
 
+import importlib
+import json
 import os
 import sys
-from pathlib import Path
-from typing import List, Tuple
+from typing import Callable, Dict
 from unittest.mock import MagicMock
 
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from suno.callbacks import MusicCallback, parse_music_callback
-from suno.client import ENDPOINTS, SunoClient
-from suno.service import SunoService
-from suno.store import InMemoryTaskStore
+
+@pytest.fixture
+def suno_modules(monkeypatch) -> Callable[..., tuple]:
+    def _loader(**env: str) -> tuple:
+        defaults: Dict[str, str] = {
+            "SUNO_API_BASE": "https://api.test",
+            "SUNO_API_TOKEN": "token-123",
+            "SUNO_GEN_PATH": "/generate",
+            "SUNO_INSTR_PATH": "/instrumental",
+            "SUNO_UPLOAD_EXTEND_PATH": "/extend",
+            "SUNO_TASK_STATUS_PATH": "/status",
+        }
+        defaults.update(env)
+        for key, value in defaults.items():
+            monkeypatch.setenv(key, value)
+        # Ensure optional values are removed when explicitly set to None
+        for key, value in env.items():
+            if value is None:
+                monkeypatch.delenv(key, raising=False)
+        import settings
+        import suno.client as suno_client
+        import suno.service as suno_service
+
+        importlib.reload(settings)
+        importlib.reload(suno_client)
+        importlib.reload(suno_service)
+        return settings, suno_client, suno_service
+
+    return _loader
 
 
-class ImmediateExecutor:
-    def submit(self, fn, *args, **kwargs):
-        fn(*args, **kwargs)
-        return MagicMock()
-
-
-def build_service(tmp_path: Path, collector: List[Tuple[str, Path]]):
-    store = InMemoryTaskStore()
-
-    def fake_downloader(url: str, dest_path, base_dir=None):
-        base_dir = Path(base_dir) if base_dir else Path("downloads")
-        if not isinstance(dest_path, Path):
-            dest_path = Path(dest_path)
-        collector.append((url, base_dir / dest_path))
-        return base_dir / dest_path
-
-    service = SunoService(
-        store=store,
-        download_dir=tmp_path,
-        executor=ImmediateExecutor(),
-        downloader=fake_downloader,
-    )
-    return service, store
-
-
-def test_endpoint_url_building():
-    session = MagicMock()
+def _mock_response(status: int, payload: dict) -> MagicMock:
     response = MagicMock()
-    response.status_code = 200
-    response.json.return_value = {"code": 200}
-    session.request.return_value = response
-    client = SunoClient(base_url="https://api.example.com", token="token", session=session)
-    expected = "https://api.example.com" + ENDPOINTS["generate_music"]
-    assert client._url_for("generate_music") == expected
+    response.status_code = status
+    body = json.dumps(payload).encode()
+    response.content = body
+    response.json.return_value = payload
+    response.headers = {}
+    return response
 
 
-def test_music_callback_extracts_assets(tmp_path):
-    collected: List[Tuple[str, Path]] = []
-    service, store = build_service(tmp_path, collected)
-    payload = {
-        "code": 200,
-        "data": {
-            "taskId": "task123",
-            "callbackType": "first",
-            "response": {
-                "audios": [
-                    {"audioId": "a1", "audioUrl": "https://cdn.example.com/a1.mp3"},
-                    {"audioId": "a2", "audioUrl": "https://cdn.example.com/a2.wav"},
-                ],
-                "images": ["https://cdn.example.com/cover.png"],
-            },
-        },
-    }
-    service.handle_music_callback(payload)
-    assert store.is_processed("task123", "first")
-    assert len(collected) == 3
-    urls = {item[0] for item in collected}
-    assert "https://cdn.example.com/a1.mp3" in urls
-    assert all(path.parent == tmp_path / "task123" for _, path in collected)
-
-
-def test_duplicate_callback_is_ignored(tmp_path):
-    collected: List[Tuple[str, Path]] = []
-    service, store = build_service(tmp_path, collected)
-    payload = {
-        "code": 200,
-        "data": {
-            "taskId": "task123",
-            "callbackType": "text",
-            "response": {},
-        },
-    }
-    service.handle_music_callback(payload)
-    service.handle_music_callback(payload)
-    assert len(collected) == 0
-    assert store.is_processed("task123", "text")
-
-
-def test_suno_client_requires_content():
-    client = SunoClient(base_url="https://api.example.com", token="token", session=MagicMock())
-    with pytest.raises(ValueError):
-        client.style_generate("")
-
-
-def test_generate_music_requires_prompt():
-    client = SunoClient(base_url="https://api.example.com", token="token", session=MagicMock())
-    with pytest.raises(ValueError):
-        client.generate_music(
-            prompt="",
-            model="model",
-            title="title",
-            style="style",
-            callBackUrl="https://callback",
-        )
-
-
-def test_parse_music_callback_normalizes_type():
-    payload = {
-        "code": 200,
-        "data": {
-            "taskId": "abc",
-            "callbackType": "FIRST",
-            "response": {
-                "tracks": [
-                    {
-                        "audioId": "track1",
-                        "audioUrl": "https://cdn.example.com/track1.mp3",
-                        "imageUrl": "https://cdn.example.com/track1.jpg",
-                    }
-                ]
-            },
-        },
-    }
-    callback = parse_music_callback(payload)
-    assert isinstance(callback, MusicCallback)
-    assert callback.type == "first"
-    assert callback.task_id == "abc"
-    assert callback.tracks and callback.tracks[0].audio_id == "track1"
-
-
-def test_client_post_includes_auth(monkeypatch):
+def test_create_music_builds_request(suno_modules, monkeypatch, tmp_path):
+    settings, suno_client, suno_service = suno_modules(SUNO_CALLBACK_URL="https://callback.example/hook")
     session = MagicMock()
-    response = MagicMock()
-    response.status_code = 200
-    response.json.return_value = {"code": 200, "data": {}}
-    session.request.return_value = response
-    client = SunoClient(base_url="https://api.example.com", token="secret", session=session)
-    client.add_instrumental({"uploadUrl": "x", "callBackUrl": "cb"})
+    payload = {
+        "code": 200,
+        "data": {
+            "taskId": "task-42",
+            "items": [
+                {
+                    "id": "song-1",
+                    "title": "Neon",
+                    "audio_url": "https://cdn.example/song.mp3",
+                    "image_url": "https://cdn.example/song.jpg",
+                    "duration_ms": 1234,
+                }
+            ],
+        },
+    }
+    session.request.return_value = _mock_response(200, payload)
+
+    http = suno_client.SunoHttp(session=session)
+    store = MagicMock()
+    service = suno_service.SunoService(store=store, download_dir=tmp_path, http=http)
+
+    result = service.create_music(title="Song", style="Synth", lyrics="text", model="MODEL_X", mode="fast")
+
+    assert result.task_id == "task-42"
+    assert result.items and result.items[0].audio_url == "https://cdn.example/song.mp3"
+
     args, kwargs = session.request.call_args
-    assert kwargs["headers"]["Authorization"] == "Bearer secret"
+    assert args[0] == "POST"
+    assert args[1] == "https://api.test/generate"
+    assert kwargs["json"]["callback_url"] == "https://callback.example/hook"
+    assert kwargs["headers"]["Authorization"] == "Bearer token-123"
+    assert kwargs["headers"]["Accept"] == "application/json"
     assert kwargs["headers"]["Content-Type"] == "application/json"
+    assert kwargs["headers"]["User-Agent"].startswith("best-veo3-bot/1.0")
 
 
-def test_generate_music_retries_on_429():
+def test_retry_on_transient_errors(monkeypatch, suno_modules, tmp_path):
+    monkeypatch.setattr("random.random", lambda: 0.0)
+    sleep_calls = []
+    monkeypatch.setattr("time.sleep", lambda value: sleep_calls.append(value))
+    settings, suno_client, suno_service = suno_modules()
+
     session = MagicMock()
-    first = MagicMock()
-    first.status_code = 429
-    first.text = "rate limit"
-    first.json.return_value = {"code": 429, "msg": "rate"}
-    second = MagicMock()
-    second.status_code = 200
-    second.json.return_value = {"code": 200, "data": {"taskId": "xyz"}}
-    session.request.side_effect = [first, second]
-    client = SunoClient(base_url="https://api.example.com", token="token", session=session)
-    result = client.generate_music(
-        prompt="melody",
-        model="model",
-        title="title",
-        style="style",
-        callBackUrl="https://callback",
+    session.request.side_effect = [
+        _mock_response(429, {"code": 429, "message": "rate"}),
+        _mock_response(502, {"code": 502, "message": "bad gateway"}),
+        _mock_response(200, {"code": 200, "data": {"taskId": "ok"}}),
+    ]
+
+    http = suno_client.SunoHttp(session=session)
+    service = suno_service.SunoService(store=MagicMock(), download_dir=tmp_path, http=http)
+    result = service.create_music(title="Song")
+
+    assert result.task_id == "ok"
+    assert session.request.call_count == 3
+    # two sleeps between three attempts
+    assert len(sleep_calls) == 2
+    assert pytest.approx(sleep_calls[0], rel=0.05) == 1.0
+    assert pytest.approx(sleep_calls[1], rel=0.05) == 2.0
+
+
+def test_not_found_raises(suno_modules, tmp_path):
+    settings, suno_client, suno_service = suno_modules()
+    session = MagicMock()
+    session.request.return_value = _mock_response(404, {"message": "missing"})
+
+    http = suno_client.SunoHttp(session=session)
+    service = suno_service.SunoService(store=MagicMock(), download_dir=tmp_path, http=http)
+
+    with pytest.raises(suno_client.SunoNotFound):
+        service.get_status("task-id")
+
+
+def test_callback_secret_header(suno_modules, tmp_path):
+    settings, suno_client, suno_service = suno_modules(
+        SUNO_CALLBACK_URL="https://callback.example/hook",
+        SUNO_CALLBACK_SECRET="secret-key",
     )
-    assert result["data"]["taskId"] == "xyz"
-    assert session.request.call_count == 2
+    session = MagicMock()
+    session.request.return_value = _mock_response(200, {"code": 200, "data": {}})
 
+    http = suno_client.SunoHttp(session=session)
+    service = suno_service.SunoService(store=MagicMock(), download_dir=tmp_path, http=http)
 
-def test_music_callback_deduplicates_audio_across_types(tmp_path):
-    collected: List[Tuple[str, Path]] = []
-    service, store = build_service(tmp_path, collected)
-    base_payload = {
-        "code": 200,
-        "data": {
-            "taskId": "task777",
-            "callbackType": "first",
-            "response": {
-                "tracks": [
-                    {
-                        "audioId": "songA",
-                        "audioUrl": "https://cdn.example.com/songA.mp3",
-                        "imageUrl": "https://cdn.example.com/songA.jpg",
-                    }
-                ]
-            },
-        },
-    }
-    service.handle_music_callback(parse_music_callback(base_payload))
-    follow_up = base_payload.copy()
-    follow_up["data"] = dict(base_payload["data"])
-    follow_up["data"]["callbackType"] = "complete"
-    service.handle_music_callback(parse_music_callback(follow_up))
-    assert store.is_processed("task777", "first")
-    assert store.is_processed("task777", "complete")
-    assert len(collected) == 2  # audio + image only once
-    saved_paths = {path for _, path in collected}
-    assert tmp_path / "task777" / "songA.mp3" in saved_paths
-    assert tmp_path / "task777" / "songA.jpeg" in saved_paths
+    service.create_music(title="Song")
+
+    headers = session.request.call_args.kwargs["headers"]
+    assert headers["X-Callback-Token"] == "secret-key"


### PR DESCRIPTION
## Summary
- add environment-driven configuration for all Suno endpoints, credentials, and callback options
- implement a hardened `SunoHttp` client with structured logging, retries, and typed error mapping
- extend `SunoService` and schemas to normalize API responses and expose new task helpers, updating tests accordingly

## Testing
- pytest tests/test_suno_basic.py

------
https://chatgpt.com/codex/tasks/task_e_68d52e31440083229aad0c17f842eb70