### PR TITLE
Stabilize Telegram command and button handling

### DIFF
--- a/tests/test_input_flow.py
+++ b/tests/test_input_flow.py
@@ -83,7 +83,7 @@ def test_wait_state_updates_veo_prompt() -> None:
 
     original_show = bot_module.show_veo_card
 
-    async def fake_show(chat_id: int, ctx_param):
+    async def fake_show(chat_id: int, ctx_param, *, force_new: bool = False):
         calls.append((chat_id, ctx_param))
         state_dict["last_ui_msg_id_veo"] = 654
 
@@ -117,7 +117,7 @@ def test_wait_state_updates_banana_prompt() -> None:
 
     original_show = bot_module.show_banana_card
 
-    async def fake_show(chat_id: int, ctx_param):
+    async def fake_show(chat_id: int, ctx_param, *, force_new: bool = False):
         calls.append((chat_id, ctx_param))
         state_dict["last_ui_msg_id_banana"] = 222
 
@@ -149,7 +149,15 @@ def test_wait_state_suno_title_updates_card() -> None:
     original_refresh = bot_module.refresh_suno_card
     refreshed: list[tuple[int, dict[str, object]]] = []
 
-    async def fake_refresh(ctx_param, chat_id: int, state_dict_param: dict[str, object], *, price: int, state_key: str = "last_ui_msg_id_suno"):
+    async def fake_refresh(
+        ctx_param,
+        chat_id: int,
+        state_dict_param: dict[str, object],
+        *,
+        price: int,
+        state_key: str = "last_ui_msg_id_suno",
+        force_new: bool = False,
+    ):
         refreshed.append((chat_id, state_dict_param))
         state_dict_param[state_key] = 777
         return 777


### PR DESCRIPTION
## Summary
- unify button and command detection with normalized helpers and aliases to avoid capturing menu inputs as user prompts
- extend card utilities to refresh safely with `force_new`, and wire balance, Suno, and image flows to use consistent card rendering and MJ↔Banana switching hints
- improve input registry logging/TTL handling and expand tests across balance, Suno, prompt-master, and engine switch scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9a12553e48322a7f231f6d4ac184b