### PR TITLE
Fix prompt command registration and safe send fallback

### DIFF
--- a/handlers/prompt_master_handler.py
+++ b/handlers/prompt_master_handler.py
@@ -6,7 +6,6 @@ import asyncio
 import html
 import logging
 import os
-import warnings
 from contextlib import suppress
 from typing import Awaitable, Callable, Optional
 
@@ -20,14 +19,6 @@ from telegram.ext import (
     MessageHandler,
     filters,
 )
-from telegram.warnings import PTBUserWarning
-
-warnings.filterwarnings(
-    "ignore",
-    message="If 'per_message=False', 'CallbackQueryHandler' will not be tracked for every message.*",
-    category=PTBUserWarning,
-)
-
 LOGGER = logging.getLogger(__name__)
 
 PROMPT_MASTER_OPEN = "PROMPT_MASTER_OPEN"
@@ -247,7 +238,7 @@ prompt_master_conv = ConversationHandler(
         CallbackQueryHandler(
             prompt_master_open,
             pattern=fr"^{PROMPT_MASTER_OPEN}$",
-            block=True,
+            per_message=False,
         ),
     ],
     states={
@@ -255,30 +246,28 @@ prompt_master_conv = ConversationHandler(
             MessageHandler(
                 filters.TEXT & ~filters.COMMAND,
                 prompt_master_generate,
-                block=True,
             ),
             CallbackQueryHandler(
                 prompt_master_reapply,
                 pattern=fr"^{PROMPT_MASTER_OPEN}$",
-                block=True,
+                per_message=False,
             ),
             CallbackQueryHandler(
                 prompt_master_cancel,
                 pattern=fr"^{PROMPT_MASTER_CANCEL}$",
-                block=True,
+                per_message=False,
             ),
         ]
     },
     fallbacks=[
-        CommandHandler("cancel", prompt_master_cancel, block=True),
+        CommandHandler("cancel", prompt_master_cancel),
         CallbackQueryHandler(
             prompt_master_cancel,
             pattern=fr"^{PROMPT_MASTER_CANCEL}$",
-            block=True,
+            per_message=False,
         ),
     ],
     name="prompt_master",
-    block=True,
 )
 
 

--- a/telegram_utils.py
+++ b/telegram_utils.py
@@ -351,8 +351,17 @@ async def safe_edit_markdown_v2(
             reply_markup=reply_markup,
         )
     except BadRequest as exc:
+        err_text = str(exc)
         if _is_message_not_modified(exc):
             return None
+        if "can't" in err_text.lower() and "edit" in err_text.lower():
+            return await bot.send_message(
+                chat_id=chat_id,
+                text=text,
+                parse_mode=ParseMode.MARKDOWN_V2,
+                disable_web_page_preview=True,
+                reply_markup=reply_markup,
+            )
         raise
 
 


### PR DESCRIPTION
## Summary
- make menu safe_send and safe_edit fall back to sending a new message when Telegram disallows edits
- clean up Prompt-Master conversation handlers to remove unsupported arguments and ensure callback queries use per_message=False
- register Prompt-Master slash command aliases so `/prompt` and `/prompt-master` mirror the menu buttons

## Testing
- pytest *(fails: SUNO_API_TOKEN is not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b9d8ae90832292663c6d298204bb