### PR TITLE
Fix handler ordering and Prompt-Master flow for PTB 21.6

### DIFF
--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -4,7 +4,8 @@ from .prompt_master_handler import (  # noqa: F401
     PM_MJ,
     PM_SUNO,
     PM_VIDEO,
-    PM_WAITING,
+    PM_SELECT,
+    PM_WAIT_IDEA,
     PROMPT_MASTER_BACK,
     PROMPT_MASTER_OPEN,
     configure_prompt_master,
@@ -22,6 +23,7 @@ __all__ = [
     "PM_BANANA",
     "PM_MJ",
     "PM_SUNO",
-    "PM_WAITING",
+    "PM_SELECT",
+    "PM_WAIT_IDEA",
     "prompt_master_start",
 ]

--- a/tests/test_handler_registration.py
+++ b/tests/test_handler_registration.py
@@ -1,0 +1,75 @@
+"""Tests for Telegram handler registration and reply button wiring."""
+
+import os
+import sys
+from typing import Dict
+
+from telegram.ext import AIORateLimiter, ApplicationBuilder, CommandHandler
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+os.environ.setdefault("SUNO_API_TOKEN", "test-token")
+os.environ.setdefault("LEDGER_BACKEND", "memory")
+
+from bot import (  # noqa: E402
+    MENU_BTN_BALANCE,
+    MENU_BTN_CHAT,
+    MENU_BTN_IMAGE,
+    MENU_BTN_SUNO,
+    MENU_BTN_VIDEO,
+    REPLY_BUTTON_ROUTES,
+    handle_balance_entry,
+    handle_chat_entry,
+    handle_image_entry,
+    handle_music_entry,
+    handle_video_entry,
+    register_handlers,
+)
+from handlers import prompt_master_conv  # noqa: E402
+
+
+def _build_application():
+    return (
+        ApplicationBuilder().token("123:ABC").rate_limiter(AIORateLimiter()).build()
+    )
+
+
+def test_chat_and_prompt_master_handlers_registered() -> None:
+    """/chat command and Prompt-Master conversation must be registered."""
+
+    application = _build_application()
+    register_handlers(application)
+
+    commands: set[str] = set()
+    conversation_present = False
+
+    for handler in application.handlers[0]:
+        if isinstance(handler, CommandHandler):
+            commands.update(handler.commands)
+        if handler is prompt_master_conv:
+            conversation_present = True
+
+    assert "chat" in commands
+    assert conversation_present
+
+    entry_commands: set[str] = set()
+    for entry in prompt_master_conv.entry_points:
+        if isinstance(entry, CommandHandler):
+            entry_commands.update(entry.commands)
+
+    assert "prompt_master" in entry_commands
+
+
+def test_reply_button_routes_match_expected() -> None:
+    """Large reply buttons should be wired to the correct handlers."""
+
+    mapping: Dict[str, object] = dict(REPLY_BUTTON_ROUTES)
+    assert mapping == {
+        MENU_BTN_VIDEO: handle_video_entry,
+        MENU_BTN_IMAGE: handle_image_entry,
+        MENU_BTN_SUNO: handle_music_entry,
+        MENU_BTN_CHAT: handle_chat_entry,
+        MENU_BTN_BALANCE: handle_balance_entry,
+    }

--- a/tests/test_prompt_master_ptb.py
+++ b/tests/test_prompt_master_ptb.py
@@ -9,15 +9,22 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from handlers import prompt_master_conv
+from handlers import (
+    PM_SELECT,
+    PM_WAIT_IDEA,
+    PROMPT_MASTER_BACK,
+    PROMPT_MASTER_OPEN,
+    prompt_master_conv,
+)
 
 
 def test_prompt_master_conversation_flags() -> None:
-    """Conversation should enforce per-chat flow without per-message duplication."""
+    """Conversation should expose expected states and settings."""
 
-    assert prompt_master_conv.per_chat is True
-    assert prompt_master_conv.per_user is True
-    assert prompt_master_conv.per_message is False
+    assert prompt_master_conv.allow_reentry is True
+    assert prompt_master_conv.conversation_timeout == 600
+    assert PM_SELECT in prompt_master_conv.states
+    assert PM_WAIT_IDEA in prompt_master_conv.states
 
 
 def test_prompt_master_conversation_registration() -> None:
@@ -30,3 +37,15 @@ def test_prompt_master_conversation_registration() -> None:
         .build()
     )
     application.add_handler(prompt_master_conv)
+
+    patterns = []
+    for handler in prompt_master_conv.states[PM_SELECT]:
+        pattern = getattr(handler, "pattern", None)
+        if pattern is None:
+            continue
+        if hasattr(pattern, "pattern"):
+            patterns.append(pattern.pattern)
+        else:
+            patterns.append(str(pattern))
+    assert any(pattern == f"^{PROMPT_MASTER_OPEN}$" for pattern in patterns)
+    assert any(pattern == f"^{PROMPT_MASTER_BACK}$" for pattern in patterns)


### PR DESCRIPTION
## Summary
- replace legacy handler registration with `register_handlers` that wires commands, callback queries, and reply buttons in the PTB 21.6-compatible order
- refresh the Prompt-Master conversation to use explicit states, new callback patterns, and menu screen without deprecated per_* flags
- add regression tests covering command/keyboard registration and Prompt-Master conversation configuration

## Testing
- `pytest tests/test_handler_registration.py tests/test_prompt_master_ptb.py`

------
https://chatgpt.com/codex/tasks/task_e_68d7c8ae42e483228b59469d8c272586