### PR TITLE
Add input state helpers and safe Telegram edit utility

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -109,6 +109,7 @@ from utils.input_state import (
     clear_wait_state,
     clear_wait,
     get_wait,
+    is_command_text,
     refresh_card_pointer,
     set_wait,
     touch_wait,
@@ -2737,7 +2738,7 @@ def is_command_or_button(message: Message) -> bool:
     stripped = text.strip()
     if not stripped:
         return False
-    if stripped.startswith("/"):
+    if is_command_text(stripped):
         return True
     return stripped in _KNOWN_BUTTON_LABELS
 

--- a/utils/telegram_utils.py
+++ b/utils/telegram_utils.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Optional
+
+from telegram import InlineKeyboardMarkup
+from telegram.error import BadRequest
+
+
+_last_hash: dict[str, str] = {}
+
+
+def _payload_hash(text: str, reply_markup: Optional[InlineKeyboardMarkup]) -> str:
+    markup_payload = reply_markup.to_dict() if reply_markup else None
+    raw = json.dumps({"t": text or "", "rm": markup_payload}, ensure_ascii=False, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def safe_edit(
+    bot,
+    chat_id: int,
+    message_id: int,
+    text: str,
+    reply_markup: Optional[InlineKeyboardMarkup] = None,
+):
+    """Edit a Telegram message only when payload changes."""
+
+    key = f"{chat_id}:{message_id}"
+    payload_hash = _payload_hash(text, reply_markup)
+    if _last_hash.get(key) == payload_hash:
+        return
+    try:
+        return bot.edit_message_text(
+            chat_id=chat_id,
+            message_id=message_id,
+            text=text,
+            reply_markup=reply_markup,
+            parse_mode="HTML",
+            disable_web_page_preview=True,
+        )
+    except BadRequest as exc:
+        if "not modified" in str(exc).lower():
+            _last_hash[key] = payload_hash
+            return
+        raise
+    else:
+        _last_hash[key] = payload_hash


### PR DESCRIPTION
## Summary
- extend the input-state module with reusable command filtering helpers and an in-memory chat wait registry
- add a safe_edit helper for Telegram message edits to avoid redundant API calls
- reuse the new command detection helper in the bot router to prevent command texts from being treated as input

## Testing
- pytest tests/test_input_flow.py
- pytest tests/test_text_router.py

------
https://chatgpt.com/codex/tasks/task_e_68d98c0252c48322a13fc1f3fec57844