### PR TITLE
Refine Suno music generation flow

### DIFF
--- a/tests/test_music_flow.py
+++ b/tests/test_music_flow.py
@@ -1,0 +1,176 @@
+import asyncio
+import importlib
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+os.environ.setdefault("SUNO_API_BASE", "https://example.com")
+os.environ.setdefault("SUNO_API_TOKEN", "token")
+os.environ.setdefault("SUNO_CALLBACK_URL", "https://callback.example")
+os.environ.setdefault("SUNO_CALLBACK_SECRET", "secret")
+os.environ.setdefault("TELEGRAM_TOKEN", "dummy-token")
+os.environ.setdefault("KIE_API_KEY", "test-key")
+os.environ.setdefault("KIE_BASE_URL", "https://example.com")
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
+os.environ.setdefault("LEDGER_BACKEND", "memory")
+os.environ.setdefault("LOG_JSON", "false")
+os.environ.setdefault("LOG_LEVEL", "WARNING")
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+bot_module = importlib.import_module("bot")
+
+
+class DummyBot:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, object]] = []
+        self.files: dict[str, object] = {}
+
+    async def send_message(self, **kwargs):  # type: ignore[override]
+        self.sent.append(kwargs)
+        return SimpleNamespace(message_id=kwargs.get("message_id", 100))
+
+    async def edit_message_text(self, **kwargs):  # type: ignore[override]
+        return SimpleNamespace(message_id=kwargs.get("message_id", 101))
+
+    async def send_chat_action(self, **kwargs):  # type: ignore[override]
+        return None
+
+    async def get_file(self, file_id: str):  # type: ignore[override]
+        return SimpleNamespace(file_path=f"audio/{file_id}.mp3")
+
+
+class DummyMessage:
+    def __init__(self, text: str, chat_id: int = 123) -> None:
+        self.text = text
+        self.chat_id = chat_id
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **_kwargs) -> None:  # type: ignore[override]
+        self.replies.append(text)
+
+
+def _setup_context() -> tuple[SimpleNamespace, dict[str, object]]:
+    bot = DummyBot()
+    ctx = SimpleNamespace(bot=bot, user_data={})
+    state_dict = bot_module.state(ctx)
+    return ctx, state_dict
+
+
+def test_instrumental_auto_style_default() -> None:
+    ctx, state_dict = _setup_context()
+    chat_id = 321
+
+    asyncio.run(
+        bot_module._music_begin_flow(chat_id, ctx, state_dict, flow="instrumental", user_id=42)
+    )
+
+    message = DummyMessage("")
+    asyncio.run(
+        bot_module._handle_suno_waiting_input(
+            ctx,
+            chat_id,
+            message,
+            state_dict,
+            bot_module.WAIT_SUNO_STYLE,
+            user_id=42,
+        )
+    )
+    suno_state = bot_module.load_suno_state(ctx)
+    assert suno_state.style == bot_module._INSTRUMENTAL_DEFAULT_STYLE
+    assert state_dict.get("suno_step") == "title"
+    assert any("стиль по умолчанию" in reply for reply in message.replies)
+
+
+def test_lyrics_manual_and_auto_generation() -> None:
+    ctx, state_dict = _setup_context()
+    chat_id = 555
+
+    asyncio.run(
+        bot_module._music_begin_flow(chat_id, ctx, state_dict, flow="lyrics", user_id=99)
+    )
+
+    # manual lyrics
+    manual_msg = DummyMessage("First line\nSecond line")
+    asyncio.run(
+        bot_module._handle_suno_waiting_input(
+            ctx,
+            chat_id,
+            manual_msg,
+            state_dict,
+            bot_module.WAIT_SUNO_LYRICS,
+            user_id=99,
+        )
+    )
+    manual_state = bot_module.load_suno_state(ctx)
+    assert manual_state.lyrics == "First line\nSecond line"
+    assert not state_dict.get("suno_auto_lyrics_pending")
+
+    # restart flow to test auto lyrics
+    asyncio.run(
+        bot_module._music_begin_flow(chat_id, ctx, state_dict, flow="lyrics", user_id=99)
+    )
+    auto_msg = DummyMessage("")
+    asyncio.run(
+        bot_module._handle_suno_waiting_input(
+            ctx,
+            chat_id,
+            auto_msg,
+            state_dict,
+            bot_module.WAIT_SUNO_LYRICS,
+            user_id=99,
+        )
+    )
+    assert state_dict.get("suno_auto_lyrics_pending") is True
+
+    # provide style to trigger auto lyrics
+    style_msg = DummyMessage("dream pop, neon")
+    asyncio.run(
+        bot_module._handle_suno_waiting_input(
+            ctx,
+            chat_id,
+            style_msg,
+            state_dict,
+            bot_module.WAIT_SUNO_STYLE,
+            user_id=99,
+        )
+    )
+    auto_state = bot_module.load_suno_state(ctx)
+    assert auto_state.lyrics
+    assert state_dict.get("suno_auto_lyrics_generated") is True
+
+
+def test_cover_upload_flow_accepts_audio() -> None:
+    ctx, state_dict = _setup_context()
+    chat_id = 777
+
+    asyncio.run(
+        bot_module._music_begin_flow(chat_id, ctx, state_dict, flow="cover", user_id=7)
+    )
+    state_dict["mode"] = "suno"
+
+    class Audio:
+        def __init__(self) -> None:
+            self.file_id = "file123"
+            self.file_name = "demo.mp3"
+            self.file_size = 1000
+            self.duration = 5
+
+    message = DummyMessage("", chat_id)
+    message.audio = Audio()
+    message.voice = None
+    update = SimpleNamespace(message=message, effective_user=SimpleNamespace(id=7))
+    asyncio.run(bot_module.handle_voice(update, ctx))
+
+    suno_state = bot_module.load_suno_state(ctx)
+    assert suno_state.cover_source_url
+    assert suno_state.cover_source_label == "demo.mp3"
+    assert state_dict.get("suno_step") == "style"
+
+
+def test_artist_name_error_message() -> None:
+    text = bot_module._suno_error_message(400, "Artist name detected")
+    assert "Please remove artist names" in text

--- a/tests/test_suno_flow.py
+++ b/tests/test_suno_flow.py
@@ -130,18 +130,22 @@ def test_render_includes_escaped_fields() -> None:
     set_style(state, "Dream pop <b>lush</b>")
     set_lyrics(state, "Line one\nLine two")
     text, _ = _render(state)
-    assert "• Название: <i>Test</i>" in text
+    assert "🏷️ Название: <i>Test</i>" in text
     assert "<Track" not in text
-    assert "• Стиль: <i>Dream pop lush</i>" in text
-    assert "• Текст: <i>Line one" in text
+    assert "🎹 Стиль: <i>Dream pop lush</i>" in text
+    assert "📜 Текст: <i>Line one" in text
 
 
 def test_render_shows_dash_for_missing_values() -> None:
     state = SunoState()
     text, _ = _render(state)
-    assert "• Название: <i>—</i>" in text
-    assert "• Стиль: <i>—</i>" in text
-    assert "• Текст: <i>—</i>" in text
+    assert "🏷️ Название: <i>—</i>" in text
+    assert "🎹 Стиль: <i>—</i>" in text
+    assert "📜" not in text
+
+    state_lyrics = SunoState(mode="lyrics")
+    text_lyrics, _ = _render(state_lyrics)
+    assert "📜 Текст: <i>—</i>" in text_lyrics
 
 
 def test_render_has_no_br_tags() -> None:
@@ -157,7 +161,7 @@ def test_lyrics_preview_and_payload() -> None:
     state = SunoState(mode="lyrics")
     set_lyrics(state, lyrics)
     text, _ = _render(state)
-    assert "• Текст: <i>First verse" in text
+    assert "📜 Текст: <i>First verse" in text
     payload = build_generation_payload(state, model="V5", lang="ru")
     assert payload["lyrics"] == "First verse\nSecond line\nThird"
 

--- a/ui_helpers.py
+++ b/ui_helpers.py
@@ -164,35 +164,41 @@ async def refresh_balance_card_if_open(
 
 
 def _suno_keyboard(
-    suno_state: SunoState, *, price: int, generating: bool
+    suno_state: SunoState,
+    *,
+    price: int,
+    generating: bool,
+    flow: Optional[str],
+    ready: bool,
 ) -> InlineKeyboardMarkup:
     rows: list[list[InlineKeyboardButton]] = []
 
-    rows.append([InlineKeyboardButton("✏️ Название", callback_data="suno:edit:title")])
-    rows.append([InlineKeyboardButton("🎨 Стиль", callback_data="suno:edit:style")])
+    if flow == "instrumental":
+        rows.append([InlineKeyboardButton("🎨 Изменить стиль", callback_data="suno:edit:style")])
+        rows.append([InlineKeyboardButton("✏️ Изменить название", callback_data="suno:edit:title")])
+    elif flow == "lyrics":
+        rows.append([InlineKeyboardButton("📝 Правка текста", callback_data="suno:edit:lyrics")])
+        rows.append([InlineKeyboardButton("🎨 Правка стиля", callback_data="suno:edit:style")])
+        rows.append([InlineKeyboardButton("✏️ Правка названия", callback_data="suno:edit:title")])
+    elif flow == "cover":
+        rows.append([InlineKeyboardButton("🎧 Сменить источник", callback_data="suno:edit:cover")])
+        rows.append([InlineKeyboardButton("🎨 Правка стиля", callback_data="suno:edit:style")])
+        rows.append([InlineKeyboardButton("✏️ Правка названия", callback_data="suno:edit:title")])
+    else:
+        rows.append([InlineKeyboardButton("🎵 Выбрать режим", callback_data="suno:menu")])
 
     preset_active = suno_state.preset == AMBIENT_NATURE_PRESET_ID
     preset_label = "🌊 Ambient Preset" + (" ✅" if preset_active else "")
     rows.append([InlineKeyboardButton(preset_label, callback_data="suno:preset:ambient")])
 
-    mode_label = "Со словами" if suno_state.has_lyrics else "Инструментал"
-    rows.append([
-        InlineKeyboardButton(
-            f"🎼 Режим: {mode_label}",
-            callback_data="suno:toggle:instrumental",
-        )
-    ])
-
-    if suno_state.has_lyrics:
-        rows.append([
-            InlineKeyboardButton("📝 Текст песни", callback_data="suno:edit:lyrics")
-        ])
-
-    generate_caption = "⏳ Генерация…" if generating else f"🎵 Генерация музыки — {price}💎"
-    rows.append([
-        InlineKeyboardButton(generate_caption, callback_data="suno:start")
-    ])
-    rows.append([InlineKeyboardButton("⬅️ Назад", callback_data="back")])
+    if generating:
+        generate_caption = "⏳ Генерация…"
+    elif ready:
+        generate_caption = f"✅ Сгенерировать — {price}💎"
+    else:
+        generate_caption = "⚠️ Заполните шаги"
+    rows.append([InlineKeyboardButton(generate_caption, callback_data="suno:start")])
+    rows.append([InlineKeyboardButton("⬅️ В меню музыки", callback_data="suno:menu")])
     return InlineKeyboardMarkup(rows)
 
 
@@ -207,10 +213,18 @@ def render_suno_card(
     safe_title = html.escape(suno_state.title) if suno_state.title else "—"
     style_display = suno_style_preview(suno_state.style, limit=200)
     safe_style = html.escape(style_display) if style_display else "—"
-    mode_label = "Со словами" if suno_state.has_lyrics else "Инструментал"
+    mode = suno_state.mode
+    flow_label_map = {
+        "instrumental": "🎹 Instrumental Music",
+        "lyrics": "🎤 Music with Lyrics",
+        "cover": "🎶 Cover Music",
+    }
+    flow_label = flow_label_map.get(mode, "🎵 Music")
     lyrics_source = suno_state.lyrics if suno_state.has_lyrics else None
     lyrics_preview = suno_lyrics_preview(lyrics_source)
     safe_lyrics = html.escape(lyrics_preview) if lyrics_preview else "—"
+    cover_display_raw = suno_state.cover_source_label or suno_state.cover_source_url or "—"
+    safe_cover = html.escape(cover_display_raw) if cover_display_raw else "—"
 
     preset_line: Optional[str] = None
     if suno_state.preset:
@@ -221,14 +235,17 @@ def render_suno_card(
                 safe_label = html.escape(label)
                 preset_line = f"• Пресет: <i>{safe_label}</i>"
 
-    lines = ["🎵 Генерация музыки"]
+    lines = ["🎶 Track Preview", flow_label]
     if balance is not None:
         lines.append(f"Баланс: {int(balance)}")
     lines.append(f"Модель: {html.escape(_SUNO_MODEL_LABEL)}")
-    lines.append(f"Режим: {mode_label}")
-    lines.append(f"• Название: <i>{safe_title}</i>")
-    lines.append(f"• Стиль: <i>{safe_style}</i>")
-    lines.append(f"• Текст: <i>{safe_lyrics}</i>")
+    lines.append("")
+    lines.append(f"🎹 Стиль: <i>{safe_style}</i>")
+    if mode == "lyrics":
+        lines.append(f"📜 Текст: <i>{safe_lyrics}</i>")
+    if mode == "cover":
+        lines.append(f"🎧 Источник: <i>{safe_cover}</i>")
+    lines.append(f"🏷️ Название: <i>{safe_title}</i>")
     if preset_line:
         lines.append(preset_line)
     lines.append("")
@@ -239,7 +256,20 @@ def render_suno_card(
         lines.append("⏳ Генерация запущена — ожидайте результат.")
 
     text = "\n".join(lines)
-    keyboard = _suno_keyboard(suno_state, price=price, generating=generating)
+    ready = True
+    if mode == "instrumental":
+        ready = bool(suno_state.style and suno_state.title)
+    elif mode == "lyrics":
+        ready = bool(suno_state.style and suno_state.title and suno_state.lyrics)
+    elif mode == "cover":
+        ready = bool(suno_state.cover_source_url and suno_state.style and suno_state.title)
+    keyboard = _suno_keyboard(
+        suno_state,
+        price=price,
+        generating=generating,
+        flow=mode,
+        ready=ready,
+    )
     return text, keyboard
 
 
@@ -253,6 +283,9 @@ async def refresh_suno_card(
     force_new: bool = False,
 ) -> Optional[int]:
     suno_state_obj = load_suno_state(ctx)
+    flow = state_dict.get("suno_flow")
+    if isinstance(flow, str) and flow in {"instrumental", "lyrics", "cover"}:
+        suno_state_obj.mode = flow  # type: ignore[assignment]
     state_dict["suno_state"] = suno_state_obj.to_dict()
     generating = bool(state_dict.get("suno_generating"))
     waiting_enqueue = bool(state_dict.get("suno_waiting_enqueue"))


### PR DESCRIPTION
## Summary
- add a guided music menu with dedicated instrumental, lyrics, and cover flows, including auto prompts and cover uploads
- update Suno state, UI card, and error messaging to reflect the new flow and cover metadata
- expand tests to cover the new guided flows and card rendering expectations

## Testing
- pytest tests/test_music_flow.py tests/test_suno_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68dbb12ab3fc8322af9b5c2fe5ff5fcf