### PR TITLE
Fix Prompt-Master HTML rendering & restore prompt insertion across engines

### DIFF
--- a/tests/test_prompt_master_ptb.py
+++ b/tests/test_prompt_master_ptb.py
@@ -1,22 +1,31 @@
 import asyncio
 import json
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from telegram.constants import ChatType
+from telegram.error import BadRequest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from handlers.prompt_master_handler import (
     PM_STATE_KEY,
     clear_pm_prompts,
     detect_language,
     get_pm_prompt,
+    _render_payload_html,
+    _edit_with_fallback,
     prompt_master_callback,
     prompt_master_open,
     prompt_master_text_handler,
 )
 from keyboards import CB_PM_PREFIX, prompt_master_keyboard, prompt_master_mode_keyboard
-from prompt_master import Engine, build_banana_prompt, build_mj_prompt, build_prompt
+from prompt_master import Engine, build_banana_prompt, build_mj_prompt, build_prompt, build_veo_prompt
+from utils.html_render import render_pm_html
+from utils.safe_send import send_html_with_fallback
 
 
 class FakeBot:
@@ -24,13 +33,21 @@ class FakeBot:
         self.sent: list[tuple[int, str, dict]] = []
         self.edited: list[tuple[int, int, str, dict]] = []
         self._message_id = 100
+        self.fail_next_html_send = False
+        self.fail_next_html_edit = False
 
     async def send_message(self, chat_id: int, text: str, **kwargs):  # pragma: no cover - simple recorder
+        if kwargs.get("parse_mode") == "HTML" and self.fail_next_html_send:
+            self.fail_next_html_send = False
+            raise BadRequest("Can't parse entities: unsupported start tag \"br/\"")
         self._message_id += 1
         self.sent.append((chat_id, text, kwargs))
         return SimpleNamespace(message_id=self._message_id, chat_id=chat_id)
 
     async def edit_message_text(self, chat_id: int, message_id: int, text: str, **kwargs):
+        if kwargs.get("parse_mode") == "HTML" and self.fail_next_html_edit:
+            self.fail_next_html_edit = False
+            raise BadRequest("Can't parse entities: unsupported start tag \"ul\"")
         self.edited.append((chat_id, message_id, text, kwargs))
         return SimpleNamespace()
 
@@ -47,6 +64,48 @@ class FakeQuery:
 
     async def edit_message_text(self, text: str, **kwargs):
         await self.bot.edit_message_text(self.message.chat.id, 999, text, **kwargs)
+
+
+def test_render_pm_html_br_self_closing() -> None:
+    result = render_pm_html("first line<br/>second line")
+    assert "<br/>" not in result
+    assert "first line<br>second line" == result
+
+
+def test_render_pm_html_json_code_block() -> None:
+    json_block = """```json\n{\n  \"key\": \"value\"\n}\n```"""
+    result = render_pm_html(json_block)
+    assert "<pre><code>" in result
+    assert "&quot;value&quot;" in result
+
+
+def test_send_html_with_fallback_on_bad_html() -> None:
+    bot = FakeBot()
+    bot.fail_next_html_send = True
+    message = asyncio.run(send_html_with_fallback(bot, 777, "<ul><li>item</li></ul>"))
+    assert message is not None
+    sent_chat, sent_text, kwargs = bot.sent[-1]
+    assert sent_chat == 777
+    assert "parse_mode" not in kwargs
+    assert "<" not in sent_text
+
+
+def test_edit_with_fallback_plain_text() -> None:
+    bot = FakeBot()
+    bot.fail_next_html_edit = True
+    ctx = SimpleNamespace(bot=bot)
+    asyncio.run(
+        _edit_with_fallback(
+            ctx,
+            555,
+            1000,
+            "<ul><li>broken</li></ul>",
+            prompt_master_mode_keyboard("en"),
+        )
+    )
+    _, _, text, kwargs = bot.edited[-1]
+    assert "parse_mode" not in kwargs
+    assert "<" not in text
 
 
 def test_prompt_master_keyboard_layout_ru() -> None:
@@ -95,9 +154,10 @@ def test_prompt_master_callback_selects_engine_and_creates_card() -> None:
     state = ctx.user_data.get(PM_STATE_KEY)
     assert state["engine"] == "veo"
     assert bot.sent, "card must be rendered"
-    chat_id, _text, kwargs = bot.sent[-1]
+    chat_id, card_html, kwargs = bot.sent[-1]
     assert chat_id == 321
     assert kwargs["reply_markup"].inline_keyboard == prompt_master_mode_keyboard("ru").inline_keyboard
+    assert "<br/>" not in card_html
     assert state["card_msg_id"]
 
 
@@ -116,10 +176,13 @@ def test_prompt_master_text_handler_generates_prompt_and_updates_status() -> Non
     status_chat, status_text, status_kwargs = bot.sent[1]
     assert status_text.startswith("✍️")
     assert status_kwargs["reply_markup"].inline_keyboard == prompt_master_mode_keyboard("en").inline_keyboard
+    assert status_kwargs.get("parse_mode") == "HTML"
     # Final edit should include result keyboard
     assert bot.edited, "status message must be edited"
     _chat, _mid, final_text, final_kwargs = bot.edited[-1]
     assert "Ready prompt" in final_text
+    assert "<pre><code>" in final_text
+    assert "<br/>" not in final_text
     buttons = final_kwargs["reply_markup"].inline_keyboard[-1]
     assert buttons[0].callback_data == "pm:copy:mj"
     assert get_pm_prompt(333, "mj") is not None
@@ -150,14 +213,37 @@ def test_prompt_master_insert_uses_cached_payload() -> None:
 @pytest.mark.parametrize(
     "builder,text,lang,needle",
     [
-        (build_banana_prompt, "remove blemishes", "en", "face"),
+        (build_banana_prompt, "remove blemishes", "en", "Preserve facial traits"),
         (build_banana_prompt, "сделай аккуратно", "ru", "Сохраняем черты лица"),
-        (build_mj_prompt, "cinematic hero", "en", "prompt"),
+        (build_mj_prompt, "cinematic hero", "en", "Preserve"),
     ],
 )
-def test_prompt_builders_return_html(builder, text, lang, needle) -> None:
+def test_prompt_builders_return_body(builder, text, lang, needle) -> None:
     payload = builder(text, lang)
-    assert needle.lower() in payload.body_html.lower()
+    assert needle.lower() in payload.body_md.lower()
+    if payload.code_block:
+        assert payload.code_block.strip().startswith("{")
+
+
+def test_render_payload_snapshot_mj() -> None:
+    payload = build_mj_prompt("cinematic hero", "en")
+    html_text = _render_payload_html(payload)
+    assert "<strong>Ready prompt for Midjourney</strong>" in html_text
+    assert "&quot;render&quot;" in html_text
+
+
+def test_render_payload_snapshot_veo() -> None:
+    payload = build_veo_prompt("cinematic hero", "en")
+    html_text = _render_payload_html(payload)
+    assert "<strong>Ready prompt for VEO</strong>" in html_text
+    assert "&quot;scene&quot;" in html_text
+
+
+def test_render_payload_snapshot_banana() -> None:
+    payload = build_banana_prompt("touch up", "en")
+    html_text = _render_payload_html(payload)
+    assert "<strong>Banana edit checklist</strong>" in html_text
+    assert "Checklist:" in html_text
 
 
 def test_build_prompt_veo_json_structure() -> None:

--- a/utils/html_render.py
+++ b/utils/html_render.py
@@ -1,0 +1,283 @@
+"""Prompt-Master HTML rendering helpers."""
+
+from __future__ import annotations
+
+import html
+import logging
+import re
+from html.parser import HTMLParser
+from typing import Iterable, List
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_TAGS = {
+    "b",
+    "strong",
+    "i",
+    "em",
+    "u",
+    "span",
+    "a",
+    "code",
+    "pre",
+    "s",
+    "tg-spoiler",
+    "blockquote",
+    "br",
+}
+_ALLOWED_ATTRS = {"a": {"href"}}
+_SELF_CLOSING_TAGS = {"br"}
+_BLOCK_TAGS = {"pre", "blockquote", "tg-spoiler"}
+
+_CODE_FENCE_RE = re.compile(r"```(?:[a-z0-9_-]+)?\n(.*?)```", re.IGNORECASE | re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"(?<!\\)`([^`]+?)`")
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_STRONG_RE = re.compile(r"__(.+?)__")
+_ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
+_EM_RE = re.compile(r"_(.+?)_")
+_STRIKE_RE = re.compile(r"~~(.+?)~~")
+_LINK_RE = re.compile(r"\[(.+?)\]\(([^\s)]+)\)")
+
+
+class _HTMLSanitizer(HTMLParser):
+    """HTML sanitizer that keeps only the allowed subset of tags."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self.result: List[str] = []
+        self._skip_depth = 0
+        self._stack: List[str] = []
+
+    # pylint: disable=too-many-branches
+    def handle_starttag(self, tag: str, attrs) -> None:  # type: ignore[override]
+        tag = tag.lower()
+        if self._skip_depth:
+            self._skip_depth += 1
+            return
+        if tag in {"p"}:
+            self._ensure_break()
+            self._stack.append(tag)
+            return
+        if tag in {"ul", "ol"}:
+            self._ensure_break()
+            self._stack.append(tag)
+            return
+        if tag == "li":
+            self._ensure_break()
+            self.result.append("• ")
+            self._stack.append(tag)
+            return
+        if tag not in _ALLOWED_TAGS:
+            self._skip_depth = 1
+            return
+        attrs = self._filter_attrs(tag, attrs)
+        attr_str = "".join(f' {name}="{html.escape(value, quote=True)}"' for name, value in attrs)
+        if tag in _SELF_CLOSING_TAGS:
+            self.result.append(f"<{tag}>")
+            return
+        self.result.append(f"<{tag}{attr_str}>")
+        self._stack.append(tag)
+
+    def handle_endtag(self, tag: str) -> None:  # type: ignore[override]
+        tag = tag.lower()
+        if self._skip_depth:
+            self._skip_depth -= 1
+            return
+        if not self._stack:
+            return
+        top = self._stack.pop()
+        if tag in {"p", "ul", "ol"}:
+            self._ensure_break()
+            return
+        if tag == "li":
+            self._ensure_break()
+            return
+        if top != tag:
+            return
+        if tag in _SELF_CLOSING_TAGS:
+            return
+        self.result.append(f"</{tag}>")
+        if tag in _BLOCK_TAGS:
+            self._ensure_break()
+
+    def handle_data(self, data: str) -> None:  # type: ignore[override]
+        if self._skip_depth:
+            return
+        if not data:
+            return
+        self.result.append(html.escape(data))
+
+    def handle_entityref(self, name: str) -> None:  # type: ignore[override]
+        if self._skip_depth:
+            return
+        self.result.append(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:  # type: ignore[override]
+        if self._skip_depth:
+            return
+        self.result.append(f"&#{name};")
+
+    def get_html(self) -> str:
+        html_text = "".join(self.result)
+        html_text = html_text.replace("<br />", "<br>").replace("<br/>", "<br>")
+        html_text = re.sub(r"(?:<br>\s*){3,}", "<br><br>", html_text)
+        return html_text.strip()
+
+    def _ensure_break(self) -> None:
+        if not self.result:
+            return
+        if self.result[-1].endswith("<br>"):
+            return
+        self.result.append("<br>")
+
+    @staticmethod
+    def _filter_attrs(tag: str, attrs) -> List[tuple[str, str]]:
+        allowed = _ALLOWED_ATTRS.get(tag, set())
+        filtered: List[tuple[str, str]] = []
+        for name, value in attrs:
+            if value is None:
+                continue
+            if name not in allowed:
+                continue
+            if tag == "a" and value.lower().startswith("javascript:"):
+                continue
+            filtered.append((name, value))
+        return filtered
+
+
+def _strip_markdown(text: str) -> str:
+    return text.replace("\r\n", "\n")
+
+
+def _escape_inline(text: str) -> str:
+    codes: list[str] = []
+
+    def repl_code(match: re.Match[str]) -> str:
+        codes.append(match.group(1))
+        return f"@@CODE{len(codes) - 1}@@"
+
+    text = _INLINE_CODE_RE.sub(repl_code, text)
+    text = html.escape(text)
+
+    for idx, code in enumerate(codes):
+        safe_code = html.escape(code)
+        text = text.replace(f"@@CODE{idx}@@", f"<code>{safe_code}</code>")
+
+    text = _BOLD_RE.sub(lambda m: f"<strong>{m.group(1)}</strong>", text)
+    text = _STRONG_RE.sub(lambda m: f"<u>{m.group(1)}</u>", text)
+    text = _ITALIC_RE.sub(lambda m: f"<em>{m.group(1)}</em>", text)
+    text = _EM_RE.sub(lambda m: f"<em>{m.group(1)}</em>", text)
+    text = _STRIKE_RE.sub(lambda m: f"<s>{m.group(1)}</s>", text)
+
+    def link_repl(match: re.Match[str]) -> str:
+        label, href = match.group(1), match.group(2)
+        safe_label = label
+        safe_href = href
+        try:
+            safe_label = html.escape(label)
+        except Exception:  # pragma: no cover - defensive
+            safe_label = label
+        try:
+            safe_href = html.escape(href, quote=True)
+        except Exception:  # pragma: no cover - defensive
+            safe_href = href
+        if href.lower().startswith("javascript:"):
+            return safe_label
+        return f'<a href="{safe_href}">{safe_label}</a>'
+
+    text = _LINK_RE.sub(link_repl, text)
+    return text
+
+
+def _markdown_to_html(markdown_text: str) -> str:
+    markdown_text = _strip_markdown(markdown_text)
+    parts: List[str] = []
+    last_index = 0
+    for match in _CODE_FENCE_RE.finditer(markdown_text):
+        start, end = match.span()
+        before = markdown_text[last_index:start]
+        if before:
+            parts.extend(_render_lines(before))
+        code_content = match.group(1)
+        safe_code = html.escape(code_content.strip("\n"))
+        parts.append(f"<pre><code>{safe_code}</code></pre>")
+        last_index = end
+    remaining = markdown_text[last_index:]
+    if remaining:
+        parts.extend(_render_lines(remaining))
+    return "".join(parts)
+
+
+def _render_lines(block: str) -> Iterable[str]:
+    lines = block.split("\n")
+    rendered: List[str] = []
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            if rendered and not rendered[-1].endswith("<br>"):
+                rendered.append("<br>")
+            continue
+        if line.startswith(('- ', '* ')):
+            content = _escape_inline(line[2:].strip())
+            rendered.append(f"• {content}<br>")
+            continue
+        if line.startswith('>'):
+            content = _escape_inline(line[1:].strip())
+            rendered.append(f"<blockquote>{content}</blockquote>")
+            continue
+        rendered.append(f"{_escape_inline(line)}<br>")
+    return rendered
+
+
+def render_pm_html(md_or_text: str) -> str:
+    """Convert Markdown/HTML string to sanitized Telegram-ready HTML."""
+
+    if not md_or_text:
+        return ""
+    try:
+        if "<" in md_or_text and ">" in md_or_text:
+            raw_html = md_or_text
+        else:
+            raw_html = _markdown_to_html(md_or_text)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("pm.render.error", exc_info=exc)
+        raw_html = html.escape(md_or_text)
+
+    raw_html = raw_html.replace("<br />", "<br>").replace("<br/>", "<br>")
+    sanitizer = _HTMLSanitizer()
+    sanitizer.feed(raw_html)
+    sanitizer.close()
+    result = sanitizer.get_html()
+    if not result:
+        return ""
+    return result
+
+
+def safe_lines(items: Iterable[str | None]) -> str:
+    """Join text fragments ensuring safe new line placement."""
+
+    parts: List[str] = []
+    for item in items:
+        if not item:
+            continue
+        text = str(item).strip()
+        if not text:
+            continue
+        parts.append(text)
+    return "\n".join(parts)
+
+
+def html_to_plain(text: str) -> str:
+    """Convert sanitized HTML into a readable plain-text string."""
+
+    if not text:
+        return ""
+    normalized = text.replace("<br />", "<br>").replace("<br/>", "<br>")
+    normalized = normalized.replace("<pre><code>", "\n").replace("</code></pre>", "\n")
+    normalized = re.sub(r"<br>\s*", "\n", normalized)
+    normalized = re.sub(r"<[^>]+>", "", normalized)
+    return html.unescape(normalized).strip()
+
+
+__all__ = ["render_pm_html", "safe_lines", "html_to_plain"]
+

--- a/utils/safe_send.py
+++ b/utils/safe_send.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+import html
+import logging
+import re
 from typing import Iterable, Optional
 
 from telegram import Bot, Message
 from telegram.constants import ParseMode
+from telegram.error import BadRequest
+
+from utils.html_render import html_to_plain
+
+logger = logging.getLogger(__name__)
 
 
 def _chunk_text(text: str, *, limit: int) -> Iterable[str]:
@@ -58,4 +66,40 @@ async def safe_send(
     return last_message
 
 
-__all__ = ["safe_send"]
+async def send_html_with_fallback(
+    bot: Bot,
+    chat_id: int,
+    text: str,
+    *,
+    reply_markup=None,
+    chunk_limit: int = 3500,
+) -> Optional[Message]:
+    """Send HTML text and fall back to plain text on parse errors."""
+
+    try:
+        return await safe_send(
+            bot,
+            chat_id,
+            text,
+            reply_markup=reply_markup,
+            chunk_limit=chunk_limit,
+        )
+    except BadRequest as exc:
+        message = str(exc).lower()
+        if "can't parse entities" not in message and "parse entities" not in message:
+            raise
+        logger.warning("pm.html_fallback", extra={"exc": repr(exc)})
+        logger.info("pm.render.fallback")
+        plain = html_to_plain(text)
+        if not plain:
+            plain = re.sub(r"<[^>]+>", "", text)
+            plain = html.unescape(plain)
+        return await bot.send_message(
+            chat_id=chat_id,
+            text=plain,
+            disable_web_page_preview=True,
+            reply_markup=reply_markup,
+        )
+
+
+__all__ = ["safe_send", "send_html_with_fallback"]


### PR DESCRIPTION
## Summary
- add a dedicated HTML renderer with Markdown support and safe line joining to normalize Prompt-Master output
- restructure prompt payloads and handler flow to use sanitized markup, logging, and message deletion only after successful delivery
- extend safe send utilities and Prompt-Master tests to cover fallback paths, keyboards, and card snapshots

## Testing
- pytest tests/test_prompt_master_ptb.py

------
https://chatgpt.com/codex/tasks/task_e_68d84ab26ab88322be99b8a14d5da2cb