### PR TITLE
Migrate Suno integration to v5 generate API

### DIFF
--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -98,7 +98,7 @@ def test_suno_client_retries(monkeypatch, requests_mock, status_codes, expected_
     response_list = []
     for status in status_codes:
         if status == 200:
-            response_list.append({"status_code": 200, "json": {"task_id": "ok"}})
+            response_list.append({"status_code": 200, "json": {"taskId": "ok"}})
         else:
             response_list.append({"status_code": status, "json": {"message": "err"}})
     requests_mock.post(
@@ -111,7 +111,7 @@ def test_suno_client_retries(monkeypatch, requests_mock, status_codes, expected_
             suno_client.create_music({"instrumental": False, "userId": 7})
     else:
         payload, version = suno_client.create_music({"instrumental": False, "userId": 7})
-        assert payload["task_id"] == "ok"
+        assert payload["taskId"] == "ok"
         assert version == "v5"
     assert requests_mock.call_count == expected_calls
 

--- a/tests/test_suno_kie_service.py
+++ b/tests/test_suno_kie_service.py
@@ -45,7 +45,7 @@ def test_enqueue_music_builds_instrumental_payload():
             additional_matcher=_capture,
         )
 
-        result = client.enqueue_music(
+        task_id = client.enqueue_music(
             user_id=878622103,
             title="Ping",
             prompt="ambient",
@@ -65,11 +65,9 @@ def test_enqueue_music_builds_instrumental_payload():
     assert payload["instrumental"] is True
     assert payload["has_lyrics"] is False
     assert payload["negativeTags"] == []
-    assert payload["tags"] == []
-    assert "lyrics" not in payload
-    assert result.task_id == "task-1"
-    assert result.req_id == "task-1"
-    assert result.custom_mode is False
+    assert payload["tags"] == ["ambient"]
+    assert payload["lyrics"] == ""
+    assert task_id == "task-1"
 
 
 def test_enqueue_music_builds_vocal_payload():
@@ -87,7 +85,7 @@ def test_enqueue_music_builds_vocal_payload():
             additional_matcher=_capture,
         )
 
-        result = client.enqueue_music(
+        task_id = client.enqueue_music(
             user_id=111,
             title="Song",
             prompt="pop ballad",
@@ -103,9 +101,8 @@ def test_enqueue_music_builds_vocal_payload():
     assert payload["has_lyrics"] is True
     assert payload["instrumental"] is False
     assert payload["lyrics"] == "hello world"
-    assert result.task_id == "task-2"
-    assert result.req_id == "task-2"
-    assert result.custom_mode is False
+    assert payload["tags"] == ["pop", "ballad"]
+    assert task_id == "task-2"
 
 
 def test_enqueue_music_returns_422_without_retry(monkeypatch):
@@ -155,7 +152,7 @@ def test_enqueue_music_retries_on_server_error():
             ],
         )
 
-        result = client.enqueue_music(
+        task_id = client.enqueue_music(
             user_id=2,
             title="Retry",
             prompt="ambient",
@@ -164,7 +161,5 @@ def test_enqueue_music_retries_on_server_error():
             lyrics=None,
         )
 
-    assert result.task_id == "ok"
-    assert result.req_id == "ok"
-    assert result.custom_mode is False
+    assert task_id == "ok"
     assert len(mocker.request_history) == 3

--- a/utils/suno_state.py
+++ b/utils/suno_state.py
@@ -238,6 +238,16 @@ def build_generation_payload(
         "instrumental": not state.has_lyrics,
         "has_lyrics": state.has_lyrics,
     }
+    tags: list[str] = []
+    if state.style:
+        for raw in re.split(r"[\s,]+", state.style):
+            tag = raw.strip().strip("#")
+            if not tag:
+                continue
+            lowered = tag.lower()
+            if lowered not in tags:
+                tags.append(lowered)
+    payload["tags"] = tags
     if state.has_lyrics:
         payload["lyrics"] = state.lyrics or ""
     if lang:


### PR DESCRIPTION
## Summary
- add a reusable Suno client payload builder that always sends V5 metadata with generated tags and negativeTags along with logging for payload and status URLs
- update Suno service and bot to use taskId-based polling, validate user inputs before debiting, propagate prepared payloads, and standardize error messaging
- derive default tags from Suno state/style and refresh tests to cover the new API flow

## Testing
- pytest tests/test_suno_basic.py tests/test_suno_kie_service.py tests/test_observability.py

------
https://chatgpt.com/codex/tasks/task_e_68dadecc56f08322ad803e695e18a21f