### PR TITLE
Fix Prompt-Master handler configuration for PTB 21 compatibility

### DIFF
--- a/handlers/prompt_master_handler.py
+++ b/handlers/prompt_master_handler.py
@@ -238,7 +238,6 @@ prompt_master_conv = ConversationHandler(
         CallbackQueryHandler(
             prompt_master_open,
             pattern=fr"^{PROMPT_MASTER_OPEN}$",
-            per_message=False,
         ),
     ],
     states={
@@ -250,12 +249,10 @@ prompt_master_conv = ConversationHandler(
             CallbackQueryHandler(
                 prompt_master_reapply,
                 pattern=fr"^{PROMPT_MASTER_OPEN}$",
-                per_message=False,
             ),
             CallbackQueryHandler(
                 prompt_master_cancel,
                 pattern=fr"^{PROMPT_MASTER_CANCEL}$",
-                per_message=False,
             ),
         ]
     },
@@ -264,10 +261,11 @@ prompt_master_conv = ConversationHandler(
         CallbackQueryHandler(
             prompt_master_cancel,
             pattern=fr"^{PROMPT_MASTER_CANCEL}$",
-            per_message=False,
         ),
     ],
     name="prompt_master",
+    per_chat=True,
+    per_user=True,
 )
 
 

--- a/tests/test_prompt_master_ptb.py
+++ b/tests/test_prompt_master_ptb.py
@@ -1,0 +1,32 @@
+"""Smoke tests for Prompt-Master PTB handlers."""
+
+import sys
+from pathlib import Path
+
+from telegram.ext import AIORateLimiter, ApplicationBuilder
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from handlers import prompt_master_conv
+
+
+def test_prompt_master_conversation_flags() -> None:
+    """Conversation should enforce per-chat flow without per-message duplication."""
+
+    assert prompt_master_conv.per_chat is True
+    assert prompt_master_conv.per_user is True
+    assert prompt_master_conv.per_message is False
+
+
+def test_prompt_master_conversation_registration() -> None:
+    """Conversation handler should be compatible with PTB 21 application builder."""
+
+    application = (
+        ApplicationBuilder()
+        .token("123:ABC")
+        .rate_limiter(AIORateLimiter())
+        .build()
+    )
+    application.add_handler(prompt_master_conv)


### PR DESCRIPTION
## Summary
- remove legacy per_message flags from Prompt-Master callback handlers and scope the conversation to chat/user on PTB 21
- add a smoke test ensuring the conversation flags remain correct and the handler registers with an Application

## Testing
- pytest tests/test_prompt_master_ptb.py

------
https://chatgpt.com/codex/tasks/task_e_68d7bfdffe8c8322b07d74128f9930c5