### PR TITLE
Allow Suno callback token in query string

### DIFF
--- a/suno_web.py
+++ b/suno_web.py
@@ -156,9 +156,10 @@ async def suno_callback(
     request: Request,
     x_callback_token: Optional[str] = Header(default=None, convert_underscores=False),
 ):
+    token = x_callback_token or request.query_params.get("token")
     if CALLBACK_SECRET:
-        if not x_callback_token or x_callback_token != CALLBACK_SECRET:
-            log.warning("Forbidden: bad X-Callback-Token")
+        if not token or token != CALLBACK_SECRET:
+            log.warning(f"Forbidden: bad X-Callback-Token ({token})")
             return JSONResponse({"error": "forbidden"}, status_code=403)
     try:
         payload = await request.json()


### PR DESCRIPTION
## Summary
- allow the Suno callback handler to read the callback token from either the header or the query parameter
- log which token caused a forbidden response when validation fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d59b66da1c8322aab07e8940af4c89