### PR TITLE
feat: overhaul suno integration

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -41,22 +41,30 @@ REDIS_PREFIX = _env_prefix or _default_prefix
 SUNO_LOG_KEY = f"{REDIS_PREFIX}:suno:logs"
 
 # Suno HTTP configuration --------------------------------------------------
-SUNO_API_BASE = _get_env("SUNO_API_BASE")
-SUNO_API_TOKEN = _get_env("SUNO_API_TOKEN")
+SUNO_API_BASE = _get_env("SUNO_API_BASE", "https://api.kie.ai")
+SUNO_API_TOKEN = _get_env("SUNO_API_TOKEN", "test-token")
 
-SUNO_GEN_PATH = _get_env("SUNO_GEN_PATH")
-SUNO_INSTR_PATH = _get_env("SUNO_INSTR_PATH")
-SUNO_UPLOAD_EXTEND_PATH = _get_env("SUNO_UPLOAD_EXTEND_PATH")
-SUNO_TASK_STATUS_PATH = _get_env("SUNO_TASK_STATUS_PATH")
-SUNO_LYRICS_PATH = _get_env("SUNO_LYRICS_PATH")
-SUNO_WAV_PATH = _get_env("SUNO_WAV_PATH")
-SUNO_WAV_INFO_PATH = _get_env("SUNO_WAV_INFO_PATH")
-SUNO_MP4_PATH = _get_env("SUNO_MP4_PATH")
-SUNO_MP4_INFO_PATH = _get_env("SUNO_MP4_INFO_PATH")
-SUNO_STEM_PATH = _get_env("SUNO_STEM_PATH")
-SUNO_STEM_INFO_PATH = _get_env("SUNO_STEM_INFO_PATH")
+SUNO_GEN_PATH = _get_env("SUNO_GEN_PATH", "/api/v1/generate/music")
+SUNO_TASK_STATUS_PATH = _get_env("SUNO_TASK_STATUS_PATH", "/api/v1/generate/record-info")
+SUNO_WAV_PATH = _get_env("SUNO_WAV_PATH", "/api/v1/wav/generate")
+SUNO_WAV_INFO_PATH = _get_env("SUNO_WAV_INFO_PATH", "/api/v1/wav/record-info")
+SUNO_MP4_PATH = _get_env("SUNO_MP4_PATH", "/api/v1/mp4/generate")
+SUNO_MP4_INFO_PATH = _get_env("SUNO_MP4_INFO_PATH", "/api/v1/mp4/record-info")
+SUNO_STEM_PATH = _get_env("SUNO_STEM_PATH", "/api/v1/vocal-removal/generate")
+SUNO_STEM_INFO_PATH = _get_env("SUNO_STEM_INFO_PATH", "/api/v1/vocal-removal/record-info")
+SUNO_LYRICS_PATH = _get_env("SUNO_LYRICS_PATH", "/api/v1/generate/get-timestamped-lyrics")
+SUNO_UPLOAD_EXTEND_PATH = _get_env("SUNO_UPLOAD_EXTEND_PATH", "/api/v1/generate/upload-extend")
+SUNO_COVER_INFO_PATH = _get_env("SUNO_COVER_INFO_PATH", "/api/v1/suno/cover/record-info")
 
 SUNO_MODEL = _get_env("SUNO_MODEL")
-SUNO_TIMEOUT_SEC = _parse_timeout(os.getenv("SUNO_TIMEOUT_SEC"))
+SUNO_TIMEOUT_SEC = _parse_timeout(os.getenv("SUNO_TIMEOUT_SEC") or str(60))
+try:
+    SUNO_HTTP_RETRIES = int(os.getenv("SUNO_HTTP_RETRIES", "4"))
+except ValueError:
+    SUNO_HTTP_RETRIES = 4
+try:
+    SUNO_RETRY_BACKOFF_BASE = float(os.getenv("SUNO_RETRY_BACKOFF_BASE", "0.6"))
+except ValueError:
+    SUNO_RETRY_BACKOFF_BASE = 0.6
 SUNO_CALLBACK_URL = _get_env("SUNO_CALLBACK_URL")
 SUNO_CALLBACK_SECRET = _get_env("SUNO_CALLBACK_SECRET")

--- a/suno/__init__.py
+++ b/suno/__init__.py
@@ -1,14 +1,12 @@
-"""Suno integration module."""
+"""Public surface for the Suno integration."""
 from .client import SunoClient, SunoAPIError
-from .store import TaskStore, InMemoryTaskStore
+from .schemas import SunoTask, SunoTrack
 from .service import SunoService
-from .callbacks import suno_bp
 
 __all__ = [
     "SunoClient",
     "SunoAPIError",
-    "TaskStore",
-    "InMemoryTaskStore",
     "SunoService",
-    "suno_bp",
+    "SunoTask",
+    "SunoTrack",
 ]

--- a/suno/client.py
+++ b/suno/client.py
@@ -1,11 +1,13 @@
-"""HTTP client for interacting with the Suno API."""
+"""Lightweight HTTP client for the Suno API."""
 from __future__ import annotations
 
 import json
 import logging
+import os
 import random
 import time
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Mapping, MutableMapping, Optional
+from urllib.parse import urljoin
 
 import requests
 from requests import Response, Session
@@ -14,386 +16,166 @@ from settings import (
     SUNO_API_BASE,
     SUNO_API_TOKEN,
     SUNO_CALLBACK_SECRET,
+    SUNO_CALLBACK_URL,
+    SUNO_GEN_PATH,
+    SUNO_HTTP_RETRIES,
+    SUNO_RETRY_BACKOFF_BASE,
+    SUNO_TASK_STATUS_PATH,
     SUNO_TIMEOUT_SEC,
 )
 
-log = logging.getLogger("suno.http")
+log = logging.getLogger("suno.client")
 
 
-class SunoError(RuntimeError):
-    """Base class for all Suno HTTP errors."""
+class SunoAPIError(RuntimeError):
+    """Raised when the Suno API returns an error response."""
 
-    def __init__(
-        self,
-        message: str,
-        *,
-        safe_message: Optional[str] = None,
-        details: Optional[Mapping[str, Any]] = None,
-        status: Optional[int] = None,
-    ) -> None:
+    def __init__(self, message: str, *, status: Optional[int] = None, payload: Any = None) -> None:
         super().__init__(message)
-        self.message = message
-        self.safe_message = safe_message or message or "Suno service error"
-        self.details: Mapping[str, Any] = details or {}
         self.status = status
+        self.payload = payload
 
 
-class SunoBadRequest(SunoError):
-    def __init__(self, message: str, *, details: Optional[Mapping[str, Any]] = None) -> None:
-        super().__init__(
-            message or "Bad request to Suno",
-            safe_message="Запрос к Suno отклонён. Проверьте параметры.",
-            details=details,
-            status=400,
-        )
+class SunoClient:
+    """HTTP wrapper with retry/backoff and default headers."""
 
-
-class SunoAuthError(SunoError):
-    def __init__(self, message: str, status: int = 401) -> None:
-        super().__init__(
-            message or "Authentication failed for Suno API",
-            safe_message="Не удалось авторизоваться в Suno. Проверьте токен.",
-            status=status,
-        )
-
-
-class SunoNotFound(SunoError):
-    def __init__(self, message: str, path: str) -> None:
-        super().__init__(
-            message or "Resource not found at Suno",
-            safe_message="Не удалось найти задачу в Suno.",
-            details={"path": path},
-            status=404,
-        )
-        self.path = path
-
-
-class SunoConflict(SunoError):
-    def __init__(self, message: str, status: int) -> None:
-        super().__init__(
-            message or "Conflict while calling Suno",
-            safe_message="Запрос конфликтует с текущим состоянием Suno.",
-            status=status,
-        )
-
-
-class SunoUnprocessable(SunoError):
-    def __init__(self, message: str, status: int) -> None:
-        super().__init__(
-            message or "Unprocessable request for Suno",
-            safe_message="Suno не смог обработать запрос.",
-            status=status,
-        )
-
-
-class SunoRateLimited(SunoError):
-    def __init__(self, message: str, retry_after: Optional[float]) -> None:
-        safe = "Слишком много запросов к Suno. Попробуйте позже."
-        details: Dict[str, Any] = {}
-        if retry_after is not None:
-            details["retry_after"] = retry_after
-        super().__init__(
-            message or "Rate limited by Suno",
-            safe_message=safe,
-            details=details,
-            status=429,
-        )
-        self.retry_after = retry_after
-
-
-class SunoServerError(SunoError):
-    def __init__(self, message: str, *, status: Optional[int] = None) -> None:
-        super().__init__(
-            message or "Suno server error",
-            safe_message="Suno временно недоступен. Попробуйте ещё раз позже.",
-            status=status or 503,
-        )
-
-
-def _validate_base_url(base_url: Optional[str]) -> str:
-    if not base_url:
-        raise RuntimeError("SUNO_API_BASE is not configured")
-    normalized = base_url.rstrip("/")
-    if not normalized.startswith("http"):
-        raise RuntimeError("SUNO_API_BASE must start with http/https")
-    return normalized
-
-
-def _validate_token(token: Optional[str]) -> str:
-    if not token:
-        raise RuntimeError("SUNO_API_TOKEN is not configured")
-    return token
-
-
-class SunoHttp:
-    """Low level HTTP client with retry and error mapping."""
-
-    _max_attempts = 3
-    _base_delay = 0.5
-    _jitter_max = 0.25
+    _RETRY_STATUSES = {408, 429}
 
     def __init__(
         self,
         *,
         base_url: Optional[str] = None,
         token: Optional[str] = None,
-        timeout: Optional[int] = None,
+        timeout: Optional[float] = None,
+        retries: Optional[int] = None,
+        backoff_base: Optional[float] = None,
         session: Optional[Session] = None,
-        callback_secret: Optional[str] = None,
     ) -> None:
-        self.base_url = _validate_base_url(base_url or SUNO_API_BASE)
-        self.token = _validate_token(token or SUNO_API_TOKEN)
-        self.timeout = timeout or SUNO_TIMEOUT_SEC or 45
+        self.base_url = (base_url or SUNO_API_BASE or "").rstrip("/") + "/"
+        if not self.base_url.startswith("http"):
+            raise RuntimeError("SUNO_API_BASE must include protocol")
+        self.token = token or SUNO_API_TOKEN
+        if not self.token:
+            raise RuntimeError("SUNO_API_TOKEN is not configured")
+        self.timeout = timeout or max(float(SUNO_TIMEOUT_SEC or 60), 1.0)
+        self.retries = max(1, int(retries or SUNO_HTTP_RETRIES or 1))
+        self.backoff_base = max(0.1, float(backoff_base or SUNO_RETRY_BACKOFF_BASE or 0.6))
         self.session = session or requests.Session()
-        self.callback_secret = callback_secret or SUNO_CALLBACK_SECRET or None
 
-    # ------------------------------------------------------------------ utils
-    def _full_url(self, path: str) -> str:
-        if not path:
-            raise ValueError("path must be provided")
-        if not path.startswith("/"):
-            path = "/" + path
-        return f"{self.base_url}{path}"
-
-    def _build_headers(self, *, has_files: bool, extra: Optional[Mapping[str, str]]) -> Dict[str, str]:
-        headers = {
+    # ------------------------------------------------------------------ helpers
+    def _headers(self) -> MutableMapping[str, str]:
+        headers: MutableMapping[str, str] = {
             "Authorization": f"Bearer {self.token}",
             "Accept": "application/json",
-            "User-Agent": "best-veo3-bot/1.0 (+render)",
+            "User-Agent": "best-veo3-bot/1.0",
         }
-        if not has_files:
-            headers["Content-Type"] = "application/json"
-        if self.callback_secret:
-            headers["X-Callback-Token"] = self.callback_secret
-        if extra:
-            headers.update(extra)
-        if has_files:
-            headers.pop("Content-Type", None)
+        callback_url = SUNO_CALLBACK_URL or os.getenv("SUNO_CALLBACK_URL")
+        callback_token = SUNO_CALLBACK_SECRET or os.getenv("SUNO_CALLBACK_SECRET")
+        if callback_url:
+            headers["X-Callback-Url"] = callback_url
+        if callback_token:
+            headers["X-Callback-Token"] = callback_token
         return headers
+
+    def _full_url(self, path: str) -> str:
+        return urljoin(self.base_url, path.lstrip("/"))
 
     def _should_retry(self, status: Optional[int]) -> bool:
         if status is None:
             return True
-        if status == 429:
+        if status in self._RETRY_STATUSES:
             return True
         return 500 <= status < 600
 
     def _sleep(self, attempt: int) -> None:
-        delay = self._base_delay * (2 ** attempt)
-        delay += random.random() * self._jitter_max
+        delay = self.backoff_base * (2 ** attempt)
+        delay += random.uniform(0, self.backoff_base)
         time.sleep(delay)
 
-    def _extract_task_id(self, payload: Any) -> Optional[str]:
-        if not isinstance(payload, Mapping):
-            return None
-        data = payload.get("data")
-        if isinstance(data, Mapping):
-            task_id = data.get("taskId") or data.get("task_id")
-            if task_id:
-                return str(task_id)
-        task_id = payload.get("taskId") or payload.get("task_id")
-        if task_id:
-            return str(task_id)
-        return None
-
-    def _parse_json(self, response: Response) -> Optional[Dict[str, Any]]:
-        if response.content is None or not response.content:
-            return None
+    def _parse_json(self, response: Response) -> Mapping[str, Any]:
+        if not response.content:
+            return {}
         try:
-            parsed = response.json()
-        except json.JSONDecodeError as exc:
-            raise SunoServerError("Invalid JSON returned by Suno", status=response.status_code) from exc
-        if isinstance(parsed, dict):
-            return parsed
-        return {"data": parsed}
+            payload = response.json()
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise SunoAPIError("Invalid JSON from Suno", status=response.status_code) from exc
+        if isinstance(payload, Mapping):
+            return payload
+        return {"data": payload}
 
-    def _error_message(self, payload: Optional[Mapping[str, Any]]) -> str:
-        if not payload:
-            return ""
-        for key in ("message", "msg", "error", "detail"):
-            value = payload.get(key)
-            if isinstance(value, str):
-                return value
-        return ""
+    def _log_attempt(self, method: str, url: str, status: Any, tries: int, started_at: float) -> None:
+        elapsed_ms = round((time.perf_counter() - started_at) * 1000)
+        log.info(
+            "SUNO HTTP | method=%s url=%s code=%s ms=%s tries=%s",
+            method.upper(),
+            url,
+            status,
+            elapsed_ms,
+            tries,
+        )
 
-    def _map_error(
-        self,
-        status: int,
-        path: str,
-        payload: Optional[Mapping[str, Any]],
-        response: Optional[Response] = None,
-    ) -> SunoError:
-        message = self._error_message(payload) or f"HTTP {status}"
-        if status == 400:
-            return SunoBadRequest(message, details=payload)
-        if status in (401, 403):
-            return SunoAuthError(message, status=status)
-        if status == 404:
-            return SunoNotFound(message, path)
-        if status in (409,):
-            return SunoConflict(message, status)
-        if status in (422,):
-            return SunoUnprocessable(message, status)
-        if status == 429:
-            retry_after: Optional[float] = None
-            if response is not None:
-                raw = response.headers.get("Retry-After") if response.headers else None
-                if raw:
-                    try:
-                        retry_after = float(raw)
-                    except ValueError:
-                        retry_after = None
-            if payload:
-                retry_after_payload = payload.get("retry_after")
-                if retry_after is None and isinstance(retry_after_payload, (int, float)):
-                    retry_after = float(retry_after_payload)
-            return SunoRateLimited(message, retry_after)
-        if status >= 500:
-            return SunoServerError(message, status=status)
-        return SunoError(message, status=status, safe_message="Неизвестная ошибка Suno", details=payload)
-
-    # ---------------------------------------------------------------- requests
-    def request(
+    def _request(
         self,
         method: str,
         path: str,
         *,
-        json: Optional[Mapping[str, Any]] = None,
+        json_payload: Optional[Mapping[str, Any]] = None,
         params: Optional[Mapping[str, Any]] = None,
-        data: Optional[Mapping[str, Any]] = None,
-        files: Optional[Mapping[str, Any]] = None,
-        headers: Optional[Mapping[str, str]] = None,
-        timeout: Optional[int] = None,
-        op: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ) -> Mapping[str, Any]:
         url = self._full_url(path)
-        payload_keys = list(json.keys()) if isinstance(json, Mapping) else []
-        attempt_error: Optional[Exception] = None
-        for attempt in range(1, self._max_attempts + 1):
-            start = time.perf_counter()
-            status: Optional[int] = None
-            task_id: Optional[str] = None
+        attempt = 0
+        last_error: Optional[Exception] = None
+        status: Optional[int] = None
+        started_at = time.perf_counter()
+        while attempt < self.retries:
+            attempt += 1
             try:
                 response = self.session.request(
-                    method,
+                    method.upper(),
                     url,
-                    json=json,
+                    json=json_payload,
                     params=params,
-                    data=data,
-                    files=files,
-                    headers=self._build_headers(has_files=files is not None, extra=headers),
-                    timeout=timeout or self.timeout,
+                    headers=self._headers(),
+                    timeout=self.timeout,
                 )
                 status = response.status_code
-                payload = None
-                if status != 204:
-                    try:
-                        payload = self._parse_json(response)
-                    except SunoError as exc:
-                        attempt_error = exc
-                        if attempt >= self._max_attempts:
-                            raise
-                        self._log_attempt(op or method.upper(), path, "invalid_json", attempt, time.perf_counter() - start, task_id, payload_keys)
-                        self._sleep(attempt)
-                        continue
-                task_id = self._extract_task_id(payload)
-                elapsed = time.perf_counter() - start
-                self._log_attempt(op or method.upper(), path, status, attempt, elapsed, task_id, payload_keys)
-                if self._should_retry(status):
-                    if attempt >= self._max_attempts:
-                        raise self._map_error(status or 503, path, payload, response)
-                    self._sleep(attempt)
+                if self._should_retry(status) and attempt < self.retries:
+                    self._sleep(attempt - 1)
                     continue
-                if status and status >= 400:
-                    raise self._map_error(status, path, payload, response)
-                if isinstance(payload, Mapping):
-                    code = payload.get("code")
-                    if isinstance(code, int) and code >= 400:
-                        raise self._map_error(code, path, payload, response)
-                    return dict(payload)
-                return {}
+                payload = self._parse_json(response)
+                if status >= 400:
+                    self._log_attempt(method, url, status, attempt, started_at)
+                    raise SunoAPIError(
+                        payload.get("message") or payload.get("msg") or f"HTTP {status}",
+                        status=status,
+                        payload=payload,
+                    )
+                self._log_attempt(method, url, status, attempt, started_at)
+                return payload
             except requests.RequestException as exc:
-                elapsed = time.perf_counter() - start
-                attempt_error = exc
-                self._log_attempt(op or method.upper(), path, "network_error", attempt, elapsed, task_id, payload_keys)
-                if attempt >= self._max_attempts:
-                    raise SunoServerError("Network error talking to Suno") from exc
-                self._sleep(attempt)
-                continue
-        if attempt_error:
-            raise SunoServerError(str(attempt_error)) from attempt_error
-        raise SunoServerError("Unknown error calling Suno")
+                last_error = exc
+                status = None
+                if attempt >= self.retries:
+                    break
+                self._sleep(attempt - 1)
+        self._log_attempt(method, url, status or "error", attempt, started_at)
+        if isinstance(last_error, Exception):
+            raise SunoAPIError("Network error talking to Suno") from last_error
+        raise SunoAPIError(f"Suno API error: HTTP {status}", status=status)
 
-    def get(
-        self,
-        path: str,
-        *,
-        params: Optional[Mapping[str, Any]] = None,
-        headers: Optional[Mapping[str, str]] = None,
-        op: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        return self.request("GET", path, params=params, headers=headers, op=op)
+    # ---------------------------------------------------------------- public API
+    def create_music(self, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        body = {key: value for key, value in payload.items() if value is not None}
+        callback_url = SUNO_CALLBACK_URL or os.getenv("SUNO_CALLBACK_URL")
+        callback_token = SUNO_CALLBACK_SECRET or os.getenv("SUNO_CALLBACK_SECRET")
+        if callback_url:
+            body.setdefault("callback_url", callback_url)
+        if callback_token:
+            body.setdefault("callback_token", callback_token)
+        return self._request("POST", SUNO_GEN_PATH, json_payload=body)
 
-    def post(
-        self,
-        path: str,
-        *,
-        json: Optional[Mapping[str, Any]] = None,
-        headers: Optional[Mapping[str, str]] = None,
-        op: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        return self.request("POST", path, json=json, headers=headers, op=op)
-
-    # ---------------------------------------------------------------- logging
-    def _log_attempt(
-        self,
-        op: str,
-        path: str,
-        status: Any,
-        attempt: int,
-        elapsed: float,
-        task_id: Optional[str],
-        payload_keys: Optional[list[str]],
-    ) -> None:
-        elapsed_ms = round(elapsed * 1000, 1)
-        extra = {
-            "op": op,
-            "path": path,
-            "status": status,
-            "elapsed_ms": elapsed_ms,
-            "try": attempt,
-        }
-        if task_id:
-            extra["task_id"] = task_id
-        if payload_keys:
-            extra["payload_keys"] = payload_keys
-        log.info(
-            "suno request op=%s path=%s status=%s elapsed_ms=%.1f try=%s task_id=%s keys=%s",
-            op,
-            path,
-            status,
-            elapsed_ms,
-            attempt,
-            task_id or "-",
-            ",".join(payload_keys or []),
-            extra=extra,
-        )
+    def get_task_status(self, task_id: str) -> Mapping[str, Any]:
+        return self._request("GET", SUNO_TASK_STATUS_PATH, params={"task_id": task_id})
 
 
-# Backwards compatibility ----------------------------------------------------
-SunoClient = SunoHttp
-SunoAPIError = SunoError
-
-__all__ = [
-    "SunoHttp",
-    "SunoClient",
-    "SunoError",
-    "SunoAPIError",
-    "SunoBadRequest",
-    "SunoAuthError",
-    "SunoNotFound",
-    "SunoConflict",
-    "SunoUnprocessable",
-    "SunoRateLimited",
-    "SunoServerError",
-]
+__all__ = ["SunoClient", "SunoAPIError"]

--- a/suno/schemas.py
+++ b/suno/schemas.py
@@ -1,82 +1,128 @@
-"""Pydantic schemas for Suno callbacks and responses."""
+"""Data-transfer objects for the Suno integration."""
 from __future__ import annotations
 
-from typing import Any, List, Optional
-
-from pydantic import BaseModel, Field
-
-
-class SunoTrack(BaseModel):
-    """Normalized representation of an item returned by the Suno API."""
-
-    id: Optional[str] = None
-    title: Optional[str] = None
-    audio_url: Optional[str] = Field(default=None, alias="audioUrl")
-    image_url: Optional[str] = Field(default=None, alias="imageUrl")
-    duration_ms: Optional[int] = Field(default=None, alias="durationMs")
-
-    model_config = {"populate_by_name": True, "extra": "allow"}
+from dataclasses import dataclass, field
+from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Sequence
 
 
-class SunoTask(BaseModel):
-    """Normalized task response returned by :class:`SunoService`."""
-
-    code: int = 0
-    message: Optional[str] = None
-    task_id: Optional[str] = Field(default=None, alias="taskId")
-    items: List[SunoTrack] = Field(default_factory=list)
-
-    model_config = {"populate_by_name": True, "extra": "allow"}
+def _first(mapping: Mapping[str, Any], keys: Sequence[str]) -> Optional[Any]:
+    for key in keys:
+        if key in mapping and mapping[key] not in (None, ""):
+            return mapping[key]
+    return None
 
 
-class CallbackResponse(BaseModel):
-    """Arbitrary payload returned inside the callback envelope."""
-
-    model_config = {"extra": "allow"}
-
-
-class CallbackData(BaseModel):
-    """Data field of callback payload."""
-
-    task_id: Optional[str] = Field(default=None, alias="taskId")
-    callback_type: Optional[str] = Field(default=None, alias="callbackType")
-    status: Optional[str] = None
-    response: Optional[CallbackResponse] = None
-
-    model_config = {"populate_by_name": True, "extra": "allow"}
+def _ensure_mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
 
 
-class CallbackEnvelope(BaseModel):
-    """Top-level callback payload."""
-
-    code: Optional[int] = 200
-    msg: Optional[str] = None
-    data: Optional[CallbackData] = None
-
-    model_config = {"extra": "allow"}
+def _ensure_list(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
 
 
-class TaskAsset(BaseModel):
-    """Normalized representation of downloadable asset."""
+@dataclass(slots=True)
+class SunoTrack:
+    """Normalized track information returned by Suno."""
+
+    id: str
+    title: str
+    audio_url: Optional[str] = None
+    image_url: Optional[str] = None
+    ext: Optional[str] = None
+
+    @classmethod
+    def from_payload(cls, payload: Any, *, fallback_id: str) -> Optional["SunoTrack"]:
+        if payload is None:
+            return None
+        if isinstance(payload, str):
+            return cls(id=fallback_id, title=f"Track {fallback_id}", audio_url=payload, image_url=None, ext=None)
+        if not isinstance(payload, Mapping):
+            return None
+        data: MutableMapping[str, Any] = dict(payload)
+        track_id = _first(data, ("id", "trackId", "track_id", "audioId", "songId")) or fallback_id
+        title = _first(data, ("title", "name")) or f"Track {track_id}"
+        audio_url = _first(
+            data,
+            (
+                "audio_url",
+                "audioUrl",
+                "url",
+                "audio",
+                "mp3Url",
+                "mp3_url",
+                "fileUrl",
+            ),
+        )
+        image_url = _first(data, ("image_url", "imageUrl", "coverUrl", "image", "cover"))
+        ext = _first(data, ("ext", "extension", "audio_extension", "audioExt"))
+        return cls(id=str(track_id), title=str(title), audio_url=_maybe_str(audio_url), image_url=_maybe_str(image_url), ext=_maybe_str(ext))
+
+
+def _maybe_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    return str(value)
+
+
+@dataclass(slots=True)
+class SunoTask:
+    """Normalized task representation used across the bot/web."""
 
     task_id: str
-    url: str
-    asset_type: str
-    identifier: Optional[str] = None
-    filename: Optional[str] = None
-
-    model_config = {"populate_by_name": True, "extra": "allow"}
-
-
-class CallbackEvent(BaseModel):
-    """Normalized callback event that service operates with."""
-
-    task_id: str
-    callback_type: str
-    payload: dict[str, Any]
-    assets: list[TaskAsset] = Field(default_factory=list)
-    status: Optional[str] = None
-    code: Optional[int] = None
+    status: str
     message: Optional[str] = None
+    items: List[SunoTrack] = field(default_factory=list)
 
-    model_config = {"populate_by_name": True, "extra": "allow"}
+    @classmethod
+    def from_payload(cls, payload: Any) -> "SunoTask":
+        if not isinstance(payload, Mapping):
+            return cls(task_id="", status="unknown", message=None, items=[])
+        data = _ensure_mapping(payload.get("data"))
+        response = _ensure_mapping(data.get("response"))
+
+        task_id = _first(data, ("task_id", "taskId", "id")) or _first(payload, ("task_id", "taskId", "id")) or ""
+        message = _first(payload, ("message", "msg", "detail", "error"))
+        if not message:
+            message = _first(data, ("message", "msg", "detail", "error"))
+
+        status = _first(data, ("callbackType", "callback_type", "status", "state"))
+        if not status:
+            status = _first(payload, ("status", "state"))
+        if not status:
+            status = _first(response, ("status", "state"))
+        status_text = str(status) if status is not None else "unknown"
+
+        items_section: Iterable[Any] = []
+        for source in (
+            data.get("data"),
+            data.get("items"),
+            data.get("tracks"),
+            data.get("songs"),
+            response.get("data"),
+            response.get("items"),
+            response.get("tracks"),
+        ):
+            if source:
+                items_section = _ensure_list(source)
+                break
+        else:
+            fallback_items = _first(payload, ("items", "tracks"))
+            if fallback_items:
+                items_section = _ensure_list(fallback_items)
+
+        tracks: List[SunoTrack] = []
+        for idx, item in enumerate(items_section, start=1):
+            track = SunoTrack.from_payload(item, fallback_id=str(idx))
+            if track:
+                tracks.append(track)
+
+        return cls(task_id=str(task_id), status=status_text, message=_maybe_str(message), items=tracks)
+
+
+__all__ = ["SunoTask", "SunoTrack"]

--- a/tests/test_suno_basic.py
+++ b/tests/test_suno_basic.py
@@ -80,5 +80,5 @@ def test_suno_e2e_mocked(monkeypatch, caplog, tmp_path):
     joined = "\n".join(caplog.messages)
     assert "callback received" in joined
     assert "processed |" in joined
-    # проверяем, что телеграм пропущен из-за отсутствия токена
-    assert "skip Telegram notify" in joined
+    # проверяем, что сервис не упал без сохранённого чата
+    assert "No chat mapping" in joined


### PR DESCRIPTION
## Summary
- replace the Suno HTTP client and response schemas with normalized dataclasses and retry-aware requests
- add a unified Suno service that stores task metadata, delivers callbacks to Telegram, and reworks the FastAPI callback handler and bot flow
- adjust configuration defaults and tests to exercise the new callback pipeline

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d58d9f694c8322890b6fdb659a6a86