### PR TITLE
Improve Prompt-Master sanitization and result handling

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6805,24 +6805,25 @@ async def prompt_master_insert_callback(update: Update, ctx: ContextTypes.DEFAUL
         return
 
     s = state(ctx)
+    body_text = str(prompt_obj.get("card_text") or prompt_obj.get("copy_text") or "")
     if engine in {"veo", "animate"}:
-        await set_veo_card_prompt(chat_id, prompt_obj.body, ctx)
+        await set_veo_card_prompt(chat_id, body_text, ctx)
         await query.answer("Промпт вставлен в карточку VEO")
         return
     if engine == "mj":
-        s["last_prompt"] = prompt_obj.body
+        s["last_prompt"] = body_text
         s["_last_text_mj"] = None
         await show_mj_prompt_card(chat_id, ctx)
         await query.answer("Промпт вставлен в карточку Midjourney")
         return
     if engine == "banana":
-        s["last_prompt"] = prompt_obj.body
+        s["last_prompt"] = body_text
         s["_last_text_banana"] = None
         await show_banana_card(chat_id, ctx)
         await query.answer("Промпт вставлен в карточку Banana")
         return
     if engine == "suno":
-        s["suno_lyrics"] = prompt_obj.body
+        s["suno_lyrics"] = body_text
         s["suno_waiting_field"] = None
         s["_last_text_suno"] = None
         await refresh_suno_card(ctx, chat_id, s, price=PRICE_SUNO)

--- a/prompt_master/__init__.py
+++ b/prompt_master/__init__.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from .generator import (
     Engine,
-    PromptPayload,
+    PMResult,
     build_animate_prompt,
     build_banana_prompt,
     build_mj_prompt,
@@ -31,7 +31,7 @@ else:  # pragma: no cover - unexpected environment
 
 __all__ = [
     "Engine",
-    "PromptPayload",
+    "PMResult",
     "build_prompt",
     "build_veo_prompt",
     "build_mj_prompt",

--- a/utils/html_render.py
+++ b/utils/html_render.py
@@ -12,22 +12,18 @@ logger = logging.getLogger(__name__)
 
 _ALLOWED_TAGS = {
     "b",
-    "strong",
     "i",
-    "em",
     "u",
-    "span",
     "a",
     "code",
     "pre",
     "s",
-    "tg-spoiler",
     "blockquote",
     "br",
 }
 _ALLOWED_ATTRS = {"a": {"href"}}
 _SELF_CLOSING_TAGS = {"br"}
-_BLOCK_TAGS = {"pre", "blockquote", "tg-spoiler"}
+_BLOCK_TAGS = {"pre", "blockquote"}
 
 _CODE_FENCE_RE = re.compile(r"```(?:[a-z0-9_-]+)?\n(.*?)```", re.IGNORECASE | re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"(?<!\\)`([^`]+?)`")
@@ -163,10 +159,10 @@ def _escape_inline(text: str) -> str:
         safe_code = html.escape(code)
         text = text.replace(f"@@CODE{idx}@@", f"<code>{safe_code}</code>")
 
-    text = _BOLD_RE.sub(lambda m: f"<strong>{m.group(1)}</strong>", text)
+    text = _BOLD_RE.sub(lambda m: f"<b>{m.group(1)}</b>", text)
     text = _STRONG_RE.sub(lambda m: f"<u>{m.group(1)}</u>", text)
-    text = _ITALIC_RE.sub(lambda m: f"<em>{m.group(1)}</em>", text)
-    text = _EM_RE.sub(lambda m: f"<em>{m.group(1)}</em>", text)
+    text = _ITALIC_RE.sub(lambda m: f"<i>{m.group(1)}</i>", text)
+    text = _EM_RE.sub(lambda m: f"<i>{m.group(1)}</i>", text)
     text = _STRIKE_RE.sub(lambda m: f"<s>{m.group(1)}</s>", text)
 
     def link_repl(match: re.Match[str]) -> str:


### PR DESCRIPTION
## Summary
- add a sanitize_html utility and enforce it across safe_send, edits, and status messaging to stop <br/> parse errors
- refactor Prompt-Master generators to return typed PMResult payloads and update handlers to use the new structure with safer status/edit flows and plain-text copy responses
- refresh bot card insertion logic and pytest coverage to validate new prompt caching, copy, and rendering behaviors

## Testing
- pytest tests/test_prompt_master_ptb.py

------
https://chatgpt.com/codex/tasks/task_e_68d852105ce0832294941dd8f8585279