### PR TITLE
Align Suno client with KIE API and harden availability guard

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -163,6 +163,7 @@ from settings import (
     SUNO_ENABLED as SETTINGS_SUNO_ENABLED,
     SUNO_API_TOKEN as SETTINGS_SUNO_API_TOKEN,
     SUNO_LOG_KEY,
+    SUNO_READY,
 )
 from suno.service import SunoService, SunoAPIError
 from suno.client import SunoServerError
@@ -719,7 +720,7 @@ SUNO_STATUS_URL = _compose_suno_url(SUNO_BASE_URL, SUNO_STATUS_PATH)
 SUNO_EXTEND_URL = _compose_suno_url(SUNO_BASE_URL, SUNO_EXTEND_PATH)
 SUNO_LYRICS_URL = _compose_suno_url(SUNO_BASE_URL, SUNO_LYRICS_PATH)
 SUNO_PRICE = SUNO_CONFIG.price
-SUNO_MODE_AVAILABLE = bool(SETTINGS_SUNO_ENABLED and SETTINGS_SUNO_API_TOKEN)
+SUNO_MODE_AVAILABLE = bool(SUNO_READY)
 SUNO_POLL_INTERVAL = 3.0
 SUNO_POLL_TIMEOUT = float(SUNO_CONFIG.timeout_sec)
 ENV_NAME            = _env("ENV_NAME", "prod") or "prod"

--- a/settings.py
+++ b/settings.py
@@ -44,7 +44,7 @@ class _AppSettings(BaseModel):
     KIE_API_KEY: Optional[str] = Field(default=None)
 
     SUNO_ENABLED: bool = Field(default=False)
-    SUNO_API_BASE: Optional[str] = Field(default=None)
+    SUNO_API_BASE: Optional[str] = Field(default="https://api.kie.ai")
     SUNO_API_TOKEN: Optional[str] = Field(default=None)
     SUNO_CALLBACK_SECRET: Optional[str] = Field(default=None)
     SUNO_CALLBACK_URL: Optional[str] = Field(default=None)
@@ -63,7 +63,7 @@ class _AppSettings(BaseModel):
     SUNO_COVER_INFO_PATH: str = Field(default="/api/v1/suno/cover/record-info")
     SUNO_INSTR_PATH: str = Field(default="/api/v1/generate/add-instrumental")
     SUNO_VOCAL_PATH: str = Field(default="/api/v1/generate/add-vocals")
-    SUNO_MODEL: Optional[str] = Field(default=None)
+    SUNO_MODEL: str = Field(default="V5")
 
     @field_validator("LOG_LEVEL", mode="before")
     def _normalize_level(cls, value: object) -> str:
@@ -115,6 +115,16 @@ class _AppSettings(BaseModel):
             text = f"/{text}"
         while "//" in text:
             text = text.replace("//", "/")
+        return text
+
+    @field_validator("SUNO_MODEL", mode="before")
+    def _normalize_model(cls, value: object) -> str:
+        text = str(value or "V5").strip()
+        if not text:
+            return "V5"
+        lowered = text.lower()
+        if lowered in {"v5", "suno-v5"}:
+            return "V5"
         return text
 
     @model_validator(mode="after")
@@ -216,7 +226,10 @@ SUNO_UPLOAD_EXTEND_PATH = _APP_SETTINGS.SUNO_UPLOAD_EXTEND_PATH
 SUNO_COVER_INFO_PATH = _APP_SETTINGS.SUNO_COVER_INFO_PATH
 SUNO_INSTR_PATH = _APP_SETTINGS.SUNO_INSTR_PATH
 SUNO_VOCAL_PATH = _APP_SETTINGS.SUNO_VOCAL_PATH
-SUNO_MODEL = _strip_optional(_APP_SETTINGS.SUNO_MODEL)
+SUNO_MODEL = _APP_SETTINGS.SUNO_MODEL or "V5"
+SUNO_READY = bool(
+    SUNO_ENABLED and SUNO_API_TOKEN and SUNO_CALLBACK_SECRET and SUNO_CALLBACK_URL
+)
 
 
 def _emit_warnings() -> None:
@@ -312,6 +325,7 @@ __all__ = [
     "SUNO_INSTR_PATH",
     "SUNO_VOCAL_PATH",
     "SUNO_MODEL",
+    "SUNO_READY",
     "SUNO_ENABLED",
     "resolve_outbound_ip",
     "token_tail",

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -95,19 +95,22 @@ def test_suno_client_retries(monkeypatch, requests_mock, status_codes, expected_
     from suno import client as client_module
 
     monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
-    responses = []
+    response_list = []
     for status in status_codes:
         if status == 200:
-            responses.append({"status_code": 200, "json": {"task_id": "ok"}})
+            response_list.append({"status_code": 200, "json": {"task_id": "ok"}})
         else:
-            responses.append({"status_code": status, "json": {"message": "err"}})
-    requests_mock.post("https://example.com/api/v1/generate/add-vocals", responses)
+            response_list.append({"status_code": status, "json": {"message": "err"}})
+    requests_mock.post(
+        "https://example.com/api/v1/generate/add-vocals",
+        response_list=response_list,
+    )
     suno_client = SunoClient(base_url="https://example.com", token="tkn", max_retries=3)
     if status_codes[0] == 403:
         with pytest.raises(SunoAPIError):
-            suno_client.create_music({"instrumental": False})
+            suno_client.create_music({"instrumental": False, "userId": 7})
     else:
-        payload, version = suno_client.create_music({"instrumental": False})
+        payload, version = suno_client.create_music({"instrumental": False, "userId": 7})
         assert payload["task_id"] == "ok"
         assert version == "v5"
     assert requests_mock.call_count == expected_calls

--- a/tests/test_suno_flow.py
+++ b/tests/test_suno_flow.py
@@ -558,6 +558,7 @@ def test_suno_enqueue_retries_then_success(monkeypatch) -> None:
     monkeypatch.setattr(bot, "_suno_configured", lambda: True)
     monkeypatch.setattr(bot, "ensure_user", lambda uid: None)
     bot.SUNO_PER_USER_COOLDOWN_SEC = 0
+    monkeypatch.setattr(bot, "SUNO_MODE_AVAILABLE", True, raising=False)
 
     async def async_noop(*args, **kwargs):
         return None
@@ -634,6 +635,7 @@ def test_suno_enqueue_retries_then_success(monkeypatch) -> None:
     params = {"title": "Demo", "style": "Pop", "lyrics": "", "instrumental": True}
 
     async def _run() -> None:
+        assert bot.SUNO_MODE_AVAILABLE is True
         await bot._launch_suno_generation(
             chat_id=111,
             ctx=ctx,
@@ -664,6 +666,7 @@ def test_suno_enqueue_all_failures(monkeypatch) -> None:
     monkeypatch.setattr(bot, "_suno_configured", lambda: True)
     monkeypatch.setattr(bot, "ensure_user", lambda uid: None)
     bot.SUNO_PER_USER_COOLDOWN_SEC = 0
+    monkeypatch.setattr(bot, "SUNO_MODE_AVAILABLE", True, raising=False)
 
     async def async_noop(*args, **kwargs):
         return None
@@ -790,6 +793,7 @@ def test_suno_enqueue_dedupes_failed_req(monkeypatch) -> None:
 
     monkeypatch.setattr(bot, "_suno_notify", fake_notify)
     monkeypatch.setattr(bot, "_suno_issue_refund", async_noop)
+    monkeypatch.setattr(bot, "SUNO_MODE_AVAILABLE", True, raising=False)
 
     ctx = SimpleNamespace(user_data={}, bot=SimpleNamespace())
     state_dict = bot.state(ctx)
@@ -811,6 +815,7 @@ def test_suno_enqueue_dedupes_failed_req(monkeypatch) -> None:
     params = {"title": "Demo", "style": "Pop", "lyrics": "", "instrumental": True}
 
     async def _run() -> None:
+        assert bot.SUNO_MODE_AVAILABLE is True
         await bot._launch_suno_generation(
             chat_id=303,
             ctx=ctx,

--- a/tests/test_suno_idempotency.py
+++ b/tests/test_suno_idempotency.py
@@ -48,6 +48,7 @@ def test_duplicate_req_id_skips_enqueue(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(bot_module, "_suno_configured", lambda: True)
     monkeypatch.setattr(bot_module, "_suno_cooldown_remaining", lambda uid: 0)
     monkeypatch.setattr(bot_module, "ensure_user", lambda uid: None)
+    monkeypatch.setattr(bot_module, "SUNO_MODE_AVAILABLE", True, raising=False)
     monkeypatch.setattr(
         bot_module,
         "build_suno_generation_payload",

--- a/tests/test_suno_kie_callback.py
+++ b/tests/test_suno_kie_callback.py
@@ -2,39 +2,73 @@ import os
 import sys
 from types import SimpleNamespace
 
+import pytest
 from fastapi.testclient import TestClient
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
 
 import suno_web
 
 
-def test_callback_ok(monkeypatch):
-    monkeypatch.setattr(suno_web, "SUNO_CALLBACK_SECRET", "s3c", raising=False)
+@pytest.fixture(autouse=True)
+def _patch_service(monkeypatch):
+    monkeypatch.setattr(suno_web, "SUNO_CALLBACK_SECRET", "expected", raising=False)
     monkeypatch.setattr(suno_web, "rds", None, raising=False)
     monkeypatch.setattr(suno_web, "_prepare_assets", lambda task: None, raising=False)
     stub_service = SimpleNamespace(
-        get_task_id_by_request=lambda *_a, **_k: None,
-        get_request_id=lambda *_a, **_k: None,
-        get_start_timestamp=lambda *_a, **_k: None,
-        handle_callback=lambda *_a, **_k: None,
+        get_task_id_by_request=lambda *_args, **_kwargs: None,
+        get_request_id=lambda *_args, **_kwargs: None,
+        get_start_timestamp=lambda *_args, **_kwargs: None,
+        handle_callback=lambda *_args, **_kwargs: None,
     )
     monkeypatch.setattr(suno_web, "service", stub_service, raising=False)
     suno_web._memory_idempotency.clear()
+    yield
 
+
+def test_callback_requires_secret():
+    client = TestClient(suno_web.app)
+    response = client.post("/suno-callback", json={})
+    assert response.status_code == 403
+
+    response = client.post(
+        "/suno-callback",
+        json={},
+        headers={"X-Callback-Secret": "wrong"},
+    )
+    assert response.status_code == 403
+
+
+def test_callback_ok_logs_summary(caplog):
     client = TestClient(suno_web.app)
     body = {
         "code": 200,
         "data": {
             "callbackType": "complete",
             "task_id": "t-123",
-            "data": [{"audio_url": "https://x/y.mp3"}],
+            "req_id": "req-abc",
+            "items": [{"audio_url": "https://cdn.example/track.mp3"}],
         },
     }
-    response = client.post(
-        "/suno-callback",
-        json=body,
-        headers={"X-Callback-Secret": "s3c"},
-    )
+
+    with caplog.at_level("INFO"):
+        response = client.post(
+            "/suno-callback",
+            json=body,
+            headers={"X-Callback-Secret": "expected"},
+        )
+
     assert response.status_code == 200
-    assert response.json()["ok"] is True
+    payload = response.json()
+    assert payload["ok"] is True
+
+    summary_records = [rec for rec in caplog.records if rec.getMessage() == "suno callback"]
+    assert summary_records, "callback summary log not found"
+    meta = summary_records[-1].__dict__.get("meta")
+    assert meta["phase"] == "callback"
+    assert meta["task_id"] == "t-123"
+    assert meta["req_id"] == "req-abc"
+    assert meta["items"] == 1
+    assert meta["type"] == "complete"

--- a/tests/test_suno_kie_service.py
+++ b/tests/test_suno_kie_service.py
@@ -4,33 +4,165 @@ import sys
 import pytest
 import requests_mock
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
 
-from suno.service import SunoError, suno_generate
+import suno.client as suno_client_module
+from suno.client import SunoClient, SunoClientError
 
 
-def test_generate_happy():
+@pytest.fixture(autouse=True)
+def _suno_defaults(monkeypatch):
+    monkeypatch.setattr(suno_client_module, "SUNO_API_TOKEN", "test-token", raising=False)
+    monkeypatch.setattr(
+        suno_client_module,
+        "SUNO_CALLBACK_URL",
+        "https://bot.example.com/suno-callback",
+        raising=False,
+    )
+    monkeypatch.setattr(suno_client_module, "SUNO_CALLBACK_SECRET", "super-secret", raising=False)
+    monkeypatch.setattr(suno_client_module, "SUNO_API_BASE", "https://api.kie.ai", raising=False)
+    yield
+
+
+def _instrumental_url() -> str:
+    return "https://api.kie.ai/api/v1/generate/add-instrumental"
+
+
+def _vocal_url() -> str:
+    return "https://api.kie.ai/api/v1/generate/add-vocals"
+
+
+def test_enqueue_music_builds_instrumental_payload():
+    client = SunoClient()
+    captured: dict[str, object] = {}
+
     with requests_mock.Mocker() as mocker:
+        def _capture(request):
+            captured["json"] = request.json()
+            return True
+
         mocker.post(
-            "https://api.kie.ai/api/v1/generate",
-            json={"code": 200, "data": {"taskId": "t-123"}},
+            _instrumental_url(),
+            json={"code": 200, "data": {"taskId": "task-1", "req_id": "req-1"}},
+            additional_matcher=_capture,
         )
-        task_id = suno_generate(
-            prompt="lofi beat",
-            customMode=True,
+
+        result = client.enqueue_music(
+            user_id=878622103,
+            title="Ping",
+            prompt="ambient",
             instrumental=True,
-            model="V5",
+            has_lyrics=False,
+            lyrics=None,
         )
-        assert task_id == "t-123"
+
+    payload = captured.get("json")
+    assert isinstance(payload, dict)
+    assert payload["model"] == "V5"
+    assert payload["userId"] == "878622103"
+    assert payload["callBackUrl"] == "https://bot.example.com/suno-callback"
+    assert payload["callBackSecret"] == "super-secret"
+    assert payload["customMode"] == "instrumental"
+    assert payload["prompt_len"] == 16
+    assert payload["instrumental"] is True
+    assert payload["has_lyrics"] is False
+    assert "lyrics" not in payload
+    assert result.task_id == "task-1"
+    assert result.req_id == "req-1"
 
 
-def test_ip_whitelist_error():
+def test_enqueue_music_builds_vocal_payload():
+    client = SunoClient()
+    captured: dict[str, object] = {}
+
+    with requests_mock.Mocker() as mocker:
+        def _capture(request):
+            captured["json"] = request.json()
+            return True
+
+        mocker.post(
+            _vocal_url(),
+            json={"code": 200, "data": {"taskId": "task-2", "req_id": "req-2"}},
+            additional_matcher=_capture,
+        )
+
+        result = client.enqueue_music(
+            user_id=111,
+            title="Song",
+            prompt="pop ballad",
+            instrumental=False,
+            has_lyrics=True,
+            lyrics="hello world",
+        )
+
+    payload = captured.get("json")
+    assert isinstance(payload, dict)
+    assert payload["model"] == "V5"
+    assert payload["customMode"] == "vocals"
+    assert payload["has_lyrics"] is True
+    assert payload["instrumental"] is False
+    assert payload["lyrics"] == "hello world"
+    assert result.task_id == "task-2"
+    assert result.req_id == "req-2"
+
+
+def test_enqueue_music_returns_422_without_retry(monkeypatch):
+    client = SunoClient()
+    attempts = {"count": 0}
+
+    def _matcher(request):
+        attempts["count"] += 1
+        return True
+
     with requests_mock.Mocker() as mocker:
         mocker.post(
-            "https://api.kie.ai/api/v1/generate",
-            json={"code": 401, "msg": "Illegal IP, please set up a whitelist"},
-            status_code=200,
+            _vocal_url(),
+            status_code=422,
+            json={
+                "detail": [
+                    {"loc": ["body", "lyrics"], "msg": "field required"},
+                ]
+            },
+            additional_matcher=_matcher,
         )
-        with pytest.raises(SunoError) as exc:
-            suno_generate(prompt="x", customMode=True, instrumental=False, model="V5")
-        assert "Illegal IP" in str(exc.value)
+
+        with pytest.raises(SunoClientError) as exc:
+            client.enqueue_music(
+                user_id=1,
+                title="Song",
+                prompt="pop",
+                instrumental=False,
+                has_lyrics=True,
+                lyrics=None,
+            )
+
+    assert "Suno validation error" in str(exc.value)
+    assert "lyrics" in str(exc.value)
+    assert attempts["count"] == 1
+
+
+def test_enqueue_music_retries_on_server_error():
+    client = SunoClient()
+    with requests_mock.Mocker() as mocker:
+        mocker.post(
+            _instrumental_url(),
+            response_list=[
+                {"status_code": 500, "json": {"message": "fail"}},
+                {"status_code": 502, "json": {"message": "still failing"}},
+                {"status_code": 200, "json": {"data": {"taskId": "ok", "req_id": "req-5"}}},
+            ],
+        )
+
+        result = client.enqueue_music(
+            user_id=2,
+            title="Retry",
+            prompt="ambient",
+            instrumental=True,
+            has_lyrics=False,
+            lyrics=None,
+        )
+
+    assert result.task_id == "ok"
+    assert len(mocker.request_history) == 3


### PR DESCRIPTION
## Summary
- align Suno settings and client payloads with the KIE API requirements, including structured logging and non-retriable 4xx handling
- update the Suno service, bot guard rails, and webhook to consume the new client API and availability flag
- extend and adjust unit tests for enqueue payloads, callbacks, UI guard rails, and flow retries/deduplication

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dab858a7a08322ba1ff53f0064d08b