### PR TITLE
Harden Suno launch notify flow

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -64,6 +64,34 @@ bot_telegram_send_fail_total = Counter(
     registry=REGISTRY,
 )
 
+suno_notify_ok = Counter(
+    "suno_notify_ok",
+    "Successful Suno launch notifications",
+    labelnames=("env", "service"),
+    registry=REGISTRY,
+)
+
+suno_notify_fail = Counter(
+    "suno_notify_fail",
+    "Failed Suno launch notifications grouped by error type",
+    labelnames=("type", "env", "service"),
+    registry=REGISTRY,
+)
+
+suno_notify_duration_seconds = Histogram(
+    "suno_notify_duration_seconds",
+    "Duration of Suno launch acknowledgement notifications",
+    labelnames=("env", "service"),
+    registry=REGISTRY,
+)
+
+suno_enqueue_duration_seconds = Histogram(
+    "suno_enqueue_duration_seconds",
+    "Duration of Suno enqueue operations",
+    labelnames=("env", "service"),
+    registry=REGISTRY,
+)
+
 process_uptime_seconds = Gauge(
     "process_uptime_seconds",
     "Process uptime in seconds",
@@ -89,6 +117,10 @@ __all__: Iterable[str] = [
     "suno_callback_total",
     "telegram_send_total",
     "suno_latency_seconds",
+    "suno_notify_ok",
+    "suno_notify_fail",
+    "suno_notify_duration_seconds",
+    "suno_enqueue_duration_seconds",
     "process_uptime_seconds",
     "render_metrics",
 ]


### PR DESCRIPTION
## Summary
- allow Suno launches to proceed when Telegram notify fails, logging outcome, tracking latency, and storing pending/refund metadata for recovery
- add Prometheus counters and histograms for Suno notify outcomes plus enqueue duration
- extend tests to cover pending/refund helpers, notify/enqueue flows, and metrics output for the new instrumentation

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d6619bf2d483229af6cc10fffb0dfa