### PR TITLE
Centralize wait-state routing for Banana inputs

### DIFF
--- a/utils/input_state.py
+++ b/utils/input_state.py
@@ -20,6 +20,7 @@ _KEY_TMPL = f"{REDIS_PREFIX}:wait-input:{{user_id}}"
 
 class WaitKind(str, Enum):
     VEO_PROMPT = "veo_prompt"
+    BANANA_PROMPT = "banana_prompt"
     SUNO_TITLE = "suno_title"
     SUNO_STYLE = "suno_style"
     SUNO_LYRICS = "suno_lyrics"
@@ -92,10 +93,9 @@ def set_wait_state(user_id: int, state: WaitInputState) -> None:
     else:
         _memory_store[int(user_id)] = state.to_dict()
     _logger.info(
-        "WAIT_SET kind=%s user_id=%s chat=%s card=%s",
+        "WAIT_SET kind=%s user_id=%s card=%s",
         state.kind.value,
         user_id,
-        state.chat_id,
         state.card_msg_id,
     )
 


### PR DESCRIPTION
## Summary
- add a dedicated BANANA wait kind and align wait-state logging with the new format
- route Banana prompt collection through the shared wait-state handler when switching modes and editing the card
- extend the text routing tests to cover Banana wait flows alongside existing Suno/Veo/MJ cases

## Testing
- pytest tests/test_text_router.py tests/test_input_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68d970ab92d88322b860cd36a5ab615d