### PR TITLE
Sanitize Telegram HTML and avoid prompt leakage

### DIFF
--- a/tests/test_prompt_leakage.py
+++ b/tests/test_prompt_leakage.py
@@ -48,10 +48,10 @@ def test_card_prompt_empty_on_open() -> None:
     state["aspect"] = "16:9"
 
     veo_text = bot_module.veo_card_text(state)
-    assert "<code></code>" in veo_text
+    assert "<code>—</code>" in veo_text
 
     mj_text = bot_module._mj_prompt_card_text("16:9", state.get("last_prompt"))
-    assert "Последний промпт" not in mj_text
+    assert "Промпт: <i>—</i>" in mj_text
 
 
 def test_menu_labels_not_saved_as_prompt() -> None:

--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from telegram.constants import ParseMode
+
+from telegram_utils import sanitize_html, safe_send
+
+
+def test_sanitize_html_replaces_br_and_strips_tags() -> None:
+    raw = "Hello<br/>world<br>!<div><span>keep</span> <b>bold</b></div><script>alert(1)</script><tg-spoiler>spoiler</tg-spoiler><"
+    sanitized = sanitize_html(raw)
+    assert "Hello\nworld\n!" in sanitized
+    assert "<b>bold</b>" in sanitized
+    assert "tg-spoiler" in sanitized
+    assert "<span>" not in sanitized
+    assert "script" not in sanitized
+    assert "keep" in sanitized
+    assert "&lt;" in sanitized
+
+
+def test_safe_send_sanitizes_html_payload() -> None:
+    captured: list[dict] = []
+
+    async def fake_send(**kwargs):
+        captured.append(kwargs)
+        return object()
+
+    asyncio.run(
+        safe_send(
+            fake_send,
+            method_name="send_message",
+            kind="test",
+            chat_id=1,
+            text="line1<br/>line2",
+            parse_mode=ParseMode.HTML,
+        )
+    )
+
+    assert captured
+    payload = captured[0]
+    assert payload["text"] == "line1\nline2"


### PR DESCRIPTION
## Summary
- add a Telegram HTML sanitizer and apply it from safe_send/safe_edit to prevent unsupported tags
- switch FAQ rendering to the safe wrappers and show placeholders in the VEO/MJ cards until users enter text
- harden wait-state input handling against button labels and cover the changes with new tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9b1bcf75c832290778e4efef40b66