### PR TITLE
Add configurable logging and Suno callback tests

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,12 @@ services:
     env: python
     region: frankfurt
     buildCommand: pip install -r requirements.txt
-    startCommand: uvicorn suno_web:app --host 0.0.0.0 --port $PORT
+    startCommand: >
+      gunicorn suno_web:app
+      -k uvicorn.workers.UvicornWorker
+      --bind 0.0.0.0:$PORT
+      --access-logfile -
+      --error-logfile -
     envVars:
       - key: PYTHONUNBUFFERED
         value: "1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ gunicorn>=21.2,<22.0
 tenacity>=8.2,<9.0
 pydantic>=2.7,<3.0
 pytest>=8.2,<9.0
+requests-mock>=1.12
 openai==0.28.1
 redis==5.0.7
 aiohttp>=3.9.5,<4.0

--- a/settings.py
+++ b/settings.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Optional
 
 from dotenv import load_dotenv
 
 load_dotenv()
+
+_VALID_LEVELS = {name for name in logging._nameToLevel if isinstance(name, str)}
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+if LOG_LEVEL not in _VALID_LEVELS:
+    LOG_LEVEL = "INFO"
 
 
 def _get_env(name: str, default: Optional[str] = None) -> Optional[str]:

--- a/suno_web.py
+++ b/suno_web.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 import requests
 from fastapi import FastAPI, Header, Request
 from fastapi.responses import JSONResponse
+from settings import LOG_LEVEL
 
 # redis optional
 try:
@@ -26,7 +27,14 @@ except Exception:  # pragma: no cover - optional helper
     suno_download_file = None  # type: ignore
 
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s | suno-web | %(message)s")
+os.environ.setdefault("PYTHONUNBUFFERED", "1")
+
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(levelname)s | suno-web | %(message)s",
+)
+for noisy in ("httpx", "urllib3", "uvicorn", "gunicorn"):
+    logging.getLogger(noisy).setLevel(logging.WARNING)
 log = logging.getLogger("suno-web")
 
 app = FastAPI(title="Suno Callback Web")


### PR DESCRIPTION
## Summary
- add LOG_LEVEL configuration shared via settings and quiet noisy libraries for bot and web worker
- enforce unbuffered stdout, quiet gunicorn access logs, and document new logging/test workflows
- add mocked Suno end-to-end callback test and required dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d542bb19bc832283b79f87aa15cca9