### PR TITLE
Improve Suno enqueue reliability and clean prompt cards

### DIFF
--- a/tests/test_card_prompts.py
+++ b/tests/test_card_prompts.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("SUNO_API_BASE", "https://example.com")
+os.environ.setdefault("SUNO_API_TOKEN", "token")
+os.environ.setdefault("SUNO_CALLBACK_URL", "https://callback.example")
+os.environ.setdefault("SUNO_CALLBACK_SECRET", "secret")
+os.environ.setdefault("TELEGRAM_TOKEN", "dummy-token")
+os.environ.setdefault("KIE_API_KEY", "test-key")
+os.environ.setdefault("KIE_BASE_URL", "https://example.com")
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
+os.environ.setdefault("LEDGER_BACKEND", "memory")
+os.environ.setdefault("LOG_JSON", "false")
+os.environ.setdefault("LOG_LEVEL", "WARNING")
+
+import bot as bot_module
+
+
+def test_veo_card_prompt_starts_empty() -> None:
+    ctx = SimpleNamespace(bot=None, user_data={})
+    state = bot_module.state(ctx)
+    veo_text = bot_module.veo_card_text(state)
+    assert "<code>—</code>" not in veo_text
+    assert "<code> </code>" in veo_text
+
+
+def test_mj_card_prompt_starts_empty() -> None:
+    ctx = SimpleNamespace(bot=None, user_data={})
+    state = bot_module.state(ctx)
+    mj_text = bot_module._mj_prompt_card_text("16:9", state.get("last_prompt"))
+    assert "Промпт: <i>—</i>" not in mj_text
+    assert "Промпт: <i> </i>" in mj_text

--- a/tests/test_prompt_leakage.py
+++ b/tests/test_prompt_leakage.py
@@ -48,10 +48,12 @@ def test_card_prompt_empty_on_open() -> None:
     state["aspect"] = "16:9"
 
     veo_text = bot_module.veo_card_text(state)
-    assert "<code>—</code>" in veo_text
+    assert "<code>—</code>" not in veo_text
+    assert "<code> </code>" in veo_text
 
     mj_text = bot_module._mj_prompt_card_text("16:9", state.get("last_prompt"))
-    assert "Промпт: <i>—</i>" in mj_text
+    assert "Промпт: <i>—</i>" not in mj_text
+    assert "Промпт: <i> </i>" in mj_text
 
 
 def test_menu_labels_not_saved_as_prompt() -> None:

--- a/tests/test_suno_basic.py
+++ b/tests/test_suno_basic.py
@@ -581,12 +581,19 @@ def test_launch_suno_notify_ok_flow(monkeypatch, bot_module):
     monkeypatch.setattr(bot, "debit_try", fake_debit_try)
 
     notify_calls = {"count": 0}
+    edited_payloads: list[str] = []
 
     async def fake_notify(*args, **kwargs):
         notify_calls["count"] += 1
         return SimpleNamespace(message_id=111)
 
     monkeypatch.setattr(bot, "_suno_notify", fake_notify)
+
+    async def fake_safe_edit_message(ctx_param, chat_id_param, message_id_param, new_text, **kwargs):
+        edited_payloads.append(new_text)
+        return True
+
+    monkeypatch.setattr(bot, "safe_edit_message", fake_safe_edit_message)
 
     async def fake_to_thread(func, *args, **kwargs):
         return func(*args, **kwargs)
@@ -641,6 +648,7 @@ def test_launch_suno_notify_ok_flow(monkeypatch, bot_module):
     assert notify_total_after == notify_total_before + 1
     assert enqueue_total_after == enqueue_total_before + 1
     assert notify_calls["count"] == 1
+    assert edited_payloads and edited_payloads[-1].startswith("✅ Списано")
     assert start_calls["count"] == 1
     assert debit_calls["count"] == 1
 

--- a/ui_helpers.py
+++ b/ui_helpers.py
@@ -197,6 +197,7 @@ def render_suno_card(
     price: int,
     balance: Optional[int] = None,
     generating: bool = False,
+    waiting_enqueue: bool = False,
 ) -> Tuple[str, InlineKeyboardMarkup]:
     safe_title = html.escape(suno_state.title) if suno_state.title else "—"
     style_display = suno_style_preview(suno_state.style, limit=200)
@@ -216,7 +217,9 @@ def render_suno_card(
     lines.append(f"• Текст: <i>{safe_lyrics}</i>")
     lines.append("")
     lines.append(f"💎 Цена: {price} 💎 за попытку")
-    if generating:
+    if waiting_enqueue:
+        lines.append("⏳ Отправляем запрос в Suno…")
+    elif generating:
         lines.append("⏳ Генерация запущена — ожидайте результат.")
 
     text = "\n".join(lines)
@@ -236,6 +239,7 @@ async def refresh_suno_card(
     suno_state_obj = load_suno_state(ctx)
     state_dict["suno_state"] = suno_state_obj.to_dict()
     generating = bool(state_dict.get("suno_generating"))
+    waiting_enqueue = bool(state_dict.get("suno_waiting_enqueue"))
     balance_val = state_dict.get("suno_balance")
     try:
         balance_num = int(balance_val) if balance_val is not None else None
@@ -246,6 +250,7 @@ async def refresh_suno_card(
         price=price,
         balance=balance_num,
         generating=generating,
+        waiting_enqueue=waiting_enqueue,
     )
     card_state_raw = state_dict.get("suno_card")
     card_state: MutableMapping[str, Any]

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -1,0 +1,76 @@
+"""Reusable helpers for resilient API interactions."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+def _default_retry_filter(exc: BaseException) -> bool:
+    """Retry on generic transient errors by default."""
+
+    return isinstance(exc, Exception)
+
+
+async def request_with_retries(
+    operation: Callable[[], Awaitable[T] | T],
+    *,
+    attempts: int = 3,
+    base_delay: float = 0.8,
+    max_delay: float = 6.0,
+    backoff_factor: float = 2.0,
+    logger: Optional[logging.Logger] = None,
+    log_context: Optional[dict[str, Any]] = None,
+    retry_filter: Optional[Callable[[BaseException], bool]] = None,
+) -> T:
+    """Execute ``operation`` with retries and exponential backoff.
+
+    ``operation`` may be synchronous or asynchronous. If it raises an exception
+    deemed retryable by ``retry_filter`` it will be re-run until ``attempts`` are
+    exhausted. Non-retryable errors are re-raised immediately.
+    """
+
+    if attempts <= 0:
+        raise ValueError("attempts must be positive")
+
+    retry_checker = retry_filter or _default_retry_filter
+    log_extra = dict(log_context or {})
+    attempt = 0
+    last_error: Optional[BaseException] = None
+
+    while attempt < attempts:
+        attempt += 1
+        try:
+            result = operation()
+            if asyncio.iscoroutine(result) or isinstance(result, Awaitable):
+                return await result  # type: ignore[return-value]
+            return result  # type: ignore[return-value]
+        except BaseException as exc:  # noqa: PERF203 - intentional broad catch
+            last_error = exc
+            if not retry_checker(exc) or attempt >= attempts:
+                raise
+            delay = min(max_delay, base_delay * (backoff_factor ** (attempt - 1)))
+            if logger:
+                logger.warning(
+                    "api.retry",  # noqa: TRY400 - structured logging key
+                    extra={
+                        **log_extra,
+                        "attempt": attempt,
+                        "max_attempts": attempts,
+                        "delay": round(delay, 3),
+                        "error": str(exc),
+                    },
+                )
+            await asyncio.sleep(delay)
+
+    # In practice the loop returns or raises, but mypy expects a fallback.
+    if last_error is not None:  # pragma: no cover - defensive guard
+        raise last_error
+    raise RuntimeError("request_with_retries exhausted without executing")
+
+
+__all__ = ["request_with_retries"]
+

--- a/utils/telegram_utils.py
+++ b/utils/telegram_utils.py
@@ -118,6 +118,12 @@ _LABEL_PATTERN_PARTS.append(_COMMAND_PATTERN)
 
 COMMAND_OR_BUTTON_REGEX = re.compile("|".join(_LABEL_PATTERN_PARTS))
 
+_PLACEHOLDER_PROMPTS = {
+    "⏳ sending request…",
+    "⚠️ generation failed, please try later.",
+    "⚠️ generation failed, please try later. 💎 токены возвращены.",
+}
+
 
 BUTTON_LABELS = set(MENU_LABELS)
 
@@ -166,6 +172,8 @@ def should_capture_to_prompt(text: Optional[str]) -> bool:
     if is_command_text(stripped):
         return False
     if is_button_label(stripped):
+        return False
+    if stripped.casefold() in _PLACEHOLDER_PROMPTS:
         return False
     return True
 


### PR DESCRIPTION
## Summary
- add a reusable `request_with_retries` helper and refactor the Suno enqueue path to show a waiting status, retry on transient API failures, and send clear success/failure messages
- surface the enqueue waiting state in the Suno card UI and guard prompt collection helpers from recording system placeholders
- remove placeholder prompt text from VEO/MJ cards and add regression coverage for empty cards plus Suno enqueue retry outcomes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da31a594d083229fd565617e384b2b