### PR TITLE
Improve Suno cover art delivery reliability

### DIFF
--- a/tests/test_suno_flow.py
+++ b/tests/test_suno_flow.py
@@ -828,10 +828,7 @@ def test_suno_enqueue_handles_400_error(monkeypatch) -> None:
 
     asyncio.run(_run())
 
-    expected = (
-        "❌ Ошибка: описание содержит запрещённые слова (например, имя артиста).\n"
-        "Пожалуйста, измените описание и попробуйте снова."
-    )
+    expected = "❗️Error: your description mentions an artist/brand. Remove the reference and try again."
     assert status_texts and status_texts[0] == "⏳ Sending request…"
     assert edited_messages and edited_messages[-1] == expected
     assert refunds and refunds[-1]["user_message"].startswith(expected)


### PR DESCRIPTION
## Summary
- ensure Suno deliveries always send cover art before audio, dedupe take deliveries, and add structured logging plus resilient Telegram retries
- harden Telegram helpers to detect remote URL failures and retry or fall back to local upload
- surface localized policy-block errors with refunds and enforce callback secrets while expanding tests for the new behaviors

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db93c599448322af57d692dc2caf72