### PR TITLE
Fix handler blocking config for Prompt-Master

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -8775,8 +8775,11 @@ async def run_bot_async() -> None:
     application.add_handler(MessageHandler(filters.PHOTO, on_photo))
     application.add_handler(MessageHandler(filters.VOICE | filters.AUDIO, handle_voice))
     application.add_handler(
-        MessageHandler(filters.TEXT & ~filters.COMMAND, prompt_master_input),
-        block=False,
+        MessageHandler(
+            filters.TEXT & ~filters.COMMAND,
+            prompt_master_input,
+            block=False,
+        )
     )
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, on_text))
     application.add_error_handler(error_handler)

--- a/handlers/prompt_master_handler.py
+++ b/handlers/prompt_master_handler.py
@@ -236,20 +236,45 @@ async def prompt_master_cancel(update: Update, context: ContextTypes.DEFAULT_TYP
 
 prompt_master_conv = ConversationHandler(
     entry_points=[
-        CallbackQueryHandler(prompt_master_open, pattern=fr"^{PROMPT_MASTER_OPEN}$"),
+        CallbackQueryHandler(
+            prompt_master_open,
+            pattern=fr"^{PROMPT_MASTER_OPEN}$",
+            block=True,
+            per_message=True,
+        ),
     ],
     states={
         _PM_STATE: [
-            MessageHandler(filters.TEXT & ~filters.COMMAND, prompt_master_generate),
-            CallbackQueryHandler(prompt_master_reapply, pattern=fr"^{PROMPT_MASTER_OPEN}$"),
-            CallbackQueryHandler(prompt_master_cancel, pattern=fr"^{PROMPT_MASTER_CANCEL}$"),
+            MessageHandler(
+                filters.TEXT & ~filters.COMMAND,
+                prompt_master_generate,
+                block=True,
+            ),
+            CallbackQueryHandler(
+                prompt_master_reapply,
+                pattern=fr"^{PROMPT_MASTER_OPEN}$",
+                block=True,
+                per_message=True,
+            ),
+            CallbackQueryHandler(
+                prompt_master_cancel,
+                pattern=fr"^{PROMPT_MASTER_CANCEL}$",
+                block=True,
+                per_message=True,
+            ),
         ]
     },
     fallbacks=[
-        CommandHandler("cancel", prompt_master_cancel),
-        CallbackQueryHandler(prompt_master_cancel, pattern=fr"^{PROMPT_MASTER_CANCEL}$"),
+        CommandHandler("cancel", prompt_master_cancel, block=True),
+        CallbackQueryHandler(
+            prompt_master_cancel,
+            pattern=fr"^{PROMPT_MASTER_CANCEL}$",
+            block=True,
+            per_message=True,
+        ),
     ],
     name="prompt_master",
+    block=True,
 )
 
 

--- a/prompt_master.py
+++ b/prompt_master.py
@@ -192,7 +192,7 @@ SECTION_LABELS = {
 
 
 def _clean_value(value: str) -> str:
-    return value.replace("```", "``\`").strip()
+    return value.replace("```", "``\\`").strip()
 
 
 def _fallback_sections(raw_text: str, lang: str) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- move the block flag from application.add_handler calls to the Prompt-Master handlers themselves
- add per_message=True to Prompt-Master callback query handlers to silence PTB warnings
- fix the triple-backtick replacement string to avoid invalid escape sequence warnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7b21f7fb48322a6068342336fed4d