### PR TITLE
Align Suno V5 client with KIE API endpoints

### DIFF
--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -102,7 +102,7 @@ def test_suno_client_retries(monkeypatch, requests_mock, status_codes, expected_
         else:
             response_list.append({"status_code": status, "json": {"message": "err"}})
     requests_mock.post(
-        "https://example.com/api/v1/generate/add-vocals",
+        "https://example.com/api/v1/generate",
         response_list=response_list,
     )
     suno_client = SunoClient(base_url="https://example.com", token="tkn", max_retries=3)


### PR DESCRIPTION
## Summary
- update the Suno V5 client to post to `/api/v1/generate`, include the expected payload fields, and treat the taskId as the request identifier
- improve logging and status polling by capturing task/message details and retrying GET `record-info` requests without `userId` when the API complains
- refresh service logic and tests to reflect the new request/response contract and to keep backwards-compatible request lookups

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dad692e78483229c32589239044754