### PR TITLE
Improve robustness of Suno enqueue and callback handling

### DIFF
--- a/suno/schemas.py
+++ b/suno/schemas.py
@@ -31,9 +31,9 @@ class SunoTask(BaseModel):
     @classmethod
     def from_envelope(cls, envelope: "CallbackEnvelope") -> "SunoTask":
         data = envelope.data or {}
-        task_id = _first(data, "task_id", "taskId", "id") or ""
+        task_id = _first(data, "task_id", "taskId", "taskID", "id") or ""
         callback_type = (
-            _first(data, "callback_type", "callbackType") or "unknown"
+            _first(data, "callback_type", "callbackType", "status", "type") or "unknown"
         )
         raw_items = _extract_items(data)
         tracks = [_build_track(item, index) for index, item in enumerate(raw_items, start=1)]
@@ -73,19 +73,19 @@ def _ensure_iterable(value: Any) -> Iterable[Any]:
 
 
 def _extract_items(data: dict[str, Any]) -> Iterable[Any]:
-    for key in ("tracks", "items", "data"):
+    for key in ("tracks", "items", "results", "data"):
         maybe = data.get(key)
         if maybe:
             return _ensure_iterable(maybe)
     input_section = data.get("input")
     if isinstance(input_section, Mapping):
-        for key in ("tracks", "items", "data"):
+        for key in ("tracks", "items", "results", "data"):
             maybe = input_section.get(key)
             if maybe:
                 return _ensure_iterable(maybe)
     response = data.get("response")
     if isinstance(response, dict):
-        for key in ("data", "items", "tracks"):
+        for key in ("data", "items", "results", "tracks"):
             maybe = response.get(key)
             if maybe:
                 return _ensure_iterable(maybe)

--- a/tests/test_ui_placeholders_and_balance.py
+++ b/tests/test_ui_placeholders_and_balance.py
@@ -20,6 +20,7 @@ os.environ.setdefault("LEDGER_BACKEND", "memory")
 os.environ.setdefault("LOG_JSON", "false")
 os.environ.setdefault("LOG_LEVEL", "WARNING")
 
+from utils.input_state import classify_wait_input
 from utils.telegram_utils import should_capture_to_prompt
 import bot as bot_module
 
@@ -81,6 +82,12 @@ def test_balance_button_not_captured() -> None:
     assert not should_capture_to_prompt("Balance")
     assert not should_capture_to_prompt("  💎 Баланс  ")
     assert not should_capture_to_prompt("balance")
+
+
+def test_balance_button_bypasses_prompt_capture() -> None:
+    should, reason = classify_wait_input("💎 Баланс")
+    assert not should
+    assert reason == "command_label"
 
 
 def test_switching_engines_resets_prompts() -> None:

--- a/tests/test_utils_api_client.py
+++ b/tests/test_utils_api_client.py
@@ -1,0 +1,49 @@
+import asyncio
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils.api_client import request_with_retries
+
+
+def test_request_with_retries_respects_jitter_and_max(monkeypatch):
+    delays: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    def fake_uniform(low: float, high: float) -> float:
+        return high
+
+    monkeypatch.setattr("utils.api_client.asyncio.sleep", fake_sleep)
+    monkeypatch.setattr("utils.api_client.random.uniform", fake_uniform)
+
+    attempts = {"count": 0}
+
+    async def operation() -> str:
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise RuntimeError(f"boom-{attempts['count']}")
+        return "ok"
+
+    result = asyncio.run(
+        request_with_retries(
+            operation,
+            attempts=3,
+            base_delay=1.0,
+            max_delay=4.0,
+            backoff_factor=2.0,
+            jitter=0.5,
+            max_total_delay=10.0,
+            logger=None,
+        )
+    )
+
+    assert result == "ok"
+    assert attempts["count"] == 3
+    assert len(delays) == 2
+    assert delays[0] == pytest.approx(1.5)
+    assert delays[1] == pytest.approx(3.0)


### PR DESCRIPTION
## Summary
- add request/task identifier extraction for enqueue responses, persistent reverse lookup storage, and structured logging for Suno requests
- normalize callback payloads from multiple wrappers, add defensive logging, and allow req_id-based task recovery
- extend Suno schemas and add regression tests for enqueue formats, callback shapes, retry jitter, and balance prompt handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da7927cfc8832288b3652dc29e5fad