### PR TITLE
Migrate Suno client to V5 with legacy fallback

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -18,7 +18,7 @@ def _labels(service: str) -> dict[str, str]:
 suno_requests_total = Counter(
     "suno_requests_total",
     "Total Suno requests grouped by outcome",
-    labelnames=("result", "reason", "env", "service"),
+    labelnames=("result", "reason", "api_version", "env", "service"),
     registry=REGISTRY,
 )
 

--- a/settings.py
+++ b/settings.py
@@ -138,8 +138,8 @@ def _get_env(name: str, default: Optional[str] = None) -> Optional[str]:
     return value or default
 
 
-SUNO_GEN_PATH = _get_env("SUNO_GEN_PATH", "/api/v1/generate/music")
-SUNO_TASK_STATUS_PATH = _get_env("SUNO_TASK_STATUS_PATH", "/api/v1/generate/record-info")
+SUNO_GEN_PATH = _get_env("SUNO_GEN_PATH", "/suno-api/generate")
+SUNO_TASK_STATUS_PATH = _get_env("SUNO_TASK_STATUS_PATH", "/suno-api/record-info")
 SUNO_WAV_PATH = _get_env("SUNO_WAV_PATH", "/api/v1/wav/generate")
 SUNO_WAV_INFO_PATH = _get_env("SUNO_WAV_INFO_PATH", "/api/v1/wav/record-info")
 SUNO_MP4_PATH = _get_env("SUNO_MP4_PATH", "/api/v1/mp4/generate")

--- a/suno/schemas.py
+++ b/suno/schemas.py
@@ -1,7 +1,7 @@
 """Pydantic models shared between the Suno bot and callback worker."""
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -73,10 +73,16 @@ def _ensure_iterable(value: Any) -> Iterable[Any]:
 
 
 def _extract_items(data: dict[str, Any]) -> Iterable[Any]:
-    for key in ("data", "items", "tracks"):
+    for key in ("tracks", "items", "data"):
         maybe = data.get(key)
         if maybe:
             return _ensure_iterable(maybe)
+    input_section = data.get("input")
+    if isinstance(input_section, Mapping):
+        for key in ("tracks", "items", "data"):
+            maybe = input_section.get(key)
+            if maybe:
+                return _ensure_iterable(maybe)
     response = data.get("response")
     if isinstance(response, dict):
         for key in ("data", "items", "tracks"):

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -101,13 +101,15 @@ def test_suno_client_retries(monkeypatch, requests_mock, status_codes, expected_
             responses.append({"status_code": 200, "json": {"task_id": "ok"}})
         else:
             responses.append({"status_code": status, "json": {"message": "err"}})
-    requests_mock.post("https://example.com/api/v1/generate/music", responses)
+    requests_mock.post("https://example.com/suno-api/generate", responses)
     suno_client = SunoClient(base_url="https://example.com", token="tkn", max_retries=3)
     if status_codes[0] == 403:
         with pytest.raises(SunoAPIError):
-            suno_client.create_music({})
+            suno_client.create_music({"instrumental": False})
     else:
-        suno_client.create_music({})
+        payload, version = suno_client.create_music({"instrumental": False})
+        assert payload["task_id"] == "ok"
+        assert version == "v5"
     assert requests_mock.call_count == expected_calls
 
 


### PR DESCRIPTION
## Summary
- update Suno client to talk to the V5 /suno-api endpoints, build the new request payload shape, and fall back to legacy paths when a 404 response is returned
- record the API version in service metrics and expose the new defaults for generate and status paths
- adjust schema parsing, callback handling tests, and add coverage for the new V5 payloads and fallback logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6ab5fc8fc8322849c2201645f872b