### PR TITLE
Add Telegram voice transcription pipeline

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -84,6 +84,27 @@ chat_context_tokens = Gauge(
     registry=REGISTRY,
 )
 
+chat_voice_total = Counter(
+    "chat_voice_total",
+    "Voice messages processed in chat",
+    labelnames=("outcome", "env", "service"),
+    registry=REGISTRY,
+)
+
+chat_voice_latency_ms = Histogram(
+    "chat_voice_latency_ms",
+    "Latency of handling chat voice messages in milliseconds",
+    labelnames=("env", "service"),
+    registry=REGISTRY,
+)
+
+chat_transcribe_latency_ms = Histogram(
+    "chat_transcribe_latency_ms",
+    "Latency of audio transcription calls in milliseconds",
+    labelnames=("env", "service"),
+    registry=REGISTRY,
+)
+
 suno_latency_seconds = Histogram(
     "suno_latency_seconds",
     "Latency from task start to callback",
@@ -176,6 +197,9 @@ __all__: Iterable[str] = [
     "chat_messages_total",
     "chat_latency_ms",
     "chat_context_tokens",
+    "chat_voice_total",
+    "chat_voice_latency_ms",
+    "chat_transcribe_latency_ms",
     "process_uptime_seconds",
     "render_metrics",
 ]

--- a/tests/test_voice_service.py
+++ b/tests/test_voice_service.py
@@ -1,0 +1,299 @@
+import asyncio
+import importlib
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import voice_service
+from voice_service import VoiceTranscribeError, transcribe
+
+
+class _FakeRateLimitError(Exception):
+    pass
+
+
+class _FakeAPIError(Exception):
+    def __init__(self, status: int) -> None:
+        super().__init__("api error")
+        self.http_status = status
+
+
+class _FakeServiceUnavailableError(Exception):
+    pass
+
+
+def _setup_openai(monkeypatch, transcribe_fn):
+    fake_openai = types.ModuleType("openai")
+    fake_error_module = types.ModuleType("openai.error")
+    fake_error_module.APIError = _FakeAPIError
+    fake_error_module.RateLimitError = _FakeRateLimitError
+    fake_error_module.ServiceUnavailableError = _FakeServiceUnavailableError
+    fake_audio = SimpleNamespace(transcribe=transcribe_fn)
+    fake_openai.Audio = fake_audio
+    fake_openai.api_key = "sk-test"
+    fake_openai.error = fake_error_module
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+    monkeypatch.setitem(sys.modules, "openai.error", fake_error_module)
+    monkeypatch.setattr(voice_service, "openai", fake_openai)
+
+
+def test_transcribe_success(monkeypatch):
+    captured = {}
+
+    def fake_transcribe(**kwargs):
+        captured.update(kwargs)
+        return {"text": "  hello world  "}
+
+    _setup_openai(monkeypatch, fake_transcribe)
+    result = transcribe(b"data", "audio/wav", "en")
+    assert result == "hello world"
+    assert captured["model"] == voice_service._MODEL_NAME
+    assert captured["language"] == "en"
+
+
+def test_transcribe_retries_on_rate_limit(monkeypatch):
+    attempts = []
+
+    def fake_transcribe(**kwargs):
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise _FakeRateLimitError("429")
+        return {"text": "done"}
+
+    _setup_openai(monkeypatch, fake_transcribe)
+    monkeypatch.setattr(voice_service.time, "sleep", lambda _: None)
+    result = transcribe(b"voice", "audio/mp3", "ru")
+    assert result == "done"
+    assert len(attempts) == 2
+
+
+def test_transcribe_retries_on_server_error(monkeypatch):
+    attempts = []
+
+    def fake_transcribe(**kwargs):
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise _FakeAPIError(500)
+        return {"text": "ok"}
+
+    _setup_openai(monkeypatch, fake_transcribe)
+    monkeypatch.setattr(voice_service.time, "sleep", lambda _: None)
+    result = transcribe(b"voice", "audio/mp3", "ru")
+    assert result == "ok"
+    assert len(attempts) == 2
+
+
+@pytest.fixture
+def bot_module(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "test-token")
+    monkeypatch.setenv("SUNO_API_BASE", "https://example.com")
+    monkeypatch.setenv("SUNO_API_TOKEN", "dummy-token")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    module = importlib.import_module("bot")
+    module = importlib.reload(module)
+    return module
+
+
+def test_handle_voice_success(monkeypatch, bot_module):
+    edits: list[str] = []
+    sends: list[str] = []
+    downloads: list[str] = []
+    ffmpeg_calls: list[list[str]] = []
+    transcribe_args: list[tuple[bytes, str, str]] = []
+
+    async def fake_ensure_user_record(update):
+        return None
+
+    async def fake_safe_send_placeholder(bot, chat_id, text):
+        edits.append(text)
+        return SimpleNamespace(message_id=42)
+
+    async def fake_safe_edit(bot, chat_id, message_id, text):
+        edits.append(text)
+
+    async def fake_safe_send_text(bot, chat_id, text):
+        sends.append(text)
+
+    async def fake_run_ffmpeg(data, args):
+        ffmpeg_calls.append(args)
+        return b"converted"
+
+    async def fake_download(url):
+        downloads.append(url)
+        return b"voice-bytes"
+
+    def fake_voice_transcribe(audio_bytes, mime, lang):
+        transcribe_args.append((audio_bytes, mime or "", lang or ""))
+        return "а" * 3100
+
+    dummy_history: list[dict[str, str]] = []
+
+    monkeypatch.setattr(bot_module, "ensure_user_record", fake_ensure_user_record)
+    monkeypatch.setattr(bot_module, "safe_send_placeholder", fake_safe_send_placeholder)
+    monkeypatch.setattr(bot_module, "safe_edit_markdown_v2", fake_safe_edit)
+    monkeypatch.setattr(bot_module, "safe_send_text", fake_safe_send_text)
+    monkeypatch.setattr(bot_module, "run_ffmpeg", fake_run_ffmpeg)
+    monkeypatch.setattr(bot_module, "_download_telegram_file", fake_download)
+    monkeypatch.setattr(bot_module, "voice_transcribe", fake_voice_transcribe)
+    monkeypatch.setattr(bot_module, "rate_limit_hit", lambda user_id: False)
+    monkeypatch.setattr(bot_module, "is_mode_on", lambda user_id: True)
+    monkeypatch.setattr(bot_module, "_mode_get", lambda chat_id: bot_module.MODE_CHAT)
+    monkeypatch.setattr(bot_module, "load_ctx", lambda user_id: list(dummy_history))
+    monkeypatch.setattr(bot_module, "estimate_tokens", lambda text: len(text) // 4 or 1)
+    monkeypatch.setattr(bot_module, "append_ctx", lambda user_id, role, content: dummy_history.append({"role": role, "content": content}))
+    monkeypatch.setattr(bot_module, "build_messages", lambda sys_prompt, history, text, lang: ["sys", text])
+    monkeypatch.setattr(bot_module, "call_llm", lambda messages: "Ответ")
+
+    chat_context_tokens_mock = MagicMock()
+    monkeypatch.setattr(bot_module, "chat_context_tokens", chat_context_tokens_mock)
+
+    chat_messages_total_mock = MagicMock()
+    chat_messages_handle = MagicMock()
+    chat_messages_total_mock.labels.return_value = chat_messages_handle
+    monkeypatch.setattr(bot_module, "chat_messages_total", chat_messages_total_mock)
+
+    chat_latency_ms_mock = MagicMock()
+    monkeypatch.setattr(bot_module, "chat_latency_ms", chat_latency_ms_mock)
+
+    chat_voice_total_mock = MagicMock()
+    chat_voice_total_handle = MagicMock()
+    chat_voice_total_mock.labels.return_value = chat_voice_total_handle
+    monkeypatch.setattr(bot_module, "chat_voice_total", chat_voice_total_mock)
+
+    chat_voice_latency_mock = MagicMock()
+    chat_voice_latency_handle = MagicMock()
+    chat_voice_latency_mock.labels.return_value = chat_voice_latency_handle
+    monkeypatch.setattr(bot_module, "chat_voice_latency_ms", chat_voice_latency_mock)
+
+    chat_transcribe_latency_mock = MagicMock()
+    chat_transcribe_latency_handle = MagicMock()
+    chat_transcribe_latency_mock.labels.return_value = chat_transcribe_latency_handle
+    monkeypatch.setattr(bot_module, "chat_transcribe_latency_ms", chat_transcribe_latency_mock)
+
+    bot_logger = MagicMock()
+
+    class DummyBot:
+        async def send_chat_action(self, chat_id, action):
+            return None
+
+        async def get_file(self, file_id):
+            return SimpleNamespace(file_path="voice.oga", mime_type="audio/ogg")
+
+    ctx = SimpleNamespace(
+        bot=DummyBot(),
+        application=SimpleNamespace(logger=bot_logger),
+    )
+
+    update = SimpleNamespace(
+        message=SimpleNamespace(
+            chat_id=100,
+            voice=SimpleNamespace(file_id="file1", file_size=10_000, duration=30, mime_type="audio/ogg"),
+            audio=None,
+            caption=None,
+        ),
+        effective_user=SimpleNamespace(id=55, language_code="ru", first_name="Имя", last_name=None),
+        effective_chat=SimpleNamespace(id=100),
+    )
+
+    asyncio.run(bot_module.handle_voice(update, ctx))
+
+    assert downloads == [bot_module.tg_direct_file_url("test-token", "voice.oga")]
+    assert ffmpeg_calls == [["-i", "pipe:0", "-ac", "1", "-ar", "16000", "-f", "wav", "pipe:1"]]
+    assert transcribe_args == [(b"converted", "audio/wav", "ru")]
+    assert "Думаю над ответом…" in edits[1]
+    assert "…\\." in edits[1]
+    assert edits[-1] == bot_module.md2_escape("Ответ")
+    chat_voice_total_mock.labels.assert_any_call(outcome="ok", **bot_module._VOICE_METRIC_LABELS)
+    chat_voice_total_handle.inc.assert_called()
+    chat_voice_latency_mock.labels.assert_any_call(**bot_module._VOICE_METRIC_LABELS)
+    chat_voice_latency_handle.observe.assert_called()
+    chat_transcribe_latency_mock.labels.assert_any_call(**bot_module._VOICE_METRIC_LABELS)
+    chat_transcribe_latency_handle.observe.assert_called()
+    assert sends == []
+
+
+def test_handle_voice_transcribe_error(monkeypatch, bot_module):
+    edits: list[str] = []
+
+    async def fake_ensure_user_record(update):
+        return None
+
+    async def fake_safe_send_placeholder(bot, chat_id, text):
+        return SimpleNamespace(message_id=99)
+
+    async def fake_safe_edit(bot, chat_id, message_id, text):
+        edits.append(text)
+
+    async def fake_run_ffmpeg(data, args):
+        return b"converted"
+
+    async def fake_download(url):
+        return b"voice"
+
+    def fake_voice_transcribe(audio_bytes, mime, lang):
+        raise VoiceTranscribeError("boom")
+
+    monkeypatch.setattr(bot_module, "ensure_user_record", fake_ensure_user_record)
+    monkeypatch.setattr(bot_module, "safe_send_placeholder", fake_safe_send_placeholder)
+    monkeypatch.setattr(bot_module, "safe_edit_markdown_v2", fake_safe_edit)
+    monkeypatch.setattr(bot_module, "safe_send_text", MagicMock())
+    monkeypatch.setattr(bot_module, "run_ffmpeg", fake_run_ffmpeg)
+    monkeypatch.setattr(bot_module, "_download_telegram_file", fake_download)
+    monkeypatch.setattr(bot_module, "voice_transcribe", fake_voice_transcribe)
+
+    chat_voice_total_mock = MagicMock()
+    chat_voice_total_handle = MagicMock()
+    chat_voice_total_mock.labels.return_value = chat_voice_total_handle
+    monkeypatch.setattr(bot_module, "chat_voice_total", chat_voice_total_mock)
+
+    chat_voice_latency_mock = MagicMock()
+    chat_voice_latency_handle = MagicMock()
+    chat_voice_latency_mock.labels.return_value = chat_voice_latency_handle
+    monkeypatch.setattr(bot_module, "chat_voice_latency_ms", chat_voice_latency_mock)
+
+    chat_transcribe_latency_mock = MagicMock()
+    chat_transcribe_latency_handle = MagicMock()
+    chat_transcribe_latency_mock.labels.return_value = chat_transcribe_latency_handle
+    monkeypatch.setattr(bot_module, "chat_transcribe_latency_ms", chat_transcribe_latency_mock)
+
+    class DummyBot:
+        async def send_chat_action(self, chat_id, action):
+            return None
+
+        async def get_file(self, file_id):
+            return SimpleNamespace(file_path="voice.oga", mime_type="audio/ogg")
+
+    ctx = SimpleNamespace(
+        bot=DummyBot(),
+        application=SimpleNamespace(logger=MagicMock()),
+    )
+
+    update = SimpleNamespace(
+        message=SimpleNamespace(
+            chat_id=200,
+            voice=SimpleNamespace(file_id="file1", file_size=5000, duration=60, mime_type="audio/ogg"),
+            audio=None,
+            caption=None,
+        ),
+        effective_user=SimpleNamespace(id=12, language_code="en", first_name="User", last_name=None),
+        effective_chat=SimpleNamespace(id=200),
+    )
+
+    asyncio.run(bot_module.handle_voice(update, ctx))
+
+    assert edits[0] == bot_module.md2_escape(bot_module.VOICE_TRANSCRIBE_ERROR_TEXT)
+    chat_voice_total_mock.labels.assert_any_call(outcome="error", **bot_module._VOICE_METRIC_LABELS)
+    chat_voice_total_handle.inc.assert_called()
+    chat_voice_latency_mock.labels.assert_any_call(**bot_module._VOICE_METRIC_LABELS)
+    chat_voice_latency_handle.observe.assert_called()
+    chat_transcribe_latency_mock.labels.assert_any_call(**bot_module._VOICE_METRIC_LABELS)
+    chat_transcribe_latency_handle.observe.assert_called()

--- a/voice_service.py
+++ b/voice_service.py
@@ -1,0 +1,124 @@
+"""Voice transcription service backed by OpenAI Whisper."""
+from __future__ import annotations
+
+import io
+import logging
+import os
+import random
+import time
+from typing import Optional
+
+try:  # pragma: no cover - optional runtime dependency
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - library might be unavailable
+    openai = None  # type: ignore
+
+log = logging.getLogger("voice.service")
+
+_OPENAI_TIMEOUT = 30
+_MAX_ATTEMPTS = 3
+_RETRY_CODES = {429}
+_MODEL_NAME = os.getenv("VOICE_MODEL", "whisper-1")
+
+
+class VoiceTranscribeError(Exception):
+    """Raised when audio transcription fails."""
+
+
+def _filename_from_mime(mime: Optional[str]) -> str:
+    if not mime:
+        return "audio.wav"
+    if "wav" in mime:
+        return "audio.wav"
+    if "mpeg" in mime:
+        return "audio.mp3"
+    if "ogg" in mime or "opus" in mime:
+        return "audio.ogg"
+    if "m4a" in mime or "mp4" in mime:
+        return "audio.m4a"
+    if "webm" in mime:
+        return "audio.webm"
+    return "audio.bin"
+
+
+def _should_retry(exc: Exception) -> bool:
+    if openai is None:  # pragma: no cover - defensive
+        return False
+    from openai.error import APIError, RateLimitError, ServiceUnavailableError  # type: ignore
+
+    if isinstance(exc, RateLimitError):
+        return True
+    if isinstance(exc, ServiceUnavailableError):
+        return True
+    if isinstance(exc, APIError):
+        status = getattr(exc, "http_status", None)
+        if status is None:
+            return False
+        return int(status) >= 500 or int(status) in _RETRY_CODES
+    status = getattr(exc, "http_status", None)
+    if isinstance(status, int) and (status in _RETRY_CODES or status >= 500):
+        return True
+    return False
+
+
+def transcribe(audio_bytes: bytes, mime: Optional[str], lang_hint: Optional[str]) -> str:
+    """Return a transcript for *audio_bytes* using Whisper."""
+
+    if openai is None or not getattr(openai, "api_key", None):
+        raise VoiceTranscribeError("OpenAI client is not configured")
+
+    filename = _filename_from_mime(mime)
+    attempt = 0
+    last_exc: Optional[Exception] = None
+    while attempt < _MAX_ATTEMPTS:
+        attempt += 1
+        try:
+            payload = io.BytesIO(audio_bytes)
+            payload.name = filename  # type: ignore[attr-defined]
+            started = time.time()
+            response = openai.Audio.transcribe(  # type: ignore[union-attr]
+                model=_MODEL_NAME,
+                file=payload,
+                language=lang_hint,
+                timeout=_OPENAI_TIMEOUT,
+            )
+            elapsed = time.time() - started
+            log.info(
+                "voice.transcribe.success",
+                extra={
+                    "meta": {
+                        "attempt": attempt,
+                        "elapsed_ms": int(elapsed * 1000),
+                        "lang": lang_hint,
+                    }
+                },
+            )
+            if isinstance(response, dict):
+                text = str(response.get("text", ""))
+            else:
+                text = str(getattr(response, "text", ""))
+            cleaned = text.strip()
+            if not cleaned:
+                raise VoiceTranscribeError("Empty transcription result")
+            return cleaned
+        except Exception as exc:  # pragma: no cover - flow split below
+            last_exc = exc
+            should_retry = attempt < _MAX_ATTEMPTS and _should_retry(exc)
+            log.warning(
+                "voice.transcribe.error",
+                extra={
+                    "meta": {
+                        "attempt": attempt,
+                        "will_retry": should_retry,
+                        "error_type": type(exc).__name__,
+                    }
+                },
+            )
+            if not should_retry:
+                break
+            delay = random.uniform(1.0, 2.5)
+            time.sleep(delay)
+    raise VoiceTranscribeError(str(last_exc) if last_exc else "Transcription failed")
+
+
+__all__ = ["transcribe", "VoiceTranscribeError"]


### PR DESCRIPTION
## Summary
- handle Telegram voice and audio messages by downloading, converting when needed, transcribing with Whisper, and routing results through the chat pipeline with proper placeholders and Markdown escaping
- record voice-specific telemetry and extend Telegram helpers with reusable placeholder sending and ffmpeg execution utilities
- add a dedicated voice transcription service module plus tests that cover retry scenarios, trimming, and full handler flows

## Testing
- pytest tests/test_voice_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d6f621418083229aaec15d9877e25d