### PR TITLE
Improve Suno polling resilience and remote track delivery

### DIFF
--- a/suno/schemas.py
+++ b/suno/schemas.py
@@ -56,6 +56,8 @@ class SunoTrack(BaseModel):
     title: str | None = None
     audio_url: str | None = None
     image_url: str | None = None
+    tags: str | None = None
+    duration: float | None = None
 
 
 class SunoTask(BaseModel):
@@ -144,11 +146,31 @@ def _build_track(raw: Any, index: int) -> SunoTrack | None:
     title = _first(raw, "title", "name")
     audio_url = _first(raw, "audio_url", "audioUrl", "url", "fileUrl", "mp3Url")
     image_url = _first(raw, "image_url", "imageUrl", "coverUrl", "imgUrl")
+    tags_value = _first(raw, "tags", "tag", "style", "styles")
+    if isinstance(tags_value, list):
+        tags = ", ".join(str(item) for item in tags_value if item not in (None, "")) or None
+    elif isinstance(tags_value, str):
+        tags = tags_value
+    else:
+        tags = None
+    duration_value = _first(raw, "duration", "durationSec", "duration_seconds")
+    duration: float | None
+    if isinstance(duration_value, (int, float)):
+        duration = float(duration_value)
+    elif isinstance(duration_value, str):
+        try:
+            duration = float(duration_value)
+        except ValueError:
+            duration = None
+    else:
+        duration = None
     return SunoTrack(
         id=str(track_id),
         title=str(title) if title is not None else None,
         audio_url=str(audio_url) if audio_url else None,
         image_url=str(image_url) if image_url else None,
+        tags=tags,
+        duration=duration,
     )
 
 


### PR DESCRIPTION
## Summary
- add configurable Suno polling backoff with improved state mapping, timeout messaging, and richer logging
- surface track metadata (tags, duration) and deliver Telegram audio via remote URLs with consistent captions and cover handling
- normalize callback payloads, enforce callback secret headers, and keep only cover downloads on webhook processing

## Testing
- pytest tests/test_suno_basic.py

------
https://chatgpt.com/codex/tasks/task_e_68daf582b46c8322a244a39f23abbf57