### PR TITLE
Add structured Prompt-Master generator and status UX improvements

### DIFF
--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -2,8 +2,6 @@
 
 from .faq_handler import configure_faq, faq_callback, faq_command
 from .prompt_master_handler import (
-    PromptOut,
-    build_prompt,
     clear_pm_prompts,
     get_pm_prompt,
     prompt_master_callback,
@@ -14,8 +12,6 @@ from .prompt_master_handler import (
 )
 
 __all__ = [
-    "PromptOut",
-    "build_prompt",
     "clear_pm_prompts",
     "configure_faq",
     "faq_callback",

--- a/keyboards.py
+++ b/keyboards.py
@@ -57,12 +57,14 @@ def prompt_master_result_keyboard(engine: str, lang: str = "ru") -> InlineKeyboa
         if lang == "ru"
         else f"⬇️ Insert into {display} card"
     )
-    rows = [
+    base_rows = prompt_master_mode_keyboard(lang).inline_keyboard
+    rows = [list(row) for row in base_rows]
+    rows.append(
         [
             InlineKeyboardButton(copy_text, callback_data=f"{CB_PM_PREFIX}copy:{engine}"),
             InlineKeyboardButton(insert_text, callback_data=f"{CB_PM_PREFIX}insert:{engine}"),
         ]
-    ]
+    )
     return InlineKeyboardMarkup(rows)
 
 

--- a/prompt_master/__init__.py
+++ b/prompt_master/__init__.py
@@ -1,0 +1,5 @@
+"""Prompt-Master package exports."""
+
+from .generator import Engine, PromptPayload, build_prompt
+
+__all__ = ["Engine", "PromptPayload", "build_prompt"]

--- a/prompt_master/generator.py
+++ b/prompt_master/generator.py
@@ -1,0 +1,356 @@
+"""Prompt-Master prompt generator for multiple engines."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List
+
+
+class Engine(str, Enum):
+    """Supported Prompt-Master engines."""
+
+    VEO_VIDEO = "veo"
+    MJ = "mj"
+    BANANA_EDIT = "banana"
+    VEO_ANIMATE = "animate"
+    SUNO = "suno"
+
+
+@dataclass
+class PromptPayload:
+    """Structured payload returned by the prompt builder."""
+
+    title: str
+    body_markdown: str
+    insert_payload: Dict[str, Any]
+    copy_text: str
+
+
+_FACE_SAFETY = {
+    "ru": "Сохраняем черты лица без искажений; аккуратная ретушь, без замены лица/стиля лица.",
+    "en": "Preserve the person’s facial features without distortion; gentle retouch, no face swap/style change.",
+}
+
+_FACE_SWAP_BAN = {
+    "ru": "Запрещено подменять или заменять лицо.",
+    "en": "Face replacement or swapping is strictly forbidden.",
+}
+
+_TITLES = {
+    Engine.VEO_VIDEO: {"ru": "Готовый промпт для VEO", "en": "Ready prompt for VEO"},
+    Engine.MJ: {"ru": "Готовый промпт для Midjourney", "en": "Ready prompt for Midjourney"},
+    Engine.BANANA_EDIT: {"ru": "Чек-лист для Banana", "en": "Banana edit checklist"},
+    Engine.VEO_ANIMATE: {"ru": "Чек-лист для “Оживить фото”", "en": "Checklist for “Animate photo”"},
+    Engine.SUNO: {"ru": "Каркас запроса для Suno", "en": "Prompt scaffold for Suno"},
+}
+
+_MJ_RENDER = "--ar 16:9 --v 6"
+
+_SUNO_DEFAULT_GENRE = {
+    "ru": "Кинематографичный электропоп",
+    "en": "Cinematic electro-pop",
+}
+
+_SUNO_DEFAULT_MOOD = {
+    "ru": "вдохновляющее",
+    "en": "uplifting",
+}
+
+_SUNO_DEFAULT_INSTRUMENTS = {
+    "ru": "синтезаторы, атмосферные пад-пэды, легкие ударные",
+    "en": "synths, airy pads, light percussion",
+}
+
+_SUNO_REFERENCES = {
+    "ru": "По настроению — Imogen Heap, Woodkid.",
+    "en": "Reference vibe: Imogen Heap, Woodkid.",
+}
+
+
+def _normalize_text(value: str) -> str:
+    return " ".join((value or "").strip().split())
+
+
+def _short_scene(text: str, *, width: int = 180) -> str:
+    cleaned = _normalize_text(text)
+    if not cleaned:
+        return ""
+    return textwrap.shorten(cleaned, width=width, placeholder="…")
+
+
+def _veo_payload(user_text: str, lang: str) -> PromptPayload:
+    scene = _short_scene(user_text)
+    camera = "Steadicam dolly out" if lang == "en" else "Стефикам с плавным выездом"
+    motion = (
+        "Dynamic storytelling, 8 seconds, no abrupt motions"
+        if lang == "en"
+        else "Динамичный сторителлинг, 8 секунд, без резких рывков"
+    )
+    lighting = (
+        "Soft diffused lighting with highlighted subject"
+        if lang == "en"
+        else "Мягкий рассеянный свет с акцентом"
+    )
+    palette = (
+        "Cinematic color grading with deep shadows"
+        if lang == "en"
+        else "Кинематографичная цветокоррекция с глубокими тенями"
+    )
+    details = (
+        "Clarify characters, setting, and the main focal moment. Close with an expressive beat."
+        if lang == "en"
+        else "Уточнить героев, окружение и ключевой акцент. Финал сделать выразительным."
+    )
+    payload = {
+        "scene": scene,
+        "camera": camera,
+        "motion": motion,
+        "lighting": lighting,
+        "palette": palette,
+        "details": details,
+    }
+    copy_text = json.dumps(payload, ensure_ascii=False, indent=2)
+    duration_line = "Видеоролик длится ~8 секунд." if lang == "ru" else "Video runs for ~8 seconds."
+    face_line = _FACE_SAFETY[lang]
+    body = f"{duration_line}\n\n```json\n{copy_text}\n```\n\n{face_line}"
+    insert_payload = {
+        "engine": Engine.VEO_VIDEO.value,
+        "format": "16:9",
+        "model": "Fast",
+        "prompt": payload,
+    }
+    return PromptPayload(
+        title=_TITLES[Engine.VEO_VIDEO][lang],
+        body_markdown=body,
+        insert_payload=insert_payload,
+        copy_text=copy_text,
+    )
+
+
+def _mj_payload(user_text: str, lang: str) -> PromptPayload:
+    scene = _short_scene(user_text, width=200)
+    style = "hyper-realistic, premium detail" if lang == "en" else "гиперреалистичный стиль, премиальная детализация"
+    camera = "Portrait 35mm low-angle" if lang == "en" else "Портрет 35мм, низкая точка"
+    lighting = "Soft diffused cinematic" if lang == "en" else "Мягкий рассеянный кинематографичный свет"
+    palette = "Harmonious, film-like grading" if lang == "en" else "Гармоничная кинематографичная палитра"
+    payload = {
+        "prompt": f"{scene}, {style}",
+        "camera": camera,
+        "lighting": lighting,
+        "palette": palette,
+        "render": _MJ_RENDER,
+    }
+    copy_text = json.dumps(payload, ensure_ascii=False, indent=2)
+    note = "MJ создаёт 4 изображения из одного промпта." if lang == "ru" else "MJ generates 4 images from a single prompt."
+    face_line = _FACE_SAFETY[lang]
+    body = f"{note}\n\n```json\n{copy_text}\n```\n\n{face_line}"
+    insert_payload = {
+        "engine": Engine.MJ.value,
+        "prompt": payload,
+    }
+    return PromptPayload(
+        title=_TITLES[Engine.MJ][lang],
+        body_markdown=body,
+        insert_payload=insert_payload,
+        copy_text=copy_text,
+    )
+
+
+def _banana_tasks(user_text: str, lang: str) -> List[str]:
+    base_tasks = [
+        (
+            "Сохранить черты лица, не менять форму глаз/носа/рта/пропорции"
+            if lang == "ru"
+            else "Preserve facial traits without altering eyes, nose, mouth or proportions"
+        ),
+        ("Фон: уточнить/очистить по описанию" if lang == "ru" else "Background: refine/clean as described"),
+        ("Одежда и цвет: привести к описанному стилю" if lang == "ru" else "Wardrobe & color: align with described style"),
+        ("Удалить лишние объекты и шум" if lang == "ru" else "Remove unwanted objects and noise"),
+        (
+            "Свет и тон: сделать аккуратным и естественным"
+            if lang == "ru"
+            else "Light & tone: keep balanced and natural"
+        ),
+        (
+            "Лёгкая ретушь кожи, без «заломов» пластики"
+            if lang == "ru"
+            else "Gentle skin retouch without plastic creases"
+        ),
+    ]
+    idea_task = (
+        f"Основная задача: {user_text.strip()}" if lang == "ru" else f"Primary request: {user_text.strip()}"
+    )
+    return [idea_task, *base_tasks]
+
+
+def _banana_payload(user_text: str, lang: str) -> PromptPayload:
+    tasks = _banana_tasks(user_text, lang)
+    checklist_title = "**Чек-лист:**" if lang == "ru" else "**Checklist:**"
+    lines = [checklist_title]
+    for task in tasks:
+        lines.append(f"- {task}")
+    face_line = _FACE_SAFETY[lang]
+    ban_line = _FACE_SWAP_BAN[lang]
+    lines.append(f"- {face_line}")
+    lines.append(f"- {ban_line}")
+    body = "\n".join(lines)
+    copy_text = "\n".join(task for task in tasks)
+    insert_payload = {
+        "engine": Engine.BANANA_EDIT.value,
+        "banana_tasks": tasks,
+    }
+    return PromptPayload(
+        title=_TITLES[Engine.BANANA_EDIT][lang],
+        body_markdown=body,
+        insert_payload=insert_payload,
+        copy_text=copy_text,
+    )
+
+
+def _animate_payload(user_text: str, lang: str) -> PromptPayload:
+    hints = [
+        (
+            "Эмоции и микромимика: мягкое мигание, лёгкая улыбка, спокойное дыхание"
+            if lang == "ru"
+            else "Emotion & micro-expression: gentle blinking, subtle smile, calm breathing"
+        ),
+        (
+            "Движение камеры: микропанорама/параллакс с плавным отклонением"
+            if lang == "ru"
+            else "Camera: micro-panorama/parallax with soft drift"
+        ),
+        (
+            "Волосы и ткань: лёгкое движение от ветра"
+            if lang == "ru"
+            else "Hair & fabric: light movement from a breeze"
+        ),
+        (
+            "Итог: естественно, без пластика и без смещения черт"
+            if lang == "ru"
+            else "Result: natural, no plastic look, no feature shifting"
+        ),
+    ]
+    body_lines = ["**Шаги:**" if lang == "ru" else "**Steps:**"]
+    for hint in hints:
+        body_lines.append(f"- {hint}")
+    face_line = _FACE_SAFETY[lang]
+    ban_line = _FACE_SWAP_BAN[lang]
+    body_lines.append(f"- {face_line}")
+    body_lines.append(f"- {ban_line}")
+    idea_line = (
+        "**Описание кадра:** " if lang == "ru" else "**Frame description:** "
+    ) + _normalize_text(user_text)
+    body_lines.insert(1, idea_line)
+    insert_payload = {
+        "engine": Engine.VEO_ANIMATE.value,
+        "animate_hints": hints,
+        "description": _normalize_text(user_text),
+    }
+    copy_text = "\n".join(hints)
+    return PromptPayload(
+        title=_TITLES[Engine.VEO_ANIMATE][lang],
+        body_markdown="\n".join(body_lines),
+        insert_payload=insert_payload,
+        copy_text=copy_text,
+    )
+
+
+def _guess_genre(text: str, lang: str) -> str:
+    lowered = text.lower()
+    mapping = [
+        ("rock", "Альтернативный рок" if lang == "ru" else "Alternative rock"),
+        ("rap", "Лиричный хип-хоп" if lang == "ru" else "Lyrical hip-hop"),
+        ("hip-hop", "Лиричный хип-хоп" if lang == "ru" else "Lyrical hip-hop"),
+        ("поп", "Современный поп" if lang == "ru" else "Modern pop"),
+        ("synth", "Синтвейв" if lang == "ru" else "Synthwave"),
+        ("джаз", "Нео-соул/джаз" if lang == "ru" else "Neo-soul/jazz"),
+        ("jazz", "Нео-соул/джаз" if lang == "ru" else "Neo-soul/jazz"),
+    ]
+    for needle, result in mapping:
+        if needle in lowered:
+            return result
+    return _SUNO_DEFAULT_GENRE[lang]
+
+
+def _generate_story_lines(text: str, lang: str) -> List[str]:
+    idea = _normalize_text(text)
+    if not idea:
+        return ["Сумеречный город, герой ищет надежду." if lang == "ru" else "Dusky city, hero searching for hope."]
+    if len(idea.split()) > 12:
+        first = textwrap.shorten(idea, width=80, placeholder="…")
+        return [first]
+    if lang == "ru":
+        return [f"Герой переживает: {idea}.", "В припеве — катарсис и свет."]
+    return [f"Protagonist faces: {idea}.", "Chorus brings catharsis and light."]
+
+
+def _suno_payload(user_text: str, lang: str) -> PromptPayload:
+    idea = _normalize_text(user_text)
+    genre = _guess_genre(user_text, lang)
+    mood = _SUNO_DEFAULT_MOOD[lang]
+    instruments = _SUNO_DEFAULT_INSTRUMENTS[lang]
+    has_lines = "\n" in user_text.strip()
+    if has_lines:
+        lyrics = user_text.strip()
+    else:
+        story_lines = _generate_story_lines(user_text, lang)
+        lyrics = "\n".join(story_lines)
+    lines = [
+        f"- **Жанр:** {genre}" if lang == "ru" else f"- **Genre:** {genre}",
+        f"- **Настроение:** {mood}" if lang == "ru" else f"- **Mood:** {mood}",
+        f"- **Сюжет/картина:** {lyrics}" if lang == "ru" else f"- **Story:** {lyrics}",
+        (
+            f"- **Инструменты:** {instruments}" if lang == "ru" else f"- **Instruments:** {instruments}"
+        ),
+        (
+            f"- **Референсы:** {_SUNO_REFERENCES[lang]}"
+            if lang == "ru"
+            else f"- **References:** {_SUNO_REFERENCES[lang]}"
+        ),
+    ]
+    if has_lines:
+        lines.append("- **Текст куплета/припева включён из запроса.**" if lang == "ru" else "- **Verse/chorus text taken from user input.**")
+    copy_lines = [
+        f"Genre: {genre}",
+        f"Mood: {mood}",
+        f"Story: {lyrics}",
+        f"Instruments: {instruments}",
+    ]
+    if has_lines:
+        copy_lines.append("Lyrics included from user input")
+    insert_payload = {
+        "engine": Engine.SUNO.value,
+        "suno": {
+            "genre": genre,
+            "mood": mood,
+            "story": idea or lyrics,
+            "instruments": instruments,
+            "lyrics": lyrics if has_lines else None,
+        },
+    }
+    return PromptPayload(
+        title=_TITLES[Engine.SUNO][lang],
+        body_markdown="\n".join(lines),
+        insert_payload=insert_payload,
+        copy_text="\n".join(copy_lines),
+    )
+
+
+async def build_prompt(engine: Engine, user_text: str, lang: str) -> PromptPayload:
+    """Build a prompt payload for the requested engine."""
+
+    lang = "ru" if lang == "ru" else "en"
+    if engine == Engine.VEO_VIDEO:
+        return _veo_payload(user_text, lang)
+    if engine == Engine.MJ:
+        return _mj_payload(user_text, lang)
+    if engine == Engine.BANANA_EDIT:
+        return _banana_payload(user_text, lang)
+    if engine == Engine.VEO_ANIMATE:
+        return _animate_payload(user_text, lang)
+    if engine == Engine.SUNO:
+        return _suno_payload(user_text, lang)
+    raise ValueError(f"Unsupported engine: {engine}")

--- a/tests/test_prompt_master_ptb.py
+++ b/tests/test_prompt_master_ptb.py
@@ -1,11 +1,20 @@
 import asyncio
 import json
+import os
+import sys
 from types import SimpleNamespace
 
+import pytest
+from telegram.constants import ChatType
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 from handlers.prompt_master_handler import (
-    build_prompt,
+    PM_ENGINE_KEY,
+    PM_STATE_KEY,
     detect_language,
     prompt_master_callback,
+    prompt_master_handle_text,
     prompt_master_open,
 )
 from keyboards import (
@@ -13,6 +22,31 @@ from keyboards import (
     prompt_master_keyboard,
     prompt_master_mode_keyboard,
 )
+from prompt_master import Engine, build_prompt
+
+
+class DummyStatusMessage:
+    def __init__(self) -> None:
+        self.edits = []
+
+    async def edit_text(self, text, **kwargs):  # pragma: no cover - simple recorder
+        self.edits.append((text, kwargs))
+
+
+class DummyMessage:
+    def __init__(self, text: str, chat_type=ChatType.PRIVATE) -> None:
+        self.text = text
+        self.chat = SimpleNamespace(id=123, type=chat_type)
+        self.reply_calls = []
+        self.deleted = False
+        self.status = DummyStatusMessage()
+
+    async def reply_text(self, text, **kwargs):
+        self.reply_calls.append((text, kwargs))
+        return self.status
+
+    async def delete(self):  # pragma: no cover - deletion recording
+        self.deleted = True
 
 
 def test_prompt_master_keyboard_layout_ru() -> None:
@@ -41,7 +75,12 @@ def test_prompt_master_open_replies_with_keyboard_html() -> None:
 
     message = SimpleNamespace(reply_text=fake_reply)
     user = SimpleNamespace(language_code="ru")
-    update = SimpleNamespace(effective_message=message, message=message, callback_query=None, effective_user=user)
+    update = SimpleNamespace(
+        effective_message=message,
+        message=message,
+        callback_query=None,
+        effective_user=user,
+    )
     ctx = SimpleNamespace(user_data={})
 
     asyncio.run(prompt_master_open(update, ctx))
@@ -67,7 +106,11 @@ def test_prompt_master_callback_sets_pm_state() -> None:
         edit_message_text=fake_edit,
         message=SimpleNamespace(chat=SimpleNamespace(id=1)),
     )
-    update = SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(id=42, language_code="ru"), effective_chat=SimpleNamespace(id=1))
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_user=SimpleNamespace(id=42, language_code="ru"),
+        effective_chat=SimpleNamespace(id=1),
+    )
     ctx = SimpleNamespace(user_data={})
 
     asyncio.run(prompt_master_callback(update, ctx))
@@ -94,7 +137,10 @@ def test_prompt_master_callback_back_returns_menu() -> None:
         edit_message_text=fake_edit,
         message=SimpleNamespace(chat=SimpleNamespace(id=1)),
     )
-    update = SimpleNamespace(callback_query=query, effective_user=SimpleNamespace(language_code="ru"))
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_user=SimpleNamespace(language_code="ru"),
+    )
     ctx = SimpleNamespace(user_data={"mode": "pm", "pm_engine": "veo"})
 
     asyncio.run(prompt_master_callback(update, ctx))
@@ -106,22 +152,63 @@ def test_prompt_master_callback_back_returns_menu() -> None:
     assert kwargs["parse_mode"] == "HTML"
 
 
+@pytest.mark.parametrize(
+    "engine,text_value",
+    [
+        (Engine.VEO_ANIMATE, "мягко оживить портрет"),
+        (Engine.BANANA_EDIT, "убрать лишний фон"),
+        (Engine.SUNO, "энергичный трек о путешествии"),
+    ],
+)
+def test_prompt_master_handle_text_flow(engine: Engine, text_value: str) -> None:
+    message = DummyMessage(text_value)
+    update = SimpleNamespace(
+        message=message,
+        effective_chat=message.chat,
+        effective_user=SimpleNamespace(id=7, language_code="ru"),
+    )
+    ctx = SimpleNamespace(
+        user_data={PM_STATE_KEY: "pm", PM_ENGINE_KEY: engine.value},
+    )
+
+    asyncio.run(prompt_master_handle_text(update, ctx))
+
+    assert message.reply_calls
+    status_text, status_kwargs = message.reply_calls[0]
+    assert status_text.startswith("⏳")
+    assert status_kwargs["reply_markup"].inline_keyboard == prompt_master_mode_keyboard("ru").inline_keyboard
+
+    edits = message.status.edits
+    assert edits, "status message must be edited with final prompt"
+    final_text, final_kwargs = edits[-1]
+    assert "Готовый промпт" in final_text or "Ready prompt" in final_text
+    markup_rows = final_kwargs["reply_markup"].inline_keyboard
+    assert markup_rows[-1][0].callback_data == f"pm:copy:{engine.value}"
+    assert markup_rows[-1][1].callback_data == f"pm:insert:{engine.value}"
+
+
 def test_build_prompt_banana_contains_safety_phrase() -> None:
-    prompt = build_prompt("banana", "remove blemishes", "en", {})
-    assert not prompt.is_json
-    assert "real face" in prompt.body.lower()
+    prompt = asyncio.run(build_prompt(Engine.BANANA_EDIT, "remove blemishes", "en"))
+    assert "face" in prompt.body_markdown.lower()
+    assert prompt.insert_payload["engine"] == Engine.BANANA_EDIT.value
 
 
 def test_build_prompt_animate_ru_mentions_safety() -> None:
-    prompt = build_prompt("animate", "мягко оживить портрет", "ru", {})
-    assert "Не менять внешность" in prompt.body
+    prompt = asyncio.run(build_prompt(Engine.VEO_ANIMATE, "мягко оживить портрет", "ru"))
+    assert "Сохраняем черты лица" in prompt.body_markdown
+    assert "Запрещено" in prompt.body_markdown
 
 
 def test_build_prompt_veo_json_structure() -> None:
-    prompt = build_prompt("veo", "cinematic sunrise", "en", {})
-    assert prompt.is_json
-    payload = json.loads(prompt.body)
+    prompt = asyncio.run(build_prompt(Engine.VEO_VIDEO, "cinematic sunrise", "en"))
+    payload = json.loads(prompt.copy_text)
     assert {"scene", "camera", "motion", "lighting", "palette", "details"} <= set(payload.keys())
+
+
+def test_build_prompt_mj_json_structure() -> None:
+    prompt = asyncio.run(build_prompt(Engine.MJ, "futuristic portrait", "en"))
+    payload = json.loads(prompt.copy_text)
+    assert {"prompt", "camera", "lighting", "palette", "render"} <= set(payload.keys())
 
 
 def test_detect_language_simple() -> None:


### PR DESCRIPTION
## Summary
- add a dedicated prompt_master.generator module that assembles engine-specific payloads with localized safety messaging and insert data
- update the Prompt-Master handler to show progress states, convert markdown results to HTML, log telemetry for copy/insert actions, and reuse the new payloads
- extend the result keyboard layout and refresh the Prompt-Master tests to cover status editing, face safety lines, and JSON validation

## Testing
- pytest tests/test_prompt_master_ptb.py

------
https://chatgpt.com/codex/tasks/task_e_68d80de8dc788322a799d9f992b7e8ef