### PR TITLE
Fix Prompt-Master handler compatibility with PTB 21.6

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -8778,7 +8778,6 @@ async def run_bot_async() -> None:
         MessageHandler(
             filters.TEXT & ~filters.COMMAND,
             prompt_master_input,
-            block=False,
         )
     )
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, on_text))

--- a/handlers/prompt_master_handler.py
+++ b/handlers/prompt_master_handler.py
@@ -6,6 +6,7 @@ import asyncio
 import html
 import logging
 import os
+import warnings
 from contextlib import suppress
 from typing import Awaitable, Callable, Optional
 
@@ -18,6 +19,13 @@ from telegram.ext import (
     ContextTypes,
     MessageHandler,
     filters,
+)
+from telegram.warnings import PTBUserWarning
+
+warnings.filterwarnings(
+    "ignore",
+    message="If 'per_message=False', 'CallbackQueryHandler' will not be tracked for every message.*",
+    category=PTBUserWarning,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -240,7 +248,6 @@ prompt_master_conv = ConversationHandler(
             prompt_master_open,
             pattern=fr"^{PROMPT_MASTER_OPEN}$",
             block=True,
-            per_message=True,
         ),
     ],
     states={
@@ -254,13 +261,11 @@ prompt_master_conv = ConversationHandler(
                 prompt_master_reapply,
                 pattern=fr"^{PROMPT_MASTER_OPEN}$",
                 block=True,
-                per_message=True,
             ),
             CallbackQueryHandler(
                 prompt_master_cancel,
                 pattern=fr"^{PROMPT_MASTER_CANCEL}$",
                 block=True,
-                per_message=True,
             ),
         ]
     },
@@ -270,7 +275,6 @@ prompt_master_conv = ConversationHandler(
             prompt_master_cancel,
             pattern=fr"^{PROMPT_MASTER_CANCEL}$",
             block=True,
-            per_message=True,
         ),
     ],
     name="prompt_master",


### PR DESCRIPTION
## Summary
- stop passing the unsupported `block` argument when wiring the Prompt-Master text handler into the application
- remove the obsolete `per_message` flags from Prompt-Master callback handlers to align with python-telegram-bot 21.6
- silence the noisy `PTBUserWarning` so Prompt-Master can start without extra warnings in the logs

## Testing
- SUNO_API_TOKEN=dummy pytest *(fails: existing Suno callback tests expect secret enforcement; voice-service test looks for unavailable helper)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b5cbaa148322863bef1bf3a2cf6f