### PR TITLE
Improve Suno delivery reliability and add polling fallback

### DIFF
--- a/tests/test_suno_basic.py
+++ b/tests/test_suno_basic.py
@@ -890,7 +890,7 @@ def test_launch_suno_notify_ok_flow(monkeypatch, bot_module):
     assert notify_total_after == notify_total_before + 1
     assert enqueue_total_after == enqueue_total_before + 1
     assert notify_calls["count"] == 1
-    assert edited_payloads and edited_payloads[-1].startswith("✅ Списано")
+    assert edited_payloads and edited_payloads[-1].startswith("✅ Task created")
     assert start_calls["count"] == 1
     assert debit_calls["count"] == 1
 

--- a/tests/test_suno_flow.py
+++ b/tests/test_suno_flow.py
@@ -650,7 +650,7 @@ def test_suno_enqueue_retries_then_success(monkeypatch) -> None:
     assert attempts["count"] == 3
     assert debit_calls["count"] == 1
     assert status_texts and status_texts[0] == "⏳ Sending request…"
-    assert edited_messages and edited_messages[-1].startswith("✅ Списано")
+    assert edited_messages and edited_messages[-1].startswith("✅ Task created")
     assert not refunds
 
 


### PR DESCRIPTION
## Summary
- allow Suno callbacks when the shared secret is empty and fix payload normalization
- send audio/cover assets via Telegram URLs when files are missing and skip duplicate final callbacks
- add polling fallback with timeout messaging and updated success prompts, plus adjust tests for the new flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68daef4f160483228985bee0fa73b439