### PR TITLE
Implement unified text input router and safe card updates

### DIFF
--- a/handlers/prompt_master_handler.py
+++ b/handlers/prompt_master_handler.py
@@ -31,6 +31,7 @@ from prompt_master import (
 )
 from utils.html_render import html_to_plain, render_pm_html, safe_lines
 from utils.safe_send import sanitize_html, safe_send, send_html_with_fallback
+from utils.input_state import get_wait_state
 
 logger = logging.getLogger(__name__)
 
@@ -501,6 +502,10 @@ async def prompt_master_callback(update: Update, context: ContextTypes.DEFAULT_T
 
 
 async def prompt_master_text_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    user = getattr(update, "effective_user", None)
+    if user and get_wait_state(user.id):
+        return
+
     message = update.message
     if message is None or not isinstance(message.text, str):
         return

--- a/tests/test_input_flow.py
+++ b/tests/test_input_flow.py
@@ -101,7 +101,7 @@ def test_wait_state_updates_veo_prompt() -> None:
     assert state_dict["last_prompt"] == "Test prompt"
     assert calls and calls[-1][0] == 777
     assert not get_wait_state(user_id)
-    assert message.replies and "Сейчас" in message.replies[-1]
+    assert message.replies and message.replies[-1] == "✅ Принято"
 
 
 def test_wait_state_suno_title_updates_card() -> None:
@@ -134,7 +134,7 @@ def test_wait_state_suno_title_updates_card() -> None:
     assert suno_state.title == "My Song"
     assert refreshed and refreshed[-1][0] == 888
     assert not get_wait_state(user_id)
-    assert message.replies and "My Song" in message.replies[-1]
+    assert message.replies and message.replies[-1] == "✅ Принято"
 
 
 def test_safe_edit_resends_after_not_modified() -> None:

--- a/tests/test_text_router.py
+++ b/tests/test_text_router.py
@@ -1,0 +1,272 @@
+import asyncio
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from telegram.error import BadRequest
+from telegram.ext import ApplicationHandlerStop
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("SUNO_API_BASE", "https://example.com")
+os.environ.setdefault("SUNO_API_TOKEN", "token")
+os.environ.setdefault("SUNO_CALLBACK_URL", "https://callback.example")
+os.environ.setdefault("SUNO_CALLBACK_SECRET", "secret")
+os.environ.setdefault("TELEGRAM_TOKEN", "dummy-token")
+os.environ.setdefault("KIE_API_KEY", "test-key")
+os.environ.setdefault("KIE_BASE_URL", "https://example.com")
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
+os.environ.setdefault("LEDGER_BACKEND", "memory")
+os.environ.setdefault("LOG_JSON", "false")
+os.environ.setdefault("LOG_LEVEL", "WARNING")
+
+import bot as bot_module
+from handlers import prompt_master_handle_text
+from utils.input_state import (
+    WaitInputState,
+    WaitKind,
+    clear_wait_state,
+    get_wait_state,
+    set_wait_state,
+)
+from utils.suno_state import load as load_suno_state
+from utils.telegram_safe import safe_edit_message
+
+
+class DummyMessage:
+    def __init__(self, chat_id: int, text: str) -> None:
+        self.chat_id = chat_id
+        self.text = text
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **_: object) -> None:  # type: ignore[override]
+        self.replies.append(text)
+
+
+class NeutralBot:
+    def __init__(self) -> None:
+        self.edit_calls: list[dict[str, object]] = []
+        self.reply_markup_calls: list[dict[str, object]] = []
+        self.sent: list[dict[str, object]] = []
+
+    async def edit_message_text(self, **kwargs):  # type: ignore[override]
+        self.edit_calls.append(kwargs)
+        return SimpleNamespace(message_id=kwargs.get("message_id"))
+
+    async def edit_message_reply_markup(self, **kwargs):  # type: ignore[override]
+        self.reply_markup_calls.append(kwargs)
+        return SimpleNamespace(message_id=kwargs.get("message_id"))
+
+    async def send_message(self, **kwargs):  # type: ignore[override]
+        self.sent.append(kwargs)
+        return SimpleNamespace(message_id=kwargs.get("message_id", 1000))
+
+
+class NotModifiedBot(NeutralBot):
+    async def edit_message_text(self, **kwargs):  # type: ignore[override]
+        self.edit_calls.append(kwargs)
+        raise BadRequest("Message is not modified")
+
+    async def edit_message_reply_markup(self, **kwargs):  # type: ignore[override]
+        self.reply_markup_calls.append(kwargs)
+        raise BadRequest("Message is not modified")
+
+
+def _run(coro):
+    try:
+        asyncio.run(coro)
+    except ApplicationHandlerStop:
+        pass
+
+
+def test_router_updates_veo_prompt() -> None:
+    ctx = SimpleNamespace(bot=None, user_data={})
+    state_dict = bot_module.state(ctx)
+    state_dict["last_ui_msg_id_veo"] = 123
+    user_id = 101
+    wait_state = WaitInputState(kind=WaitKind.VEO_PROMPT, card_msg_id=123, chat_id=777, meta={})
+    set_wait_state(user_id, wait_state)
+
+    calls: list[int] = []
+    original_show = bot_module.show_veo_card
+
+    async def fake_show(chat_id: int, ctx_param):
+        calls.append(chat_id)
+        state_dict["last_ui_msg_id_veo"] = 456
+
+    bot_module.show_veo_card = fake_show  # type: ignore[assignment]
+
+    message = DummyMessage(chat_id=777, text=" Test prompt ")
+    update = SimpleNamespace(effective_message=message, effective_user=SimpleNamespace(id=user_id))
+
+    try:
+        _run(bot_module.handle_text_input(update, ctx))
+    finally:
+        bot_module.show_veo_card = original_show  # type: ignore[assignment]
+        clear_wait_state(user_id)
+
+    assert state_dict["last_prompt"] == "Test prompt"
+    assert calls == [777]
+    assert not get_wait_state(user_id)
+    assert message.replies == ["✅ Принято"]
+
+
+def test_router_updates_mj_prompt() -> None:
+    ctx = SimpleNamespace(bot=None, user_data={})
+    state_dict = bot_module.state(ctx)
+    state_dict["last_ui_msg_id_mj"] = 999
+    user_id = 202
+    wait_state = WaitInputState(kind=WaitKind.MJ_PROMPT, card_msg_id=999, chat_id=888, meta={})
+    set_wait_state(user_id, wait_state)
+
+    calls: list[int] = []
+    original_show = bot_module.show_mj_prompt_card
+
+    async def fake_show(chat_id: int, ctx_param):
+        calls.append(chat_id)
+        state_dict["last_ui_msg_id_mj"] = 1001
+
+    bot_module.show_mj_prompt_card = fake_show  # type: ignore[assignment]
+
+    message = DummyMessage(chat_id=888, text="Midjourney idea")
+    update = SimpleNamespace(effective_message=message, effective_user=SimpleNamespace(id=user_id))
+
+    try:
+        _run(bot_module.handle_text_input(update, ctx))
+    finally:
+        bot_module.show_mj_prompt_card = original_show  # type: ignore[assignment]
+        clear_wait_state(user_id)
+
+    assert state_dict["last_prompt"] == "Midjourney idea"
+    assert calls == [888]
+    assert not get_wait_state(user_id)
+    assert message.replies == ["✅ Принято"]
+
+
+def test_router_updates_suno_fields() -> None:
+    ctx = SimpleNamespace(bot=None, user_data={})
+    state_dict = bot_module.state(ctx)
+
+    refreshed: list[int] = []
+    original_refresh = bot_module.refresh_suno_card
+
+    async def fake_refresh(ctx_param, chat_id: int, state_payload: dict[str, object], *, price: int):
+        refreshed.append(chat_id)
+        state_payload["last_ui_msg_id_suno"] = 321
+        return 321
+
+    bot_module.refresh_suno_card = fake_refresh  # type: ignore[assignment]
+
+    try:
+        user_id = 303
+        # Title
+        set_wait_state(
+            user_id,
+            WaitInputState(kind=WaitKind.SUNO_TITLE, card_msg_id=0, chat_id=444, meta={}),
+        )
+        message = DummyMessage(chat_id=444, text="  My Song  ")
+        update = SimpleNamespace(effective_message=message, effective_user=SimpleNamespace(id=user_id))
+        _run(bot_module.handle_text_input(update, ctx))
+        suno_state = load_suno_state(ctx)
+        assert suno_state.title == "My Song"
+        assert message.replies == ["✅ Принято"]
+
+        # Style
+        set_wait_state(
+            user_id,
+            WaitInputState(kind=WaitKind.SUNO_STYLE, card_msg_id=0, chat_id=444, meta={}),
+        )
+        style_message = DummyMessage(chat_id=444, text="Epic cinematic score")
+        update_style = SimpleNamespace(
+            effective_message=style_message,
+            effective_user=SimpleNamespace(id=user_id),
+        )
+        _run(bot_module.handle_text_input(update_style, ctx))
+        suno_state = load_suno_state(ctx)
+        assert suno_state.style == "Epic cinematic score"
+        assert style_message.replies == ["✅ Принято"]
+
+        # Lyrics
+        set_wait_state(
+            user_id,
+            WaitInputState(kind=WaitKind.SUNO_LYRICS, card_msg_id=0, chat_id=444, meta={}),
+        )
+        lyrics_message = DummyMessage(chat_id=444, text="Line one\nLine two")
+        update_lyrics = SimpleNamespace(
+            effective_message=lyrics_message,
+            effective_user=SimpleNamespace(id=user_id),
+        )
+        _run(bot_module.handle_text_input(update_lyrics, ctx))
+        suno_state = load_suno_state(ctx)
+        assert suno_state.lyrics == "Line one\nLine two"
+        assert lyrics_message.replies == ["✅ Принято"]
+    finally:
+        bot_module.refresh_suno_card = original_refresh  # type: ignore[assignment]
+        clear_wait_state(303)
+
+    assert refreshed == [444, 444, 444]
+
+
+def test_router_handles_repeated_text_without_error() -> None:
+    bot = NotModifiedBot()
+    ctx = SimpleNamespace(bot=bot, user_data={})
+    state_dict = bot_module.state(ctx)
+    state_dict["last_ui_msg_id_veo"] = 555
+    state_dict["_last_text_veo"] = None
+    state_dict["last_prompt"] = "Same"
+
+    user_id = 404
+    set_wait_state(
+        user_id,
+        WaitInputState(kind=WaitKind.VEO_PROMPT, card_msg_id=555, chat_id=999, meta={}),
+    )
+
+    message = DummyMessage(chat_id=999, text="Same")
+    update = SimpleNamespace(effective_message=message, effective_user=SimpleNamespace(id=user_id))
+
+    try:
+        _run(bot_module.handle_text_input(update, ctx))
+    finally:
+        clear_wait_state(user_id)
+
+    assert bot.edit_calls  # attempted edit
+    assert bot.reply_markup_calls  # attempted markup update fallback
+    assert message.replies == ["✅ Принято"]
+
+
+def test_wait_state_blocks_prompt_master() -> None:
+    ctx = SimpleNamespace(bot=None, user_data={})
+    message = DummyMessage(chat_id=111, text="Prompt text")
+    update = SimpleNamespace(effective_message=message, message=message, effective_user=SimpleNamespace(id=505))
+
+    set_wait_state(505, WaitInputState(kind=WaitKind.VEO_PROMPT, card_msg_id=0, chat_id=111, meta={}))
+
+    try:
+        asyncio.run(prompt_master_handle_text(update, ctx))
+    finally:
+        clear_wait_state(505)
+
+    assert "pm_state" not in ctx.user_data
+    assert message.replies == []
+
+
+def test_safe_edit_message_handles_not_modified() -> None:
+    bot = NotModifiedBot()
+    ctx = SimpleNamespace(bot=bot)
+
+    markup = SimpleNamespace()
+    result = asyncio.run(
+        safe_edit_message(
+            ctx,
+            chat_id=1,
+            message_id=10,
+            new_text="Hello",
+            reply_markup=markup,
+        )
+    )
+
+    assert result is False
+    assert bot.edit_calls and bot.reply_markup_calls

--- a/utils/telegram_safe.py
+++ b/utils/telegram_safe.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from telegram.constants import ParseMode
+from telegram.error import BadRequest
+
+
+_logger = logging.getLogger("telegram-safe")
+
+
+async def safe_edit_message(
+    ctx: Any,
+    chat_id: int,
+    message_id: int,
+    new_text: Optional[str] = None,
+    reply_markup: Any = None,
+    *,
+    parse_mode: ParseMode = ParseMode.HTML,
+    disable_web_page_preview: bool = True,
+) -> bool:
+    """Safely edit a Telegram message without crashing on no-op updates.
+
+    Returns ``True`` if the message text or markup was edited. ``False`` means the
+    content was already up to date. Other exceptions are propagated to let the
+    caller decide how to recover (e.g. resend the card).
+    """
+
+    bot = getattr(ctx, "bot", None)
+    if bot is None:
+        raise RuntimeError("Context has no bot instance")
+
+    if new_text is None:
+        text_payload = ""
+    else:
+        text_payload = str(new_text)
+
+    try:
+        await bot.edit_message_text(
+            chat_id=chat_id,
+            message_id=message_id,
+            text=text_payload,
+            reply_markup=reply_markup,
+            parse_mode=parse_mode,
+            disable_web_page_preview=disable_web_page_preview,
+        )
+        return True
+    except BadRequest as exc:
+        lowered = str(exc).lower()
+        if "message is not modified" not in lowered:
+            raise
+        _logger.debug(
+            "safe_edit_message.noop",
+            extra={"chat_id": chat_id, "message_id": message_id},
+        )
+        if reply_markup is None:
+            return False
+        try:
+            await bot.edit_message_reply_markup(
+                chat_id=chat_id,
+                message_id=message_id,
+                reply_markup=reply_markup,
+            )
+        except BadRequest as markup_exc:
+            markup_lowered = str(markup_exc).lower()
+            if "message is not modified" not in markup_lowered:
+                raise
+            _logger.debug(
+                "safe_edit_message.reply_markup_noop",
+                extra={"chat_id": chat_id, "message_id": message_id},
+            )
+            return False
+        return True


### PR DESCRIPTION
## Summary
- add a top-level wait-state text router with consistent acknowledgements and handler ordering
- harden card updates through a reusable safe edit helper and guard Prompt-Master text handling on active waits
- add regression coverage for VEO, MJ, Suno, and safe-edit flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9667d4b0883228d63ab2eabadb1da