### PR TITLE
Implement contextual chat mode with metrics and tests

### DIFF
--- a/chat_service.py
+++ b/chat_service.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+from typing import Dict, List, Optional
+
+try:  # pragma: no cover - optional redis factory
+    from redis_utils import rds as _redis_instance  # type: ignore
+except Exception:  # pragma: no cover - redis optional
+    _redis_instance = None
+
+CHAT_PREFIX = os.getenv("REDIS_PREFIX", "veo3:prod")
+CTX_KEY = CHAT_PREFIX + ":chat:ctx:{user_id}"
+MODE_KEY = CHAT_PREFIX + ":chat:mode:{user_id}"
+RATE_KEY = CHAT_PREFIX + ":chat:rate:{user_id}"
+
+CTX_TTL_SEC = 48 * 3600
+CTX_MAX_PAIRS = 12
+CTX_MAX_TOKENS = 2048
+INPUT_MAX_CHARS = 3000
+
+_memory: Dict[str, Dict[str, object]] = {
+    "ctx": {},
+    "mode": {},
+    "rate": {},
+}
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def estimate_tokens(text: str) -> int:
+    text = text or ""
+    return max(1, len(text) // 4)
+
+
+def _get_redis():
+    return _redis_instance
+
+
+def append_ctx(user_id: int, role: str, content: str) -> None:
+    item = {"role": role, "content": content, "ts": _now()}
+    key = CTX_KEY.format(user_id=user_id)
+    payload = json.dumps(item, ensure_ascii=False)
+    redis = _get_redis()
+    if redis:
+        try:
+            redis.rpush(key, payload)
+            redis.expire(key, CTX_TTL_SEC)
+            return
+        except Exception:
+            pass
+    ctx_store = _memory.setdefault("ctx", {})
+    existing = ctx_store.get(key)
+    if not isinstance(existing, list):
+        existing = []
+        ctx_store[key] = existing
+    existing.append(item)
+
+
+def load_ctx(
+    user_id: int,
+    max_pairs: int = CTX_MAX_PAIRS,
+    max_tokens: int = CTX_MAX_TOKENS,
+) -> List[Dict[str, object]]:
+    key = CTX_KEY.format(user_id=user_id)
+    redis = _get_redis()
+    raw_items: List[Dict[str, object]] = []
+    if redis:
+        try:
+            entries = redis.lrange(key, 0, -1) or []
+        except Exception:
+            entries = []
+        for entry in entries:
+            if isinstance(entry, bytes):
+                entry = entry.decode("utf-8")
+            try:
+                parsed = json.loads(entry)
+            except Exception:
+                continue
+            if isinstance(parsed, dict):
+                raw_items.append(parsed)
+    else:
+        ctx_store = _memory.setdefault("ctx", {})
+        stored = ctx_store.get(key)
+        if isinstance(stored, list):
+            raw_items = list(stored)
+        else:
+            raw_items = []
+
+    trimmed: List[Dict[str, object]] = []
+    tokens = 0
+    pairs = 0
+    for item in reversed(raw_items):
+        content = str(item.get("content", ""))
+        token_add = estimate_tokens(content)
+        if tokens + token_add > max_tokens:
+            break
+        trimmed.append(item)
+        tokens += token_add
+        role = item.get("role")
+        if role in ("user", "assistant"):
+            pairs = sum(1 for it in trimmed if it.get("role") in ("user", "assistant")) // 2
+            if pairs >= max_pairs:
+                break
+    return list(reversed(trimmed))
+
+
+def clear_ctx(user_id: int) -> None:
+    key = CTX_KEY.format(user_id=user_id)
+    redis = _get_redis()
+    if redis:
+        try:
+            redis.delete(key)
+            return
+        except Exception:
+            pass
+    ctx_store = _memory.setdefault("ctx", {})
+    ctx_store.pop(key, None)
+
+
+def set_mode(user_id: int, on: bool) -> None:
+    key = MODE_KEY.format(user_id=user_id)
+    redis = _get_redis()
+    if redis:
+        try:
+            if on:
+                redis.setex(key, CTX_TTL_SEC, "on")
+            else:
+                redis.delete(key)
+            return
+        except Exception:
+            pass
+    mode_store = _memory.setdefault("mode", {})
+    if on:
+        mode_store[key] = {"value": "on", "exp": _now() + CTX_TTL_SEC}
+    else:
+        mode_store.pop(key, None)
+
+
+def is_mode_on(user_id: int) -> bool:
+    key = MODE_KEY.format(user_id=user_id)
+    redis = _get_redis()
+    if redis:
+        try:
+            value = redis.get(key)
+        except Exception:
+            value = None
+        if isinstance(value, bytes):
+            value = value.decode("utf-8")
+        return value == "on"
+    mode_store = _memory.setdefault("mode", {})
+    entry = mode_store.get(key)
+    if not isinstance(entry, dict):
+        return False
+    exp = entry.get("exp")
+    if isinstance(exp, (int, float)) and exp >= _now():
+        return True
+    mode_store.pop(key, None)
+    return False
+
+
+def rate_limit_hit(user_id: int) -> bool:
+    key = RATE_KEY.format(user_id=user_id)
+    redis = _get_redis()
+    if redis:
+        try:
+            created = redis.setnx(key, "1")
+            if created:
+                redis.expire(key, 1)
+                return False
+            return True
+        except Exception:
+            pass
+    rate_store = _memory.setdefault("rate", {})
+    expires_at = rate_store.get(key, 0)
+    now = _now()
+    if now < expires_at:
+        return True
+    rate_store[key] = now + 1
+    return False
+
+
+def build_messages(
+    system_prompt: str,
+    history: List[Dict[str, object]],
+    user_text: str,
+    answer_lang: str,
+) -> List[Dict[str, str]]:
+    messages: List[Dict[str, str]] = [
+        {
+            "role": "system",
+            "content": f"{system_prompt}\nЯзык ответа: {answer_lang}.",
+        }
+    ]
+    for item in history:
+        role = str(item.get("role", ""))
+        content = str(item.get("content", ""))
+        messages.append({"role": role, "content": content})
+    messages.append({"role": "user", "content": user_text})
+    return messages
+
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
+OPENAI_API_BASE = os.getenv("OPENAI_API_BASE", "https://api.openai.com/v1")
+LLM_MODEL = os.getenv("CHAT_MODEL", "gpt-4o-mini")
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except Exception:  # pragma: no cover - fallback for type checkers
+    requests = None  # type: ignore
+
+
+def call_llm(
+    messages: List[Dict[str, str]],
+    temperature: float = 0.6,
+    max_output_tokens: int = 800,
+    timeout_sec: float = 20.0,
+) -> str:
+    if not requests:
+        raise RuntimeError("requests library is required for call_llm")
+
+    url = f"{OPENAI_API_BASE}/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {OPENAI_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": LLM_MODEL,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": max_output_tokens,
+    }
+
+    backoffs = [1.0 + random.random() * 1.5 for _ in range(3)]
+    for attempt in range(3):
+        try:
+            response = requests.post(
+                url,
+                headers=headers,
+                json=payload,
+                timeout=timeout_sec,
+            )
+        except Exception as exc:
+            if attempt < 2:
+                time.sleep(backoffs[attempt])
+                continue
+            raise RuntimeError(f"llm request failed: {exc}") from exc
+
+        if response.status_code == 200:
+            data = response.json()
+            choices = data.get("choices") or []
+            if not choices:
+                raise RuntimeError("llm response missing choices")
+            message = choices[0].get("message") or {}
+            content = message.get("content")
+            if not isinstance(content, str):
+                raise RuntimeError("llm response invalid content")
+            return content.strip()
+
+        if response.status_code in {429, 500, 502, 503, 504} and attempt < 2:
+            time.sleep(backoffs[attempt])
+            continue
+        text = response.text[:400] if response.text else ""
+        raise RuntimeError(f"llm http {response.status_code}: {text}")
+
+    raise RuntimeError("llm request exhausted retries")
+
+
+__all__ = [
+    "append_ctx",
+    "build_messages",
+    "call_llm",
+    "clear_ctx",
+    "estimate_tokens",
+    "is_mode_on",
+    "load_ctx",
+    "rate_limit_hit",
+    "set_mode",
+    "CTX_MAX_PAIRS",
+    "CTX_MAX_TOKENS",
+    "INPUT_MAX_CHARS",
+]

--- a/metrics.py
+++ b/metrics.py
@@ -64,6 +64,26 @@ telegram_send_total = Counter(
     registry=REGISTRY,
 )
 
+chat_messages_total = Counter(
+    "chat_messages_total",
+    "Total chat messages processed",
+    labelnames=("outcome",),
+    registry=REGISTRY,
+)
+
+chat_latency_ms = Histogram(
+    "chat_latency_ms",
+    "Chat roundtrip latency in milliseconds",
+    buckets=(50, 100, 200, 400, 800, 1500, 3000, 6000, 10000),
+    registry=REGISTRY,
+)
+
+chat_context_tokens = Gauge(
+    "chat_context_tokens",
+    "Estimated tokens in chat context (last observed)",
+    registry=REGISTRY,
+)
+
 suno_latency_seconds = Histogram(
     "suno_latency_seconds",
     "Latency from task start to callback",
@@ -153,6 +173,9 @@ __all__: Iterable[str] = [
     "suno_notify_fail",
     "suno_notify_duration_seconds",
     "suno_enqueue_duration_seconds",
+    "chat_messages_total",
+    "chat_latency_ms",
+    "chat_context_tokens",
     "process_uptime_seconds",
     "render_metrics",
 ]

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -1,0 +1,86 @@
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import chat_service
+from chat_service import append_ctx, clear_ctx, estimate_tokens, load_ctx
+
+
+@pytest.fixture(autouse=True)
+def reset_chat_state(monkeypatch):
+    chat_service._memory["ctx"].clear()
+    chat_service._memory["mode"].clear()
+    chat_service._memory["rate"].clear()
+    monkeypatch.setattr(chat_service, "_get_redis", lambda: None)
+    yield
+
+
+def test_estimate_tokens_various_lengths():
+    assert estimate_tokens("") == 1
+    assert estimate_tokens("abcd") == 1
+    assert estimate_tokens("abcdefgh") == 2
+    assert estimate_tokens("a" * 25) == 6
+
+
+def test_load_ctx_limits_pairs_and_tokens():
+    user_id = 101
+    for idx in range(3):
+        append_ctx(user_id, "user", f"u{idx}")
+        append_ctx(user_id, "assistant", f"a{idx}")
+
+    limited_tokens = load_ctx(user_id, max_tokens=2)
+    assert [item["role"] for item in limited_tokens] == ["user", "assistant"]
+    assert limited_tokens[-1]["content"] == "a2"
+
+    limited_pairs = load_ctx(user_id, max_pairs=1, max_tokens=100)
+    assert [item["role"] for item in limited_pairs] == ["user", "assistant"]
+    assert limited_pairs[0]["content"] == "u2"
+
+
+def test_append_and_clear_with_redis(monkeypatch):
+    class FakeRedis:
+        def __init__(self) -> None:
+            self.store: dict[str, list[str]] = {}
+            self.values: dict[str, str] = {}
+
+        def rpush(self, key: str, value: str) -> None:
+            self.store.setdefault(key, []).append(value)
+
+        def expire(self, key: str, ttl: int) -> None:  # pragma: no cover - no-op
+            return None
+
+        def lrange(self, key: str, start: int, end: int) -> list[str]:
+            items = self.store.get(key, [])
+            if end == -1:
+                end = len(items) - 1
+            return items[start : end + 1]
+
+        def delete(self, key: str) -> None:
+            self.store.pop(key, None)
+
+        def setex(self, key: str, ttl: int, value: str) -> None:
+            self.values[key] = value
+
+        def get(self, key: str) -> Any:
+            return self.values.get(key)
+
+    fake = FakeRedis()
+    monkeypatch.setattr(chat_service, "_get_redis", lambda: fake)
+
+    user_id = 7
+    append_ctx(user_id, "user", "hello")
+    append_ctx(user_id, "assistant", "world")
+
+    history = load_ctx(user_id)
+    assert len(history) == 2
+    assert history[0]["content"] == "hello"
+
+    clear_ctx(user_id)
+    assert fake.store == {}
+    assert load_ctx(user_id) == []


### PR DESCRIPTION
## Summary
- add a dedicated chat service module to persist dialog context, rate limiting, and LLM calls
- update bot handlers and Telegram helpers to provide Markdown-safe chat replies, metrics, and new commands
- expose chat Prometheus metrics and cover chat service logic with unit tests

## Testing
- pytest tests/test_chat_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ed5249dc8322b2d7f663fa28321d