### PR TITLE
Update Suno integration for new API endpoints and callbacks

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4116,6 +4116,7 @@ async def _suno_issue_refund(
     reply_markup: Optional[InlineKeyboardMarkup] = None,
     reply_to: Optional["telegram.Message"] = None,
     req_id: Optional[str] = None,
+    user_message: Optional[str] = None,
 ) -> None:
     meta = dict(base_meta or {})
     if task_id:
@@ -4175,10 +4176,11 @@ async def _suno_issue_refund(
     await refresh_suno_card(ctx, chat_id, s, price=PRICE_SUNO)
     await refresh_balance_card_if_open(user_id, chat_id, ctx=ctx, state_dict=s)
 
+    message = user_message or f"❌ Не удалось сгенерировать. Средства возвращены (+{PRICE_SUNO}💎)."
     await _suno_notify(
         ctx,
         chat_id,
-        f"❌ Не удалось сгенерировать. Средства возвращены (+{PRICE_SUNO}💎).",
+        message,
         req_id=req_id,
         reply_to=reply_to,
         reply_markup=reply_markup,
@@ -4346,7 +4348,8 @@ async def _launch_suno_generation(
         )
 
         notify_text = (
-            f"✅ Списано {PRICE_SUNO}💎 (req {req_label}). Задача создана и отправлена в Suno. "
+            f"✅ Списано {PRICE_SUNO}💎 (req {req_label}).\n"
+            "Задача создана, ждём результат…\n"
             "Как только получим коллбек — пришлю аудио/ссылки."
         )
         notify_exc: Optional[Exception] = None
@@ -4517,6 +4520,10 @@ async def _launch_suno_generation(
                 reason="suno:refund:create_err",
                 req_id=req_id,
                 reply_to=reply_to,
+                user_message=(
+                    "Ошибка API Suno: не удалось создать задачу. Попробуйте другой запрос.\n"
+                    f"Средства возвращены (+{PRICE_SUNO}💎)."
+                ),
             )
             return
 

--- a/settings.py
+++ b/settings.py
@@ -138,8 +138,8 @@ def _get_env(name: str, default: Optional[str] = None) -> Optional[str]:
     return value or default
 
 
-SUNO_GEN_PATH = _get_env("SUNO_GEN_PATH", "/api/v1/generate/music")
-SUNO_TASK_STATUS_PATH = _get_env("SUNO_TASK_STATUS_PATH", "/api/v1/generate/record-info")
+SUNO_GEN_PATH = _get_env("SUNO_GEN_PATH", "/api/v1/suno/generate/music")
+SUNO_TASK_STATUS_PATH = _get_env("SUNO_TASK_STATUS_PATH", "/api/v1/suno/record-info")
 SUNO_WAV_PATH = _get_env("SUNO_WAV_PATH", "/api/v1/wav/generate")
 SUNO_WAV_INFO_PATH = _get_env("SUNO_WAV_INFO_PATH", "/api/v1/wav/record-info")
 SUNO_MP4_PATH = _get_env("SUNO_MP4_PATH", "/api/v1/mp4/generate")
@@ -147,7 +147,7 @@ SUNO_MP4_INFO_PATH = _get_env("SUNO_MP4_INFO_PATH", "/api/v1/mp4/record-info")
 SUNO_STEM_PATH = _get_env("SUNO_STEM_PATH", "/api/v1/vocal-removal/generate")
 SUNO_STEM_INFO_PATH = _get_env("SUNO_STEM_INFO_PATH", "/api/v1/vocal-removal/record-info")
 SUNO_LYRICS_PATH = _get_env("SUNO_LYRICS_PATH", "/api/v1/generate/get-timestamped-lyrics")
-SUNO_UPLOAD_EXTEND_PATH = _get_env("SUNO_UPLOAD_EXTEND_PATH", "/api/v1/generate/upload-extend")
+SUNO_UPLOAD_EXTEND_PATH = _get_env("SUNO_UPLOAD_EXTEND_PATH", "/api/v1/suno/upload-extend")
 SUNO_COVER_INFO_PATH = _get_env("SUNO_COVER_INFO_PATH", "/api/v1/suno/cover/record-info")
 SUNO_INSTR_PATH = _get_env("SUNO_INSTR_PATH", "/api/v1/generate/add-instrumental")
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -101,7 +101,7 @@ def test_suno_client_retries(monkeypatch, requests_mock, status_codes, expected_
             responses.append({"status_code": 200, "json": {"task_id": "ok"}})
         else:
             responses.append({"status_code": status, "json": {"message": "err"}})
-    requests_mock.post("https://example.com/suno-api/generate", responses)
+    requests_mock.post("https://example.com/api/v1/suno/generate/music", responses)
     suno_client = SunoClient(base_url="https://example.com", token="tkn", max_retries=3)
     if status_codes[0] == 403:
         with pytest.raises(SunoAPIError):


### PR DESCRIPTION
## Summary
- switch Suno client and settings to the /api/v1/suno/* endpoints and ensure music requests always send input_text with a sensible default
- improve Suno callback handling/logging, propagate request IDs, and update user messaging for enqueue success/failure
- extend the Suno test suite for the new payload shape, status polling, and end-to-end callback handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d928d3ec7c8322b3130ca9b5d60344