### PR TITLE
Improve Suno error handling and single-message delivery

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4840,8 +4840,8 @@ def _suno_error_message(status: Optional[int], reason: Optional[str]) -> str:
         lowered = reason.lower()
         if any(phrase in lowered for phrase in ("artist name", "living artist", "brand")):
             return (
-                "⚠️ Your description includes a living artist/brand. "
-                "Please remove explicit names and try: '80s dark R&B, neon city mood, falsetto vocals, cinematic builds'."
+                "❌ Ошибка: описание содержит запрещённые слова (например, имя артиста).\n"
+                "Пожалуйста, измените описание и попробуйте снова."
             )
     if reason:
         return f"⚠️ Generation failed: {md2_escape(reason)}"


### PR DESCRIPTION
## Summary
- add a localized Suno 400 error response and verify refunds are triggered
- preserve user-provided titles for captions and audio filenames while attaching covers via the audio message
- expand unit coverage for caption formatting and forbidden-content failures

## Testing
- pytest tests/test_suno_basic.py::test_policy_error_message_text tests/test_suno_basic.py::test_delivery_uses_remote_urls tests/test_suno_flow.py::test_suno_enqueue_handles_400_error

------
https://chatgpt.com/codex/tasks/task_e_68db1264cf1c83229142dd2914acc171