### PR TITLE
Improve Suno observability and reliability

### DIFF
--- a/suno_web.py
+++ b/suno_web.py
@@ -7,6 +7,7 @@ import os
 import signal
 import threading
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
@@ -18,7 +19,12 @@ from requests.adapters import HTTPAdapter
 from urllib3.util import Timeout
 
 from logging_utils import configure_logging
-from metrics import render_metrics, suno_callback_download_fail_total, suno_callback_total
+from metrics import (
+    render_metrics,
+    suno_callback_download_fail_total,
+    suno_callback_total,
+    suno_latency_seconds,
+)
 from redis_utils import rds
 from settings import (
     HTTP_POOL_CONNECTIONS,
@@ -54,6 +60,8 @@ _session = requests.Session()
 _session.mount("https://", _adapter)
 _session.mount("http://", _adapter)
 _timeout = Timeout(connect=HTTP_TIMEOUT_CONNECT, read=HTTP_TIMEOUT_READ, total=HTTP_TIMEOUT_TOTAL)
+_ENV = (os.getenv("APP_ENV") or "prod").strip() or "prod"
+_WEB_LABELS = {"env": _ENV, "service": "web"}
 
 
 def _active_count() -> int:
@@ -186,6 +194,20 @@ def _record_download_failure(reason: str, url: str) -> None:
     log.warning("asset download failed", extra={"meta": {"reason": reason, "url": url}})
 
 
+def _parse_iso8601(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
 def _download(url: str, dest: Path) -> str:
     if not url:
         return url
@@ -238,6 +260,7 @@ async def suno_callback(
     provided = x_callback_token or request.query_params.get("token")
     if SUNO_CALLBACK_SECRET and provided != SUNO_CALLBACK_SECRET:
         log.warning("forbidden callback", extra={"meta": {"provided": bool(provided)}})
+        suno_callback_total.labels(status="forbidden", **_WEB_LABELS).inc()
         return JSONResponse({"error": "forbidden"}, status_code=403)
 
     body = await request.body()
@@ -253,17 +276,30 @@ async def suno_callback(
 
     envelope = CallbackEnvelope.model_validate(payload)
     task = SunoTask.from_envelope(envelope)
-    suno_callback_total.labels(
-        type=(task.callback_type or "unknown"),
-        code=str(task.code or 0),
-    ).inc()
+    header_req_id = (
+        request.headers.get("X-Request-ID")
+        or request.headers.get("X-Req-Id")
+        or request.headers.get("X-Req-ID")
+    )
+    req_id = header_req_id or service.get_request_id(task.task_id)
+    start_ts = service.get_start_timestamp(task.task_id)
+    if start_ts:
+        started_at = _parse_iso8601(start_ts)
+        if started_at is not None:
+            elapsed = max(0.0, (datetime.now(timezone.utc) - started_at).total_seconds())
+            suno_latency_seconds.labels(**_WEB_LABELS).observe(elapsed)
     key = _idempotency_key(task.task_id, task.callback_type)
     if not _register_once(key):
-        log.info("duplicate callback ignored", extra={"meta": {"key": key}})
+        log.info(
+            "duplicate callback ignored",
+            extra={"meta": {"key": key, "task_id": task.task_id, "req_id": req_id}},
+        )
+        suno_callback_total.labels(status="skipped", **_WEB_LABELS).inc()
         return {"ok": True, "duplicate": True}
 
     _prepare_assets(task)
-    service.handle_callback(task)
+    service.handle_callback(task, req_id=req_id)
+    suno_callback_total.labels(status="ok", **_WEB_LABELS).inc()
     return {"ok": True}
 
 

--- a/telegram_utils.py
+++ b/telegram_utils.py
@@ -1,0 +1,270 @@
+"""Helpers for resilient Telegram API calls with retries and metrics."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import random
+from typing import Any, Awaitable, Callable, Optional
+
+from telegram.error import BadRequest, Forbidden, NetworkError, RetryAfter, TelegramError, TimedOut
+
+from metrics import telegram_send_total
+
+log = logging.getLogger("telegram.utils")
+
+_ENV = (os.getenv("APP_ENV") or "prod").strip() or "prod"
+_BOT_LABELS = {"env": _ENV, "service": "bot"}
+_RETRY_SCHEDULE = (0.6, 1.0, 1.6)
+_TEMP_ERROR_CODES = {409, 420, 429}
+_PERM_ERROR_CODES = {400, 403, 404}
+
+
+def _extract_status(exc: BaseException) -> Optional[int]:
+    for attr in ("status_code", "code", "error_code"):
+        value = getattr(exc, attr, None)
+        if isinstance(value, int):
+            return value
+    return None
+
+
+def _is_message_not_modified(exc: BadRequest) -> bool:
+    message = str(exc)
+    return "message is not modified" in message.lower()
+
+
+def _should_retry(exc: BaseException, status: Optional[int]) -> bool:
+    if isinstance(exc, RetryAfter):
+        return True
+    if isinstance(exc, (TimedOut, NetworkError)):
+        return True
+    if status is None:
+        return False
+    if status in _TEMP_ERROR_CODES:
+        return True
+    if status >= 500:
+        return True
+    return False
+
+
+def _retry_delay(attempt: int) -> float:
+    base = _RETRY_SCHEDULE[min(attempt - 1, len(_RETRY_SCHEDULE) - 1)]
+    return base * random.uniform(0.6, 1.6)
+
+
+async def _call_telegram(method: Callable[..., Awaitable[Any]], **kwargs: Any) -> Any:
+    return await method(**kwargs)
+
+
+async def safe_send(
+    method: Callable[..., Awaitable[Any]],
+    *,
+    method_name: str,
+    kind: str,
+    req_id: Optional[str] = None,
+    max_attempts: int = 4,
+    **kwargs: Any,
+) -> Any:
+    """Call a Telegram Bot API coroutine with retry handling."""
+
+    attempt = 0
+    while attempt < max_attempts:
+        attempt += 1
+        try:
+            result = await _call_telegram(method, **kwargs)
+            telegram_send_total.labels(kind=kind, result="ok", **_BOT_LABELS).inc()
+            if attempt > 1:
+                log.info(
+                    "telegram send succeeded",
+                    extra={
+                        "meta": {
+                            "method": method_name,
+                            "attempt": attempt,
+                            "req_id": req_id,
+                        }
+                    },
+                )
+            return result
+        except BadRequest as exc:
+            if _is_message_not_modified(exc):
+                telegram_send_total.labels(kind=kind, result="ok", **_BOT_LABELS).inc()
+                log.info(
+                    "telegram send noop",
+                    extra={
+                        "meta": {
+                            "method": method_name,
+                            "attempt": attempt,
+                            "req_id": req_id,
+                            "reason": "message_not_modified",
+                        }
+                    },
+                )
+                return None
+            status = 400
+            if _should_retry(exc, status) and attempt < max_attempts:
+                telegram_send_total.labels(kind=kind, result="retry", **_BOT_LABELS).inc()
+                delay = _retry_delay(attempt)
+                log.warning(
+                    "telegram retry",
+                    extra={
+                        "meta": {
+                            "method": method_name,
+                            "attempt": attempt,
+                            "delay": round(delay, 3),
+                            "status": status,
+                            "req_id": req_id,
+                        }
+                    },
+                )
+                await asyncio.sleep(delay)
+                continue
+            telegram_send_total.labels(kind=kind, result="fail", **_BOT_LABELS).inc()
+            log.warning(
+                "telegram send permanent failure",
+                extra={
+                    "meta": {
+                        "method": method_name,
+                        "status": status,
+                        "attempt": attempt,
+                        "req_id": req_id,
+                        "error": str(exc),
+                    }
+                },
+            )
+            raise
+        except Forbidden as exc:
+            status = 403
+            telegram_send_total.labels(kind=kind, result="fail", **_BOT_LABELS).inc()
+            log.warning(
+                "telegram forbidden",
+                extra={
+                    "meta": {
+                        "method": method_name,
+                        "status": status,
+                        "attempt": attempt,
+                        "req_id": req_id,
+                        "error": str(exc),
+                    }
+                },
+            )
+            raise
+        except RetryAfter as exc:
+            delay_base = getattr(exc, "retry_after", None)
+            if delay_base is None:
+                delay = _retry_delay(attempt)
+            else:
+                delay = float(delay_base) * random.uniform(0.6, 1.6)
+            if attempt < max_attempts:
+                telegram_send_total.labels(kind=kind, result="retry", **_BOT_LABELS).inc()
+                log.warning(
+                    "telegram retry",
+                    extra={
+                        "meta": {
+                            "method": method_name,
+                            "attempt": attempt,
+                            "delay": round(delay, 3),
+                            "status": getattr(exc, "status_code", 429),
+                            "req_id": req_id,
+                        }
+                    },
+                )
+                await asyncio.sleep(delay)
+                continue
+            telegram_send_total.labels(kind=kind, result="fail", **_BOT_LABELS).inc()
+            log.warning(
+                "telegram send failure",
+                extra={
+                    "meta": {
+                        "method": method_name,
+                        "status": getattr(exc, "status_code", 429),
+                        "attempt": attempt,
+                        "req_id": req_id,
+                        "error": str(exc),
+                    }
+                },
+            )
+            raise
+        except TelegramError as exc:
+            status = _extract_status(exc)
+            if status in _PERM_ERROR_CODES:
+                telegram_send_total.labels(kind=kind, result="fail", **_BOT_LABELS).inc()
+                log.warning(
+                    "telegram send permanent failure",
+                    extra={
+                        "meta": {
+                            "method": method_name,
+                            "status": status,
+                            "attempt": attempt,
+                            "req_id": req_id,
+                            "error": str(exc),
+                        }
+                    },
+                )
+                raise
+            if _should_retry(exc, status) and attempt < max_attempts:
+                telegram_send_total.labels(kind=kind, result="retry", **_BOT_LABELS).inc()
+                delay = _retry_delay(attempt)
+                log.warning(
+                    "telegram retry",
+                    extra={
+                        "meta": {
+                            "method": method_name,
+                            "attempt": attempt,
+                            "delay": round(delay, 3),
+                            "status": status,
+                            "req_id": req_id,
+                        }
+                    },
+                )
+                await asyncio.sleep(delay)
+                continue
+            telegram_send_total.labels(kind=kind, result="fail", **_BOT_LABELS).inc()
+            log.warning(
+                "telegram send failure",
+                extra={
+                    "meta": {
+                        "method": method_name,
+                        "status": status,
+                        "attempt": attempt,
+                        "req_id": req_id,
+                        "error": str(exc),
+                    }
+                },
+            )
+            raise
+        except (TimedOut, NetworkError) as exc:
+            if attempt < max_attempts:
+                telegram_send_total.labels(kind=kind, result="retry", **_BOT_LABELS).inc()
+                delay = _retry_delay(attempt)
+                log.warning(
+                    "telegram retry",
+                    extra={
+                        "meta": {
+                            "method": method_name,
+                            "attempt": attempt,
+                            "delay": round(delay, 3),
+                            "req_id": req_id,
+                            "error": str(exc),
+                        }
+                    },
+                )
+                await asyncio.sleep(delay)
+                continue
+            telegram_send_total.labels(kind=kind, result="fail", **_BOT_LABELS).inc()
+            log.warning(
+                "telegram send failure",
+                extra={
+                    "meta": {
+                        "method": method_name,
+                        "attempt": attempt,
+                        "req_id": req_id,
+                        "error": str(exc),
+                    }
+                },
+            )
+            raise
+    telegram_send_total.labels(kind=kind, result="fail", **_BOT_LABELS).inc()
+    raise RuntimeError(f"Telegram send exceeded retries for {method_name}")
+
+
+__all__ = ["safe_send"]

--- a/tests/test_leader.py
+++ b/tests/test_leader.py
@@ -69,6 +69,10 @@ def reload_bot(monkeypatch, **env):
     monkeypatch.setenv("LEDGER_BACKEND", "memory")
     monkeypatch.setenv("DATABASE_URL", "")
     monkeypatch.setenv("POSTGRES_DSN", "")
+    monkeypatch.setenv("SUNO_API_BASE", "https://example.com")
+    monkeypatch.setenv("SUNO_API_TOKEN", "token")
+    monkeypatch.setenv("SUNO_CALLBACK_URL", "https://callback")
+    monkeypatch.setenv("SUNO_CALLBACK_SECRET", "secret")
     for key, value in env.items():
         monkeypatch.setenv(key, value)
     module = importlib.import_module("bot")

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -108,13 +108,13 @@ def test_suno_client_retries(monkeypatch, requests_mock, status_codes, expected_
 
 
 def test_metrics_endpoint_outputs_counters(monkeypatch):
-    suno_callback_total.labels(type="test", code="200").inc()
+    env = (os.getenv("APP_ENV") or "prod").strip() or "prod"
+    suno_callback_total.labels(status="ok", env=env, service="test").inc()
     suno_callback_download_fail_total.labels(reason="network").inc()
     suno_task_store_total.labels(result="memory").inc()
     payload = render_metrics().decode("utf-8")
     assert "suno_callback_total" in payload
-    assert 'code="200"' in payload
-    assert 'type="test"' in payload
+    assert 'status="ok"' in payload
     assert "process_uptime_seconds" in payload
 
 

--- a/tests/test_suno_helpers.py
+++ b/tests/test_suno_helpers.py
@@ -1,0 +1,99 @@
+import asyncio
+import importlib
+import os
+import time
+
+import pytest
+from telegram.error import RetryAfter
+
+os.environ.setdefault("SUNO_API_BASE", "https://example.com")
+os.environ.setdefault("SUNO_API_TOKEN", "token")
+os.environ.setdefault("SUNO_CALLBACK_URL", "https://callback")
+os.environ.setdefault("SUNO_CALLBACK_SECRET", "secret")
+
+from telegram_utils import safe_send
+
+os.environ.setdefault("TELEGRAM_TOKEN", "dummy")
+
+
+def test_safe_send_retries(monkeypatch):
+    calls = {"count": 0}
+
+    class Dummy:
+        async def method(self, **kwargs):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise RetryAfter(1)
+            return "ok"
+
+    dummy = Dummy()
+
+    async def _instant_sleep(delay):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+    monkeypatch.setattr("telegram_utils.asyncio.sleep", _instant_sleep)
+    result = asyncio.run(
+        safe_send(
+            dummy.method,
+            method_name="sendMessage",
+            kind="message",
+            req_id="req-test",
+            chat_id=123,
+            text="hi",
+        )
+    )
+    assert result == "ok"
+    assert calls["count"] == 2
+
+
+def _import_bot(monkeypatch):
+    module = importlib.import_module("bot")
+    module._SUNO_REFUND_MEMORY.clear()
+    module._SUNO_COOLDOWN_MEMORY.clear()
+    return module
+
+
+def test_refund_idempotent(monkeypatch):
+    bot = _import_bot(monkeypatch)
+
+    class FakeRedis:
+        def __init__(self):
+            self.store = set()
+
+        def set(self, key, value, nx=False, ex=None):
+            if nx and key in self.store:
+                return False
+            self.store.add(key)
+            return True
+
+    fake = FakeRedis()
+    monkeypatch.setattr(bot, "rds", fake)
+    assert bot._suno_acquire_refund("task-one") is True
+    assert bot._suno_acquire_refund("task-one") is False
+
+
+def test_cooldown_blocks(monkeypatch):
+    bot = _import_bot(monkeypatch)
+    bot.SUNO_PER_USER_COOLDOWN_SEC = 5
+
+    class FakeRedis:
+        def __init__(self):
+            self.ttl_values = {}
+
+        def setex(self, key, ttl, value):
+            self.ttl_values[key] = ttl
+
+        def ttl(self, key):
+            return self.ttl_values.get(key, -2)
+
+    fake = FakeRedis()
+    monkeypatch.setattr(bot, "rds", fake)
+    bot._suno_set_cooldown(42)
+    remaining = bot._suno_cooldown_remaining(42)
+    assert remaining == 5
+
+    monkeypatch.setattr(bot, "rds", None)
+    bot._SUNO_COOLDOWN_MEMORY[84] = time.time() + 3
+    remaining_local = bot._suno_cooldown_remaining(84)
+    assert remaining_local >= 2


### PR DESCRIPTION
## Summary
- propagate correlation IDs through the Suno request lifecycle, add per-user cooldown checks, and make Suno refunds idempotent with structured logging
- extend the Suno client/service/web layers with request ID headers, latency metrics, and richer Prometheus counters including Telegram send telemetry
- introduce a shared Telegram send helper with jittered retries and expand logging/metrics masking to cover additional secrets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6509d440083229d5ad97bde4cf39e