### PR TITLE
Implement Suno end-to-end pipeline and tests

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -35,14 +35,21 @@ def _parse_timeout(raw: Optional[str]) -> int:
     return max(1, min(value, 300))
 
 
-_default_prefix = "veo3:prod"
-_env_prefix = _get_env("REDIS_PREFIX", "") or ""
-REDIS_PREFIX = _env_prefix or _default_prefix
+REDIS_PREFIX = (os.getenv("REDIS_PREFIX") or "suno:prod").strip() or "suno:prod"
 SUNO_LOG_KEY = f"{REDIS_PREFIX}:suno:logs"
 
 # Suno HTTP configuration --------------------------------------------------
-SUNO_API_BASE = _get_env("SUNO_API_BASE", "https://api.kie.ai")
-SUNO_API_TOKEN = _get_env("SUNO_API_TOKEN", "test-token")
+SUNO_API_BASE = os.getenv("SUNO_API_BASE", "https://api.kie.ai")
+SUNO_API_TOKEN = os.getenv("SUNO_API_TOKEN")
+SUNO_CALLBACK_SECRET = os.getenv("SUNO_CALLBACK_SECRET")
+try:
+    SUNO_TIMEOUT_SEC = int(os.getenv("SUNO_TIMEOUT_SEC", "75"))
+except ValueError:
+    SUNO_TIMEOUT_SEC = 75
+try:
+    SUNO_MAX_RETRIES = int(os.getenv("SUNO_MAX_RETRIES", "5"))
+except ValueError:
+    SUNO_MAX_RETRIES = 5
 
 SUNO_GEN_PATH = _get_env("SUNO_GEN_PATH", "/api/v1/generate/music")
 SUNO_TASK_STATUS_PATH = _get_env("SUNO_TASK_STATUS_PATH", "/api/v1/generate/record-info")
@@ -57,14 +64,4 @@ SUNO_UPLOAD_EXTEND_PATH = _get_env("SUNO_UPLOAD_EXTEND_PATH", "/api/v1/generate/
 SUNO_COVER_INFO_PATH = _get_env("SUNO_COVER_INFO_PATH", "/api/v1/suno/cover/record-info")
 
 SUNO_MODEL = _get_env("SUNO_MODEL")
-SUNO_TIMEOUT_SEC = _parse_timeout(os.getenv("SUNO_TIMEOUT_SEC") or str(60))
-try:
-    SUNO_HTTP_RETRIES = int(os.getenv("SUNO_HTTP_RETRIES", "4"))
-except ValueError:
-    SUNO_HTTP_RETRIES = 4
-try:
-    SUNO_RETRY_BACKOFF_BASE = float(os.getenv("SUNO_RETRY_BACKOFF_BASE", "0.6"))
-except ValueError:
-    SUNO_RETRY_BACKOFF_BASE = 0.6
 SUNO_CALLBACK_URL = _get_env("SUNO_CALLBACK_URL")
-SUNO_CALLBACK_SECRET = _get_env("SUNO_CALLBACK_SECRET")

--- a/suno/client.py
+++ b/suno/client.py
@@ -1,16 +1,14 @@
-"""Lightweight HTTP client for the Suno API."""
+"""HTTP client wrapper for the Suno API."""
 from __future__ import annotations
 
 import json
 import logging
-import os
-import random
 import time
 from typing import Any, Mapping, MutableMapping, Optional
 from urllib.parse import urljoin
 
 import requests
-from requests import Response, Session
+from requests import RequestException, Response, Session
 
 from settings import (
     SUNO_API_BASE,
@@ -18,17 +16,19 @@ from settings import (
     SUNO_CALLBACK_SECRET,
     SUNO_CALLBACK_URL,
     SUNO_GEN_PATH,
-    SUNO_HTTP_RETRIES,
-    SUNO_RETRY_BACKOFF_BASE,
+    SUNO_MAX_RETRIES,
     SUNO_TASK_STATUS_PATH,
     SUNO_TIMEOUT_SEC,
 )
 
 log = logging.getLogger("suno.client")
 
+_RETRYABLE_CODES = {429, 502, 503, 504}
+_BACKOFF_SCHEDULE = (1, 3, 7)
+
 
 class SunoAPIError(RuntimeError):
-    """Raised when the Suno API returns an error response."""
+    """Raised when the Suno API responds with an error."""
 
     def __init__(self, message: str, *, status: Optional[int] = None, payload: Any = None) -> None:
         super().__init__(message)
@@ -37,62 +37,47 @@ class SunoAPIError(RuntimeError):
 
 
 class SunoClient:
-    """HTTP wrapper with retry/backoff and default headers."""
-
-    _RETRY_STATUSES = {408, 429}
+    """Thin wrapper around :mod:`requests` with retries/backoff."""
 
     def __init__(
         self,
         *,
         base_url: Optional[str] = None,
         token: Optional[str] = None,
-        timeout: Optional[float] = None,
-        retries: Optional[int] = None,
-        backoff_base: Optional[float] = None,
         session: Optional[Session] = None,
+        max_retries: Optional[int] = None,
+        timeout: Optional[tuple[int, int]] = None,
     ) -> None:
-        self.base_url = (base_url or SUNO_API_BASE or "").rstrip("/") + "/"
-        if not self.base_url.startswith("http"):
-            raise RuntimeError("SUNO_API_BASE must include protocol")
-        self.token = token or SUNO_API_TOKEN
+        raw_base = (base_url or SUNO_API_BASE or "").strip()
+        if not raw_base:
+            raise RuntimeError("SUNO_API_BASE is not configured")
+        self.base_url = raw_base.rstrip("/") + "/"
+        self.token = (token or SUNO_API_TOKEN or "").strip()
         if not self.token:
             raise RuntimeError("SUNO_API_TOKEN is not configured")
-        self.timeout = timeout or max(float(SUNO_TIMEOUT_SEC or 60), 1.0)
-        self.retries = max(1, int(retries or SUNO_HTTP_RETRIES or 1))
-        self.backoff_base = max(0.1, float(backoff_base or SUNO_RETRY_BACKOFF_BASE or 0.6))
         self.session = session or requests.Session()
+        retries = max_retries if max_retries is not None else SUNO_MAX_RETRIES
+        self.max_attempts = max(1, int(retries))
+        read_timeout = max(1, int(SUNO_TIMEOUT_SEC or 75) - 15)
+        self.timeout = timeout or (10, read_timeout)
 
     # ------------------------------------------------------------------ helpers
     def _headers(self) -> MutableMapping[str, str]:
         headers: MutableMapping[str, str] = {
             "Authorization": f"Bearer {self.token}",
             "Accept": "application/json",
-            "User-Agent": "best-veo3-bot/1.0",
         }
-        callback_url = SUNO_CALLBACK_URL or os.getenv("SUNO_CALLBACK_URL")
-        callback_token = SUNO_CALLBACK_SECRET or os.getenv("SUNO_CALLBACK_SECRET")
-        if callback_url:
-            headers["X-Callback-Url"] = callback_url
-        if callback_token:
-            headers["X-Callback-Token"] = callback_token
+        if SUNO_CALLBACK_URL:
+            headers["X-Callback-Url"] = SUNO_CALLBACK_URL
+        if SUNO_CALLBACK_SECRET:
+            headers["X-Callback-Token"] = SUNO_CALLBACK_SECRET
         return headers
 
-    def _full_url(self, path: str) -> str:
+    def _url(self, path: str) -> str:
         return urljoin(self.base_url, path.lstrip("/"))
 
-    def _should_retry(self, status: Optional[int]) -> bool:
-        if status is None:
-            return True
-        if status in self._RETRY_STATUSES:
-            return True
-        return 500 <= status < 600
-
-    def _sleep(self, attempt: int) -> None:
-        delay = self.backoff_base * (2 ** attempt)
-        delay += random.uniform(0, self.backoff_base)
-        time.sleep(delay)
-
-    def _parse_json(self, response: Response) -> Mapping[str, Any]:
+    @staticmethod
+    def _parse_json(response: Response) -> Mapping[str, Any]:
         if not response.content:
             return {}
         try:
@@ -103,16 +88,17 @@ class SunoClient:
             return payload
         return {"data": payload}
 
-    def _log_attempt(self, method: str, url: str, status: Any, tries: int, started_at: float) -> None:
-        elapsed_ms = round((time.perf_counter() - started_at) * 1000)
-        log.info(
-            "SUNO HTTP | method=%s url=%s code=%s ms=%s tries=%s",
-            method.upper(),
-            url,
-            status,
-            elapsed_ms,
-            tries,
-        )
+    def _maybe_backoff(self, code: Optional[int], attempt: int) -> bool:
+        if attempt >= self.max_attempts:
+            return False
+        if code is None or code in _RETRYABLE_CODES:
+            delay = _BACKOFF_SCHEDULE[min(attempt - 1, len(_BACKOFF_SCHEDULE) - 1)]
+            log.warning(
+                "suno.http retry code=%s attempt=%s backoff=%.1f", code or "error", attempt, float(delay)
+            )
+            time.sleep(delay)
+            return True
+        return False
 
     def _request(
         self,
@@ -122,56 +108,48 @@ class SunoClient:
         json_payload: Optional[Mapping[str, Any]] = None,
         params: Optional[Mapping[str, Any]] = None,
     ) -> Mapping[str, Any]:
-        url = self._full_url(path)
+        url = self._url(path)
         attempt = 0
-        last_error: Optional[Exception] = None
-        status: Optional[int] = None
-        started_at = time.perf_counter()
-        while attempt < self.retries:
+        last_error: Optional[BaseException] = None
+        while attempt < self.max_attempts:
             attempt += 1
             try:
                 response = self.session.request(
                     method.upper(),
                     url,
+                    headers=self._headers(),
                     json=json_payload,
                     params=params,
-                    headers=self._headers(),
                     timeout=self.timeout,
                 )
-                status = response.status_code
-                if self._should_retry(status) and attempt < self.retries:
-                    self._sleep(attempt - 1)
-                    continue
-                payload = self._parse_json(response)
-                if status >= 400:
-                    self._log_attempt(method, url, status, attempt, started_at)
-                    raise SunoAPIError(
-                        payload.get("message") or payload.get("msg") or f"HTTP {status}",
-                        status=status,
-                        payload=payload,
-                    )
-                self._log_attempt(method, url, status, attempt, started_at)
-                return payload
-            except requests.RequestException as exc:
+            except RequestException as exc:
                 last_error = exc
-                status = None
-                if attempt >= self.retries:
-                    break
-                self._sleep(attempt - 1)
-        self._log_attempt(method, url, status or "error", attempt, started_at)
-        if isinstance(last_error, Exception):
-            raise SunoAPIError("Network error talking to Suno") from last_error
-        raise SunoAPIError(f"Suno API error: HTTP {status}", status=status)
+                if not self._maybe_backoff(None, attempt):
+                    log.error("suno.http failed attempt=%s error=%s", attempt, exc)
+                    raise SunoAPIError("Network error talking to Suno") from exc
+                continue
 
-    # ---------------------------------------------------------------- public API
+            status = response.status_code
+            if status in _RETRYABLE_CODES and self._maybe_backoff(status, attempt):
+                continue
+
+            payload = self._parse_json(response)
+            if status >= 400:
+                log.error("suno.http error code=%s attempt=%s", status, attempt)
+                raise SunoAPIError(
+                    payload.get("message") or payload.get("msg") or f"HTTP {status}",
+                    status=status,
+                    payload=payload,
+                )
+
+            log.info("suno.http success code=%s attempt=%s", status, attempt)
+            return payload
+
+        raise SunoAPIError("Suno request exhausted retries", payload=getattr(last_error, "response", None))
+
+    # ------------------------------------------------------------------ public API
     def create_music(self, payload: Mapping[str, Any]) -> Mapping[str, Any]:
         body = {key: value for key, value in payload.items() if value is not None}
-        callback_url = SUNO_CALLBACK_URL or os.getenv("SUNO_CALLBACK_URL")
-        callback_token = SUNO_CALLBACK_SECRET or os.getenv("SUNO_CALLBACK_SECRET")
-        if callback_url:
-            body.setdefault("callback_url", callback_url)
-        if callback_token:
-            body.setdefault("callback_token", callback_token)
         return self._request("POST", SUNO_GEN_PATH, json_payload=body)
 
     def get_task_status(self, task_id: str) -> Mapping[str, Any]:

--- a/suno_web.py
+++ b/suno_web.py
@@ -3,20 +3,21 @@ from __future__ import annotations
 
 import json
 import logging
-import mimetypes
 import os
-import random
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Optional
+from urllib.parse import urlparse
 
 import requests
 from fastapi import FastAPI, Header, Request
 from fastapi.responses import JSONResponse
 
-from settings import LOG_LEVEL
-from suno.schemas import SunoTask
+from redis_utils import rds
+from settings import LOG_LEVEL, REDIS_PREFIX, SUNO_CALLBACK_SECRET
+from suno.schemas import CallbackEnvelope, SunoTask
 from suno.service import SunoService
+
 
 logging.basicConfig(
     level=getattr(logging, LOG_LEVEL, logging.INFO),
@@ -26,190 +27,143 @@ for noisy in ("httpx", "urllib3", "uvicorn", "gunicorn"):
     logging.getLogger(noisy).setLevel(logging.WARNING)
 log = logging.getLogger("suno-web")
 
+
 app = FastAPI(title="Suno Callback Web")
-
-CALLBACK_SECRET = os.getenv("SUNO_CALLBACK_SECRET", "")
-DOWNLOAD_TIMEOUT = float(os.getenv("SUNO_DOWNLOAD_TIMEOUT", "60"))
-DOWNLOAD_TRIES = int(os.getenv("SUNO_DOWNLOAD_TRIES", "3"))
-UA = os.getenv("SUNO_DOWNLOAD_UA") or "best-veo3-bot/1.0"
-HEADERS = {"User-Agent": UA, "Accept": "*/*", "Connection": "close"}
-BASE_DIR = Path("/tmp/suno")
-
 service = SunoService()
-_seen_callbacks: set[str] = set()
 
-
-@app.get("/healthz")
-def healthz() -> Dict[str, bool]:
-    return {"ok": True}
+_CALLBACK_TTL = 24 * 60 * 60
+_DOWNLOAD_TRIES = 3
+_BACKOFF_SCHEDULE = (1, 3, 7)
+_BASE_DIR = Path(os.getenv("SUNO_STORAGE", "/tmp/suno"))
+_memory_idempotency: dict[str, float] = {}
 
 
 @app.get("/")
-def root() -> Dict[str, bool]:
+def root() -> dict[str, bool]:
     return {"ok": True}
 
 
-def _idem_key(task_id: str, cb_type: str) -> str:
-    return f"{task_id}:{cb_type}" if task_id else cb_type
+@app.get("/healthz")
+def healthz() -> dict[str, bool]:
+    return {"ok": True}
 
 
-def _should_skip(key: str) -> bool:
+@app.get("/callbackz")
+def callbackz() -> dict[str, str | bool]:
+    return {"ok": True, "endpoint": "/suno-callback"}
+
+
+def _idempotency_key(task: str, cb_type: str) -> str:
+    task_part = task or "unknown"
+    type_part = cb_type or "unknown"
+    return f"{REDIS_PREFIX}:cb:{task_part}:{type_part}"
+
+
+def _register_once(key: str) -> bool:
     if not key:
-        return False
-    if key in _seen_callbacks:
         return True
-    _seen_callbacks.add(key)
-    return False
-
-
-def _ensure_dir(path: Path) -> None:
-    path.mkdir(parents=True, exist_ok=True)
-
-
-def _guess_ext(resp: requests.Response, url_path: str, suggested: Optional[str]) -> str:
-    if suggested:
-        clean = suggested if suggested.startswith(".") else f".{suggested}"
-        return clean
-    ct = resp.headers.get("Content-Type", "").split(";")[0].strip().lower()
-    if ct:
-        ext = mimetypes.guess_extension(ct, strict=False)
-        if ext:
-            return ext
-        if ct == "audio/mpeg":
-            return ".mp3"
-        if ct == "audio/wav":
-            return ".wav"
-    path_ext = Path(url_path or "").suffix
-    return path_ext if path_ext else ".bin"
-
-
-def _download(url: str, destination: Path, *, suggested_ext: Optional[str]) -> Tuple[Optional[Path], Optional[str]]:
-    if not url:
-        return None, None
-    tries = max(1, DOWNLOAD_TRIES)
-    delay = 1.0
-    last_error: Optional[str] = None
-    parsed_path = Path(url).name
-    for attempt in range(1, tries + 1):
+    if rds is not None:
         try:
-            with requests.get(url, headers=HEADERS, stream=True, timeout=DOWNLOAD_TIMEOUT) as resp:
+            stored = rds.set(key, "1", nx=True, ex=_CALLBACK_TTL)
+            if stored:
+                return True
+            return False
+        except Exception as exc:  # pragma: no cover - Redis failure fallback
+            log.warning("idempotency redis error | key=%s err=%s", key, exc)
+    now = time.time()
+    expires_at = now + _CALLBACK_TTL
+    current = _memory_idempotency.get(key)
+    if current and current > now:
+        return False
+    _memory_idempotency[key] = expires_at
+    return True
+
+
+def _ensure_directory(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _apply_extension(base: Path, url: str) -> Path:
+    parsed = urlparse(url)
+    suffix = Path(parsed.path or "").suffix
+    if suffix:
+        return base.with_suffix(suffix)
+    return base
+
+
+def _download(url: str, dest: Path) -> str:
+    if not url:
+        return url
+    for attempt in range(1, _DOWNLOAD_TRIES + 1):
+        try:
+            with requests.get(url, stream=True, timeout=(10, 30)) as resp:
                 status = resp.status_code
-                if status in {403, 404}:
-                    return None, f"http{status}"
-                if status >= 500:
-                    last_error = f"http{status}"
-                    raise requests.HTTPError(status)
+                if status in {403, 408} or 500 <= status < 600:
+                    if attempt == _DOWNLOAD_TRIES:
+                        log.warning("asset download failed | code=%s url=%s", status, url)
+                        return url
+                    delay = _BACKOFF_SCHEDULE[min(attempt - 1, len(_BACKOFF_SCHEDULE) - 1)]
+                    time.sleep(delay)
+                    continue
                 if status >= 400:
-                    return None, f"http{status}"
-                final_dest = destination
-                if not destination.suffix:
-                    ext = _guess_ext(resp, parsed_path, suggested_ext)
-                    final_dest = destination.with_suffix(ext)
-                _ensure_dir(final_dest.parent)
-                with final_dest.open("wb") as fh:
+                    log.warning("asset download non-retryable | code=%s url=%s", status, url)
+                    return url
+                _ensure_directory(dest)
+                with dest.open("wb") as fh:
                     for chunk in resp.iter_content(8192):
                         if chunk:
                             fh.write(chunk)
-                return final_dest, None
-        except Exception as exc:  # pragma: no cover - network errors
-            last_error = last_error or str(exc)
-            if attempt < tries:
-                time.sleep(delay + random.uniform(0, 0.25))
-                delay *= 1.5
-    return None, last_error
+                return str(dest)
+        except requests.RequestException as exc:
+            if attempt == _DOWNLOAD_TRIES:
+                log.warning("asset download exception | url=%s err=%s", url, exc)
+                return url
+            delay = _BACKOFF_SCHEDULE[min(attempt - 1, len(_BACKOFF_SCHEDULE) - 1)]
+            time.sleep(delay)
+    return url
 
 
-def _process_tracks(task_id: str, task: SunoTask) -> Tuple[List[str], List[str]]:
-    downloaded: List[str] = []
-    errors: List[str] = []
-    if not task_id:
-        return downloaded, errors
-    base_dir = BASE_DIR / task_id
-    for idx, track in enumerate(task.items, start=1):
-        track_id = track.id or str(idx)
-        title = track.title or f"track-{idx}"
+def _prepare_assets(task: SunoTask) -> None:
+    if not task.task_id:
+        return
+    base_dir = _BASE_DIR / task.task_id
+    for index, track in enumerate(task.items, start=1):
+        track_id = track.id or str(index)
         if track.audio_url:
-            dest = base_dir / track_id
-            path, err = _download(track.audio_url, dest, suggested_ext=track.ext)
-            if path:
-                size = path.stat().st_size
-                downloaded.append(f"audio:{path.name}:{size}")
-            else:
-                downloaded.append(f"audio-link:{track.audio_url}")
-                if err:
-                    errors.append(f"audio:{track_id}:{err}")
+            target = _apply_extension(base_dir / track_id, track.audio_url)
+            track.audio_url = _download(track.audio_url, target)
         if track.image_url:
-            dest = base_dir / f"{track_id}_cover"
-            path, err = _download(track.image_url, dest, suggested_ext=None)
-            if path:
-                size = path.stat().st_size
-                downloaded.append(f"image:{path.name}:{size}")
-            else:
-                downloaded.append(f"image-link:{track.image_url}")
-                if err:
-                    errors.append(f"image:{track_id}:{err}")
-    return downloaded, errors
+            target = _apply_extension(base_dir / f"{track_id}_cover", track.image_url)
+            track.image_url = _download(track.image_url, target)
 
 
 @app.post("/suno-callback")
 async def suno_callback(
     request: Request,
-    x_callback_token: Optional[str] = Header(default=None, convert_underscores=False),
+    x_callback_token: Optional[str] = Header(default=None),
 ):
-    token = x_callback_token or request.query_params.get("token")
-    if CALLBACK_SECRET:
-        if not token or token != CALLBACK_SECRET:
-            log.warning(f"Forbidden: bad X-Callback-Token ({token})")
-            return JSONResponse({"error": "forbidden"}, status_code=403)
+    provided = x_callback_token or request.query_params.get("token")
+    if SUNO_CALLBACK_SECRET and provided != SUNO_CALLBACK_SECRET:
+        log.warning("forbidden callback | provided=%s", provided)
+        return JSONResponse({"error": "forbidden"}, status_code=403)
+
     try:
         payload = await request.json()
-    except json.JSONDecodeError as exc:
+    except json.JSONDecodeError:
         body = await request.body()
-        log.error("Invalid JSON payload: %s body=%s", exc, body[:200])
-        return {"status": "received"}
-    if not isinstance(payload, dict):
-        log.error("Unexpected payload type: %s", type(payload))
-        return {"status": "received"}
+        log.error("invalid json payload: %s", body[:200])
+        return JSONResponse({"status": "ignored"}, status_code=400)
 
-    data = payload.get("data") or {}
-    callback_type = str(data.get("callbackType") or data.get("callback_type") or "").lower() or "unknown"
-    task_id = str(data.get("task_id") or data.get("taskId") or "").strip()
-    code = payload.get("code")
-    items = data.get("data") or []
+    envelope = CallbackEnvelope.model_validate(payload)
+    task = SunoTask.from_envelope(envelope)
+    key = _idempotency_key(task.task_id, task.callback_type)
+    if not _register_once(key):
+        log.info("duplicate callback ignored | key=%s", key)
+        return {"ok": True, "duplicate": True}
 
-    key = _idem_key(task_id, callback_type)
-    if _should_skip(key):
-        log.info("duplicate callback dropped | task=%s type=%s", task_id or "?", callback_type)
-        return {"status": "received"}
+    _prepare_assets(task)
+    service.handle_callback(task)
+    return {"ok": True}
 
-    log.info(
-        "callback received | code=%s task=%s type=%s items=%s",
-        code,
-        task_id or "?",
-        callback_type,
-        len(items) if isinstance(items, list) else 0,
-    )
 
-    task = SunoTask.from_payload(payload)
-    if task_id and not task.task_id:
-        task.task_id = task_id
-    task.status = callback_type or task.status
-
-    downloaded_assets, download_errors = _process_tracks(task.task_id, task)
-
-    log_line = {
-        "task_id": task.task_id,
-        "callbackType": callback_type,
-        "code": code,
-        "assets": downloaded_assets,
-        "errors": download_errors,
-        "message": payload.get("msg"),
-    }
-    log.info("processed | %s", json.dumps(log_line, ensure_ascii=False))
-
-    try:
-        service.handle_callback(task)
-    except Exception:  # pragma: no cover - defensive
-        log.exception("SunoService.handle_callback failed for task %s", task.task_id)
-
-    return {"status": "received"}
+__all__ = ["app"]


### PR DESCRIPTION
## Summary
- apply explicit defaults for Redis and Suno environment variables
- build a resilient Suno HTTP client, schemas, service pipeline, and callback app with retries, storage, and admin telemetry
- extend the bot with user-level locking and Suno admin commands, plus coverage for the webhook flow

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d5a1cc5f5883229859be357f473414