### PR TITLE
Implement automatic chat fallback routing

### DIFF
--- a/chat_mode.py
+++ b/chat_mode.py
@@ -1,0 +1,27 @@
+"""Helpers for managing the chat mode flag in Redis."""
+
+from __future__ import annotations
+
+from chat_service import is_mode_on as _is_mode_on
+from chat_service import set_mode as _set_mode
+
+
+def turn_on(user_id: int) -> None:
+    """Mark the conversational chat mode as enabled for the user."""
+
+    _set_mode(user_id, True)
+
+
+def is_on(user_id: int) -> bool:
+    """Return whether conversational chat mode is enabled for the user."""
+
+    return _is_mode_on(user_id)
+
+
+def turn_off(user_id: int) -> None:
+    """Disable conversational chat mode for the user."""
+
+    _set_mode(user_id, False)
+
+
+__all__ = ["turn_on", "turn_off", "is_on"]

--- a/metrics.py
+++ b/metrics.py
@@ -84,6 +84,19 @@ chat_context_tokens = Gauge(
     registry=REGISTRY,
 )
 
+chat_autoswitch_total = Counter(
+    "chat_autoswitch_total",
+    "Automatic chat mode routing events grouped by outcome",
+    labelnames=("outcome",),
+    registry=REGISTRY,
+)
+
+chat_first_hint_total = Counter(
+    "chat_first_hint_total",
+    "Total hint messages shown for automatic chat activation",
+    registry=REGISTRY,
+)
+
 chat_voice_total = Counter(
     "chat_voice_total",
     "Voice messages processed in chat",
@@ -197,6 +210,8 @@ __all__: Iterable[str] = [
     "chat_messages_total",
     "chat_latency_ms",
     "chat_context_tokens",
+    "chat_autoswitch_total",
+    "chat_first_hint_total",
     "chat_voice_total",
     "chat_voice_latency_ms",
     "chat_transcribe_latency_ms",


### PR DESCRIPTION
## Summary
- add chat mode helpers and Prometheus counters for automatic chat activation
- auto-enable the conversational chat mode on free-form text with hint, placeholder, and suggestion keyboard
- expose callback handlers to route the new suggestion buttons to existing flows

## Testing
- pytest *(fails: SUNO_API_TOKEN is not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ffb3cc6083228fc3fd61440eb07b