### PR TITLE
Harden Suno request id flow and placeholder rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.7.1-suno-stable
+- Prefix Suno request IDs with the initiating user ID for idempotent reuse.
+- Expand enqueue retry jitter to ±30% and align max delay with 15s budget.
+- Persist pending metadata under the expanded request ID format in tests.
+- Render VEO/MJ prompt cards with empty placeholders until users type.
+- Add regression coverage for request ID reuse and duplicate suppression.
+
 ## v0.7.0-freeze-suno
 - Freeze current bot release prior to Suno reliability improvements.
 - Harden Suno enqueue retries with jittered exponential backoff and 12s cap.

--- a/tests/test_prompt_placeholders.py
+++ b/tests/test_prompt_placeholders.py
@@ -96,7 +96,7 @@ def test_veo_card_opens_with_empty_prompt() -> None:
         bot_module.set_mode = original_set_mode  # type: ignore[assignment]
 
     assert captured, "card render not captured"
-    assert "Введите промпт…" in captured[-1]
+    assert "<code> </code>" in captured[-1]
 
 
 def test_mj_card_opens_with_empty_prompt() -> None:
@@ -151,7 +151,7 @@ def test_mj_card_opens_with_empty_prompt() -> None:
         bot_module.set_mode = original_set_mode  # type: ignore[assignment]
 
     assert captured, "card render not captured"
-    assert "Введите промпт…" in captured[-1]
+    assert "Промпт: <i> </i>" in captured[-1]
 
 
 def test_menu_label_not_saved_as_prompt() -> None:

--- a/tests/test_suno_idempotency.py
+++ b/tests/test_suno_idempotency.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("SUNO_API_BASE", "https://example.com")
+os.environ.setdefault("SUNO_API_TOKEN", "token")
+os.environ.setdefault("SUNO_CALLBACK_URL", "https://callback.example")
+os.environ.setdefault("SUNO_CALLBACK_SECRET", "secret")
+os.environ.setdefault("TELEGRAM_TOKEN", "dummy-token")
+os.environ.setdefault("KIE_API_KEY", "test-key")
+os.environ.setdefault("KIE_BASE_URL", "https://example.com")
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
+os.environ.setdefault("LEDGER_BACKEND", "memory")
+os.environ.setdefault("LOG_JSON", "false")
+os.environ.setdefault("LOG_LEVEL", "WARNING")
+
+bot_module = importlib.import_module("bot")
+
+
+def test_generate_request_id_includes_user() -> None:
+    rid = bot_module._generate_suno_request_id(555)
+    assert rid.startswith("suno:555:"), rid
+    rid2 = bot_module._generate_suno_request_id(555)
+    assert rid != rid2
+
+
+def test_duplicate_req_id_skips_enqueue(monkeypatch: pytest.MonkeyPatch) -> None:
+    ctx = SimpleNamespace(bot=None, user_data={})
+    state_dict = bot_module.state(ctx)
+    state_dict["suno_generating"] = False
+    state_dict["suno_waiting_enqueue"] = False
+    state_dict["suno_current_req_id"] = None
+    card_meta = state_dict.get("suno_card")
+    if isinstance(card_meta, dict):
+        card_meta["msg_id"] = None
+
+    monkeypatch.setattr(bot_module, "_suno_configured", lambda: True)
+    monkeypatch.setattr(bot_module, "_suno_cooldown_remaining", lambda uid: 0)
+    monkeypatch.setattr(bot_module, "ensure_user", lambda uid: None)
+    monkeypatch.setattr(
+        bot_module,
+        "build_suno_generation_payload",
+        lambda *_, **__: {"prompt": "demo", "instrumental": True},
+    )
+    monkeypatch.setattr(bot_module, "sanitize_payload_for_log", lambda payload: payload)
+
+    seen: dict[str, str] = {}
+
+    def fake_pending_load(req_id: str):
+        seen["req_id"] = req_id
+        return {"status": "enqueued", "task_id": "task-1"}
+
+    monkeypatch.setattr(bot_module, "_suno_pending_load", fake_pending_load)
+
+    async def fail_notify(*_args, **_kwargs):
+        raise AssertionError("should not notify while job pending")
+
+    monkeypatch.setattr(bot_module, "_suno_notify", fail_notify)
+
+    def fail_start_music(*_args, **_kwargs):
+        raise AssertionError("duplicate launch should not enqueue")
+
+    monkeypatch.setattr(bot_module.SUNO_SERVICE, "start_music", fail_start_music)
+
+    async def scenario() -> None:
+        params = {"instrumental": True, "title": "", "style": "", "lyrics": "", "has_lyrics": False}
+        await bot_module._launch_suno_generation(
+            123,
+            ctx,
+            params=params,
+            user_id=777,
+            reply_to=None,
+            trigger="test",
+        )
+
+    asyncio.run(scenario())
+
+    assert "req_id" in seen
+    assert seen["req_id"].startswith("suno:777:")

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -59,15 +59,16 @@ async def request_with_retries(
             delay = max(0.0, base_delay * (backoff_factor ** (attempt - 1)))
             delay = min(max_delay, delay)
             if jitter:
-                low: float
-                high: float
                 if isinstance(jitter, tuple):
                     low, high = jitter
+                    if high < low:
+                        low, high = high, low
+                    jitter_value = random.uniform(low, high)
                 else:
-                    low, high = 0.0, float(jitter)
-                if high < low:
-                    low, high = high, low
-                jitter_value = random.uniform(low, high)
+                    pct = float(jitter)
+                    pct = max(min(pct, 1.0), 0.0)
+                    spread = delay * pct
+                    jitter_value = random.uniform(-spread, spread)
                 delay = min(max(delay + jitter_value, 0.0), max_delay)
             if max_total_delay is not None:
                 remaining = max_total_delay - total_delay


### PR DESCRIPTION
## Summary
- prefix Suno request ids with the user id, reuse them when duplicates are pending, and align enqueue jitter with the 15s retry budget
- keep VEO and MJ cards empty until the user types while updating regression coverage for the new placeholders and request id format
- document the v0.7.1-suno-stable release notes

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68da581675fc8322bc908dcec6907460