### PR TITLE
Stabilize Prompt-Master flows and HTML messaging

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -60,11 +60,11 @@ from handlers import (
 )
 
 from prompt_master import (
-    build_animate_prompt,
-    build_banana_json,
-    build_mj_json,
-    build_suno_prompt,
-    build_video_prompt,
+    legacy_build_animate_prompt as build_animate_prompt,
+    legacy_build_banana_json as build_banana_json,
+    legacy_build_mj_json as build_mj_json,
+    legacy_build_suno_prompt as build_suno_prompt,
+    legacy_build_video_prompt as build_video_prompt,
 )
 
 # === KIE Banana wrapper ===
@@ -8760,7 +8760,7 @@ def register_handlers(application: Any) -> None:
 
     pm_handler = MessageHandler(filters.TEXT & ~filters.COMMAND, prompt_master_handle_text)
     pm_handler.block = False
-    application.add_handler(pm_handler)
+    application.add_handler(pm_handler, group=0)
 
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, on_text))
 

--- a/prompt_master/__init__.py
+++ b/prompt_master/__init__.py
@@ -1,5 +1,46 @@
 """Prompt-Master package exports."""
 
-from .generator import Engine, PromptPayload, build_prompt
+from importlib import util
+from pathlib import Path
 
-__all__ = ["Engine", "PromptPayload", "build_prompt"]
+from .generator import (
+    Engine,
+    PromptPayload,
+    build_animate_prompt,
+    build_banana_prompt,
+    build_mj_prompt,
+    build_prompt,
+    build_suno_prompt,
+    build_veo_prompt,
+)
+
+_LEGACY_PATH = Path(__file__).resolve().parent.parent / "prompt_master.py"
+_LEGACY_SPEC = util.spec_from_file_location("_prompt_master_legacy", _LEGACY_PATH)
+if _LEGACY_SPEC and _LEGACY_SPEC.loader:  # pragma: no cover - import safety
+    _legacy = util.module_from_spec(_LEGACY_SPEC)
+    _LEGACY_SPEC.loader.exec_module(_legacy)
+    legacy_build_video_prompt = _legacy.build_video_prompt
+    legacy_build_banana_json = _legacy.build_banana_json
+    legacy_build_mj_json = _legacy.build_mj_json
+    legacy_build_animate_prompt = _legacy.build_animate_prompt
+    legacy_build_suno_prompt = _legacy.build_suno_prompt
+else:  # pragma: no cover - unexpected environment
+    legacy_build_video_prompt = legacy_build_banana_json = None
+    legacy_build_mj_json = legacy_build_animate_prompt = None
+    legacy_build_suno_prompt = None
+
+__all__ = [
+    "Engine",
+    "PromptPayload",
+    "build_prompt",
+    "build_veo_prompt",
+    "build_mj_prompt",
+    "build_banana_prompt",
+    "build_animate_prompt",
+    "build_suno_prompt",
+    "legacy_build_video_prompt",
+    "legacy_build_banana_json",
+    "legacy_build_mj_json",
+    "legacy_build_animate_prompt",
+    "legacy_build_suno_prompt",
+]

--- a/tests/test_faq.py
+++ b/tests/test_faq.py
@@ -1,5 +1,3 @@
-"""FAQ handler tests for new inline menu."""
-
 import asyncio
 from types import SimpleNamespace
 
@@ -8,31 +6,36 @@ from keyboards import CB_FAQ_PREFIX, faq_keyboard
 from texts import FAQ_INTRO, FAQ_SECTIONS
 
 
+class FakeBot:
+    def __init__(self) -> None:
+        self.sent: list[tuple[int, str, dict]] = []
+
+    async def send_message(self, chat_id: int, text: str, **kwargs):
+        self.sent.append((chat_id, text, kwargs))
+        return SimpleNamespace(message_id=1, chat_id=chat_id)
+
+
 def setup_function():
     configure_faq(show_main_menu=None, on_root_view=None, on_section_view=None)
 
 
 def test_faq_command_sends_intro_and_keyboard():
-    calls = []
-
-    async def fake_reply(text, **kwargs):
-        calls.append((text, kwargs))
-
-    message = SimpleNamespace(reply_text=fake_reply)
+    bot = FakeBot()
+    message = SimpleNamespace(chat=SimpleNamespace(id=101), chat_id=101)
     update = SimpleNamespace(effective_message=message)
-    ctx = SimpleNamespace()
+    ctx = SimpleNamespace(bot=bot)
 
     root_calls = []
     configure_faq(on_root_view=lambda: root_calls.append(True))
 
     asyncio.run(faq_command(update, ctx))
 
-    assert calls
-    text, kwargs = calls[0]
-    assert text == FAQ_INTRO
+    assert bot.sent
+    chat_id, text, kwargs = bot.sent[0]
+    assert chat_id == 101
+    assert "<b>FAQ</b>" in text
     assert kwargs["reply_markup"].inline_keyboard == faq_keyboard().inline_keyboard
-    assert kwargs["parse_mode"] == "Markdown"
-    assert kwargs["disable_web_page_preview"] is True
+    assert kwargs["parse_mode"] == "HTML"
     assert root_calls == [True]
 
 
@@ -42,10 +45,8 @@ def test_faq_callback_sends_section_text():
     async def fake_edit(text, **kwargs):
         edits.append((text, kwargs))
 
-    answers = []
-
     async def fake_answer():
-        answers.append(True)
+        pass
 
     section_calls = []
     configure_faq(on_section_view=lambda key: section_calls.append(key))
@@ -54,28 +55,26 @@ def test_faq_callback_sends_section_text():
         data=f"{CB_FAQ_PREFIX}veo",
         edit_message_text=fake_edit,
         answer=fake_answer,
-        message=SimpleNamespace(chat_id=1),
+        message=SimpleNamespace(chat=SimpleNamespace(id=202)),
     )
     update = SimpleNamespace(callback_query=query, effective_user=None)
-    ctx = SimpleNamespace(application=SimpleNamespace(bot=None))
+    ctx = SimpleNamespace()
 
     asyncio.run(faq_callback(update, ctx))
 
-    assert answers == [True]
     assert edits
     text, kwargs = edits[0]
-    assert text == FAQ_SECTIONS["veo"]
+    assert "<b>Видео" in text
     assert kwargs["reply_markup"].inline_keyboard == faq_keyboard().inline_keyboard
-    assert kwargs["parse_mode"] == "Markdown"
-    assert kwargs["disable_web_page_preview"] is True
+    assert kwargs["parse_mode"] == "HTML"
     assert section_calls == ["veo"]
 
 
 def test_faq_callback_back_calls_main_menu():
-    menu_calls = []
+    bot = FakeBot()
 
     async def fake_menu(update, ctx):
-        menu_calls.append((update, ctx))
+        await bot.send_message(303, "menu called")
 
     configure_faq(show_main_menu=fake_menu)
 
@@ -86,16 +85,15 @@ def test_faq_callback_back_calls_main_menu():
         data=f"{CB_FAQ_PREFIX}back",
         answer=fake_answer,
         edit_message_text=None,
-        message=SimpleNamespace(chat_id=1),
+        message=SimpleNamespace(chat=SimpleNamespace(id=303)),
     )
     update = SimpleNamespace(callback_query=query, effective_user=None)
-    ctx = SimpleNamespace(application=SimpleNamespace(bot=None))
+    ctx = SimpleNamespace(bot=bot)
 
     asyncio.run(faq_callback(update, ctx))
 
-    assert len(menu_calls) == 1
-    assert menu_calls[0][0] is update
-    assert menu_calls[0][1] is ctx
+    assert bot.sent
+    assert bot.sent[0][0] == 303
 
 
 def test_faq_callback_unknown_section_returns_fallback():
@@ -111,10 +109,10 @@ def test_faq_callback_unknown_section_returns_fallback():
         data=f"{CB_FAQ_PREFIX}unknown",
         edit_message_text=fake_edit,
         answer=fake_answer,
-        message=SimpleNamespace(chat_id=1),
+        message=SimpleNamespace(chat=SimpleNamespace(id=404)),
     )
     update = SimpleNamespace(callback_query=query, effective_user=None)
-    ctx = SimpleNamespace(application=SimpleNamespace(bot=None))
+    ctx = SimpleNamespace()
 
     asyncio.run(faq_callback(update, ctx))
 

--- a/tests/test_prompt_master_ptb.py
+++ b/tests/test_prompt_master_ptb.py
@@ -1,52 +1,52 @@
 import asyncio
 import json
-import os
-import sys
 from types import SimpleNamespace
 
 import pytest
+
 from telegram.constants import ChatType
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 from handlers.prompt_master_handler import (
-    PM_ENGINE_KEY,
     PM_STATE_KEY,
+    clear_pm_prompts,
     detect_language,
+    get_pm_prompt,
     prompt_master_callback,
-    prompt_master_handle_text,
     prompt_master_open,
+    prompt_master_text_handler,
 )
-from keyboards import (
-    CB_PM_PREFIX,
-    prompt_master_keyboard,
-    prompt_master_mode_keyboard,
-)
-from prompt_master import Engine, build_prompt
+from keyboards import CB_PM_PREFIX, prompt_master_keyboard, prompt_master_mode_keyboard
+from prompt_master import Engine, build_banana_prompt, build_mj_prompt, build_prompt
 
 
-class DummyStatusMessage:
+class FakeBot:
     def __init__(self) -> None:
-        self.edits = []
+        self.sent: list[tuple[int, str, dict]] = []
+        self.edited: list[tuple[int, int, str, dict]] = []
+        self._message_id = 100
 
-    async def edit_text(self, text, **kwargs):  # pragma: no cover - simple recorder
-        self.edits.append((text, kwargs))
+    async def send_message(self, chat_id: int, text: str, **kwargs):  # pragma: no cover - simple recorder
+        self._message_id += 1
+        self.sent.append((chat_id, text, kwargs))
+        return SimpleNamespace(message_id=self._message_id, chat_id=chat_id)
+
+    async def edit_message_text(self, chat_id: int, message_id: int, text: str, **kwargs):
+        self.edited.append((chat_id, message_id, text, kwargs))
+        return SimpleNamespace()
 
 
-class DummyMessage:
-    def __init__(self, text: str, chat_type=ChatType.PRIVATE) -> None:
-        self.text = text
-        self.chat = SimpleNamespace(id=123, type=chat_type)
-        self.reply_calls = []
-        self.deleted = False
-        self.status = DummyStatusMessage()
+class FakeQuery:
+    def __init__(self, data: str, bot: FakeBot):
+        self.data = data
+        self.bot = bot
+        self.message = SimpleNamespace(chat=SimpleNamespace(id=321))
+        self._answers: list[tuple[str, bool]] = []
 
-    async def reply_text(self, text, **kwargs):
-        self.reply_calls.append((text, kwargs))
-        return self.status
+    async def answer(self, text: str = "", show_alert: bool = False):  # pragma: no cover - simple recorder
+        self._answers.append((text, show_alert))
 
-    async def delete(self):  # pragma: no cover - deletion recording
-        self.deleted = True
+    async def edit_message_text(self, text: str, **kwargs):
+        await self.bot.edit_message_text(self.message.chat.id, 999, text, **kwargs)
 
 
 def test_prompt_master_keyboard_layout_ru() -> None:
@@ -67,148 +67,103 @@ def test_prompt_master_keyboard_layout_ru() -> None:
     assert layout == expected
 
 
-def test_prompt_master_open_replies_with_keyboard_html() -> None:
-    calls = []
-
-    async def fake_reply(text, **kwargs):
-        calls.append((text, kwargs))
-
-    message = SimpleNamespace(reply_text=fake_reply)
-    user = SimpleNamespace(language_code="ru")
+def test_prompt_master_open_uses_safe_send_html() -> None:
+    bot = FakeBot()
     update = SimpleNamespace(
-        effective_message=message,
-        message=message,
-        callback_query=None,
-        effective_user=user,
-    )
-    ctx = SimpleNamespace(user_data={})
-
-    asyncio.run(prompt_master_open(update, ctx))
-
-    assert calls
-    _text, kwargs = calls[0]
-    assert kwargs["reply_markup"].inline_keyboard == prompt_master_keyboard("ru").inline_keyboard
-    assert kwargs["parse_mode"] == "HTML"
-
-
-def test_prompt_master_callback_sets_pm_state() -> None:
-    edits = []
-
-    async def fake_edit(text, **kwargs):
-        edits.append((text, kwargs))
-
-    async def fake_answer(*args, **kwargs):
-        pass
-
-    query = SimpleNamespace(
-        data=f"{CB_PM_PREFIX}veo",
-        answer=fake_answer,
-        edit_message_text=fake_edit,
-        message=SimpleNamespace(chat=SimpleNamespace(id=1)),
-    )
-    update = SimpleNamespace(
-        callback_query=query,
-        effective_user=SimpleNamespace(id=42, language_code="ru"),
-        effective_chat=SimpleNamespace(id=1),
-    )
-    ctx = SimpleNamespace(user_data={})
-
-    asyncio.run(prompt_master_callback(update, ctx))
-
-    assert ctx.user_data.get("mode") == "pm"
-    assert ctx.user_data.get("pm_engine") == "veo"
-    assert edits
-    _text, kwargs = edits[0]
-    assert kwargs["reply_markup"].inline_keyboard == prompt_master_mode_keyboard("ru").inline_keyboard
-
-
-def test_prompt_master_callback_back_returns_menu() -> None:
-    edits = []
-
-    async def fake_edit(text, **kwargs):
-        edits.append((text, kwargs))
-
-    async def fake_answer(*args, **kwargs):
-        pass
-
-    query = SimpleNamespace(
-        data=f"{CB_PM_PREFIX}back",
-        answer=fake_answer,
-        edit_message_text=fake_edit,
-        message=SimpleNamespace(chat=SimpleNamespace(id=1)),
-    )
-    update = SimpleNamespace(
-        callback_query=query,
+        effective_message=SimpleNamespace(chat=SimpleNamespace(id=555), chat_id=555),
         effective_user=SimpleNamespace(language_code="ru"),
     )
-    ctx = SimpleNamespace(user_data={"mode": "pm", "pm_engine": "veo"})
-
-    asyncio.run(prompt_master_callback(update, ctx))
-
-    assert not ctx.user_data.get("pm_engine")
-    assert edits
-    _text, kwargs = edits[0]
-    assert kwargs["reply_markup"].inline_keyboard == prompt_master_keyboard("ru").inline_keyboard
+    ctx = SimpleNamespace(bot=bot, user_data={})
+    asyncio.run(prompt_master_open(update, ctx))
+    assert bot.sent
+    _, text, kwargs = bot.sent[-1]
+    assert "<b>Prompt-Master</b>" in text
     assert kwargs["parse_mode"] == "HTML"
+    assert kwargs["reply_markup"].inline_keyboard == prompt_master_keyboard("ru").inline_keyboard
+
+
+def test_prompt_master_callback_selects_engine_and_creates_card() -> None:
+    bot = FakeBot()
+    query = FakeQuery(f"{CB_PM_PREFIX}veo", bot)
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_user=SimpleNamespace(id=77, language_code="ru"),
+        effective_chat=SimpleNamespace(id=321),
+    )
+    ctx = SimpleNamespace(bot=bot, user_data={})
+    asyncio.run(prompt_master_callback(update, ctx))
+    state = ctx.user_data.get(PM_STATE_KEY)
+    assert state["engine"] == "veo"
+    assert bot.sent, "card must be rendered"
+    chat_id, _text, kwargs = bot.sent[-1]
+    assert chat_id == 321
+    assert kwargs["reply_markup"].inline_keyboard == prompt_master_mode_keyboard("ru").inline_keyboard
+    assert state["card_msg_id"]
+
+
+def test_prompt_master_text_handler_generates_prompt_and_updates_status() -> None:
+    bot = FakeBot()
+    state = {"engine": "mj", "card_msg_id": None, "autodelete": False}
+    ctx = SimpleNamespace(bot=bot, user_data={PM_STATE_KEY: state})
+    message = SimpleNamespace(text="futuristic portrait", chat=SimpleNamespace(id=333, type=ChatType.PRIVATE))
+    update = SimpleNamespace(message=message, effective_chat=message.chat)
+    asyncio.run(prompt_master_text_handler(update, ctx))
+    # First send is card, second send is status
+    assert len(bot.sent) >= 2
+    card_chat, card_text, card_kwargs = bot.sent[0]
+    assert card_chat == 333
+    assert "<pre><code>" in card_text
+    status_chat, status_text, status_kwargs = bot.sent[1]
+    assert status_text.startswith("✍️")
+    assert status_kwargs["reply_markup"].inline_keyboard == prompt_master_mode_keyboard("en").inline_keyboard
+    # Final edit should include result keyboard
+    assert bot.edited, "status message must be edited"
+    _chat, _mid, final_text, final_kwargs = bot.edited[-1]
+    assert "Ready prompt" in final_text
+    buttons = final_kwargs["reply_markup"].inline_keyboard[-1]
+    assert buttons[0].callback_data == "pm:copy:mj"
+    assert get_pm_prompt(333, "mj") is not None
+
+
+def test_prompt_master_insert_uses_cached_payload() -> None:
+    bot = FakeBot()
+    payload = build_banana_prompt("почисти фон", "ru")
+    ctx = SimpleNamespace(bot=bot, user_data={PM_STATE_KEY: {"engine": "banana", "card_msg_id": None}})
+    chat_id = 444
+    clear_pm_prompts(chat_id)
+    # store payload to simulate previous run
+    from handlers.prompt_master_handler import _store_prompt  # type: ignore
+
+    _store_prompt(chat_id, "banana", payload)
+    query = FakeQuery(f"pm:insert:banana", bot)
+    query.message.chat.id = chat_id
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(language_code="ru"),
+    )
+    asyncio.run(prompt_master_callback(update, ctx))
+    assert ctx.user_data[PM_STATE_KEY]["prompt"] == payload.card_text
+    assert bot.sent, "card should be rendered on insert"
 
 
 @pytest.mark.parametrize(
-    "engine,text_value",
+    "builder,text,lang,needle",
     [
-        (Engine.VEO_ANIMATE, "мягко оживить портрет"),
-        (Engine.BANANA_EDIT, "убрать лишний фон"),
-        (Engine.SUNO, "энергичный трек о путешествии"),
+        (build_banana_prompt, "remove blemishes", "en", "face"),
+        (build_banana_prompt, "сделай аккуратно", "ru", "Сохраняем черты лица"),
+        (build_mj_prompt, "cinematic hero", "en", "prompt"),
     ],
 )
-def test_prompt_master_handle_text_flow(engine: Engine, text_value: str) -> None:
-    message = DummyMessage(text_value)
-    update = SimpleNamespace(
-        message=message,
-        effective_chat=message.chat,
-        effective_user=SimpleNamespace(id=7, language_code="ru"),
-    )
-    ctx = SimpleNamespace(
-        user_data={PM_STATE_KEY: "pm", PM_ENGINE_KEY: engine.value},
-    )
-
-    asyncio.run(prompt_master_handle_text(update, ctx))
-
-    assert message.reply_calls
-    status_text, status_kwargs = message.reply_calls[0]
-    assert status_text.startswith("⏳")
-    assert status_kwargs["reply_markup"].inline_keyboard == prompt_master_mode_keyboard("ru").inline_keyboard
-
-    edits = message.status.edits
-    assert edits, "status message must be edited with final prompt"
-    final_text, final_kwargs = edits[-1]
-    assert "Готовый промпт" in final_text or "Ready prompt" in final_text
-    markup_rows = final_kwargs["reply_markup"].inline_keyboard
-    assert markup_rows[-1][0].callback_data == f"pm:copy:{engine.value}"
-    assert markup_rows[-1][1].callback_data == f"pm:insert:{engine.value}"
-
-
-def test_build_prompt_banana_contains_safety_phrase() -> None:
-    prompt = asyncio.run(build_prompt(Engine.BANANA_EDIT, "remove blemishes", "en"))
-    assert "face" in prompt.body_markdown.lower()
-    assert prompt.insert_payload["engine"] == Engine.BANANA_EDIT.value
-
-
-def test_build_prompt_animate_ru_mentions_safety() -> None:
-    prompt = asyncio.run(build_prompt(Engine.VEO_ANIMATE, "мягко оживить портрет", "ru"))
-    assert "Сохраняем черты лица" in prompt.body_markdown
-    assert "Запрещено" in prompt.body_markdown
+def test_prompt_builders_return_html(builder, text, lang, needle) -> None:
+    payload = builder(text, lang)
+    assert needle.lower() in payload.body_html.lower()
 
 
 def test_build_prompt_veo_json_structure() -> None:
     prompt = asyncio.run(build_prompt(Engine.VEO_VIDEO, "cinematic sunrise", "en"))
     payload = json.loads(prompt.copy_text)
     assert {"scene", "camera", "motion", "lighting", "palette", "details"} <= set(payload.keys())
-
-
-def test_build_prompt_mj_json_structure() -> None:
-    prompt = asyncio.run(build_prompt(Engine.MJ, "futuristic portrait", "en"))
-    payload = json.loads(prompt.copy_text)
-    assert {"prompt", "camera", "lighting", "palette", "render"} <= set(payload.keys())
 
 
 def test_detect_language_simple() -> None:

--- a/utils/safe_send.py
+++ b/utils/safe_send.py
@@ -1,0 +1,61 @@
+"""Utilities for safely delivering HTML-formatted Telegram messages."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from telegram import Bot, Message
+from telegram.constants import ParseMode
+
+
+def _chunk_text(text: str, *, limit: int) -> Iterable[str]:
+    """Yield safe chunks for Telegram send operations."""
+
+    if not text:
+        yield ""
+        return
+
+    start = 0
+    text_len = len(text)
+    while start < text_len:
+        end = min(start + limit, text_len)
+        if end < text_len:
+            split = text.rfind("\n", start, end)
+            if split <= start:
+                split = text.rfind(" ", start, end)
+            if split <= start:
+                split = end
+        else:
+            split = end
+        yield text[start:split]
+        start = split
+
+
+async def safe_send(
+    bot: Bot,
+    chat_id: int,
+    text: str,
+    *,
+    reply_markup=None,
+    chunk_limit: int = 3500,
+) -> Optional[Message]:
+    """Send HTML text safely, slicing long payloads into chunks.
+
+    ``reply_markup`` is attached only to the last chunk.
+    """
+
+    last_message: Optional[Message] = None
+    chunks = list(_chunk_text(text, limit=chunk_limit))
+    total = len(chunks)
+    for index, chunk in enumerate(chunks):
+        last_message = await bot.send_message(
+            chat_id=chat_id,
+            text=chunk,
+            parse_mode=ParseMode.HTML,
+            disable_web_page_preview=True,
+            reply_markup=reply_markup if index == total - 1 else None,
+        )
+    return last_message
+
+
+__all__ = ["safe_send"]


### PR DESCRIPTION
## Summary
- add a safe_send helper to send HTML messages safely and reuse it across Prompt-Master and FAQ handlers
- refactor Prompt-Master handler to manage the new pm_state structure, keep keyboards on edits, and surface cached results with HTML payloads
- switch prompt generators and FAQ outputs to HTML-safe rendering while exposing legacy builders for the rest of the bot, and update tests accordingly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d815b12a0c83228525c48e195ce876