### PR TITLE
Align Suno integration with KIE API and harden callbacks

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -161,6 +161,7 @@ from settings import (
     REDIS_PREFIX,
     SUNO_CALLBACK_URL as SETTINGS_SUNO_CALLBACK_URL,
     SUNO_ENABLED as SETTINGS_SUNO_ENABLED,
+    SUNO_API_TOKEN as SETTINGS_SUNO_API_TOKEN,
     SUNO_LOG_KEY,
 )
 from suno.service import SunoService, SunoAPIError
@@ -718,6 +719,7 @@ SUNO_STATUS_URL = _compose_suno_url(SUNO_BASE_URL, SUNO_STATUS_PATH)
 SUNO_EXTEND_URL = _compose_suno_url(SUNO_BASE_URL, SUNO_EXTEND_PATH)
 SUNO_LYRICS_URL = _compose_suno_url(SUNO_BASE_URL, SUNO_LYRICS_PATH)
 SUNO_PRICE = SUNO_CONFIG.price
+SUNO_MODE_AVAILABLE = bool(SETTINGS_SUNO_ENABLED and SETTINGS_SUNO_API_TOKEN)
 SUNO_POLL_INTERVAL = 3.0
 SUNO_POLL_TIMEOUT = float(SUNO_CONFIG.timeout_sec)
 ENV_NAME            = _env("ENV_NAME", "prod") or "prod"
@@ -4911,6 +4913,14 @@ async def _launch_suno_generation(
     trigger: str,
 ) -> None:
     s = state(ctx)
+    if not SUNO_MODE_AVAILABLE:
+        await _suno_notify(
+            ctx,
+            chat_id,
+            "Suno временно недоступен",
+            reply_to=reply_to,
+        )
+        return
     if s.get("suno_generating"):
         await _suno_notify(
             ctx,

--- a/render.yaml
+++ b/render.yaml
@@ -5,11 +5,9 @@ services:
     region: frankfurt
     buildCommand: pip install -r requirements.txt
     startCommand: >
-      gunicorn suno_web:app
-      -k uvicorn.workers.UvicornWorker
-      --bind 0.0.0.0:$PORT
-      --access-logfile -
-      --error-logfile -
+      uvicorn suno_web:app
+      --host 0.0.0.0
+      --port $PORT
     envVars:
       - key: PYTHONUNBUFFERED
         value: "1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ requests==2.32.3
 python-dotenv==1.0.1
 fastapi>=0.111,<0.112
 uvicorn[standard]>=0.30,<0.31
+httpx>=0.27,<0.28
 Flask>=3.0.3,<4.0
 gunicorn>=21.2,<22.0
 tenacity>=8.2,<9.0

--- a/suno/service.py
+++ b/suno/service.py
@@ -22,6 +22,7 @@ from settings import (
     HTTP_POOL_PER_HOST,
     REDIS_PREFIX,
     SUNO_API_BASE,
+    SUNO_API_TOKEN,
     SUNO_CALLBACK_SECRET,
     SUNO_CALLBACK_URL,
     SUNO_ENABLED,
@@ -39,9 +40,9 @@ except Exception:  # pragma: no cover - optional import
 
 log = logging.getLogger("suno.service")
 
-API_BASE = (os.getenv("SUNO_API_BASE") or "https://api.kie.ai").rstrip("/")
-API_KEY = os.getenv("SUNO_API_KEY")
-CALLBACK_URL = os.getenv("SUNO_CALLBACK_URL")
+API_BASE = SUNO_API_BASE
+API_KEY = SUNO_API_TOKEN
+CALLBACK_URL = SUNO_CALLBACK_URL
 
 
 class SunoError(Exception):
@@ -814,6 +815,8 @@ class SunoService:
         }
         if lang:
             payload["lang"] = str(lang).strip()
+        if user_id is not None:
+            payload["userId"] = str(user_id)
         try:
             result, api_version = self.client.create_music(payload, req_id=req_id)
         except SunoAPIError as exc:


### PR DESCRIPTION
## Summary
- centralize runtime configuration with new KIE/Suno defaults, cached outbound IP detection, and helpful warnings
- overhaul the Suno HTTP client/service to use the updated KIE endpoints, payloads, and error diagnostics
- tighten the FastAPI callback surface, add health/debug probes, and gate bot-side Suno flows when credentials are missing

## Testing
- not run (environment only)

------
https://chatgpt.com/codex/tasks/task_e_68daaed73d648322b491ee30a3e60490