### PR TITLE
feat: upload Suno cover sources

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -64,6 +64,9 @@ class _AppSettings(BaseModel):
     SUNO_INSTR_PATH: str = Field(default="/api/v1/generate/add-instrumental")
     SUNO_VOCAL_PATH: str = Field(default="/api/v1/generate/add-vocals")
     SUNO_MODEL: str = Field(default="V5")
+    UPLOAD_BASE_URL: Optional[str] = Field(default=None)
+    UPLOAD_STREAM_PATH: str = Field(default="/api/v1/upload/stream")
+    UPLOAD_URL_PATH: str = Field(default="/api/v1/upload/url")
 
     @field_validator("LOG_LEVEL", mode="before")
     def _normalize_level(cls, value: object) -> str:
@@ -227,6 +230,12 @@ SUNO_COVER_INFO_PATH = _APP_SETTINGS.SUNO_COVER_INFO_PATH
 SUNO_INSTR_PATH = _APP_SETTINGS.SUNO_INSTR_PATH
 SUNO_VOCAL_PATH = _APP_SETTINGS.SUNO_VOCAL_PATH
 SUNO_MODEL = _APP_SETTINGS.SUNO_MODEL or "V5"
+
+UPLOAD_BASE_URL = (
+    _strip_optional(_APP_SETTINGS.UPLOAD_BASE_URL) or SUNO_API_BASE
+).rstrip("/")
+UPLOAD_STREAM_PATH = _APP_SETTINGS.UPLOAD_STREAM_PATH
+UPLOAD_URL_PATH = _APP_SETTINGS.UPLOAD_URL_PATH
 SUNO_READY = bool(
     SUNO_ENABLED and SUNO_API_TOKEN and SUNO_CALLBACK_SECRET and SUNO_CALLBACK_URL
 )
@@ -327,6 +336,9 @@ __all__ = [
     "SUNO_MODEL",
     "SUNO_READY",
     "SUNO_ENABLED",
+    "UPLOAD_BASE_URL",
+    "UPLOAD_STREAM_PATH",
+    "UPLOAD_URL_PATH",
     "resolve_outbound_ip",
     "token_tail",
 ]

--- a/suno/cover_source.py
+++ b/suno/cover_source.py
@@ -1,0 +1,340 @@
+"""Helpers for validating and uploading Suno cover sources."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Mapping, MutableMapping, Optional
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from settings import (
+    SUNO_API_TOKEN,
+    SUNO_TIMEOUT_SEC,
+    UPLOAD_BASE_URL,
+    UPLOAD_STREAM_PATH,
+    UPLOAD_URL_PATH,
+)
+
+MAX_AUDIO_MB = 50
+_ALLOWED_EXTENSIONS = {".mp3", ".wav"}
+
+
+class CoverSourceError(Exception):
+    """Base error for cover source operations."""
+
+
+class CoverSourceValidationError(CoverSourceError):
+    """Raised when the provided source is invalid."""
+
+
+class CoverSourceClientError(CoverSourceError):
+    """Raised when the upload service rejects the request."""
+
+
+class CoverSourceUnavailableError(CoverSourceError):
+    """Raised when the upload service is temporarily unavailable."""
+
+
+class _RetryableError(Exception):
+    """Internal helper to signal retryable errors."""
+
+    def __init__(self, message: str, response: Optional[httpx.Response] = None) -> None:
+        super().__init__(message)
+        self.response = response
+
+
+def _compose_upload_url(path: str) -> str:
+    base = (UPLOAD_BASE_URL or "").rstrip("/") + "/"
+    return urljoin(base, path.lstrip("/"))
+
+
+def _auth_header() -> dict[str, str]:
+    token = (SUNO_API_TOKEN or "").strip()
+    if not token:
+        raise CoverSourceUnavailableError("missing-token")
+    if not token.lower().startswith("bearer "):
+        token = f"Bearer {token}"
+    return {"Authorization": token}
+
+
+def _extract_kie_file_id(payload: Mapping[str, Any]) -> Optional[str]:
+    for key in ("kie_file_id", "file_id", "id"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    data = payload.get("data")
+    if isinstance(data, Mapping):
+        return _extract_kie_file_id(data)
+    return None
+
+
+async def _request_with_retries(
+    operation: str,
+    request_cb,
+    *,
+    logger: Optional[logging.Logger],
+    request_id: str,
+) -> httpx.Response:
+    delays = [1, 2, 4]
+    last_exc: Optional[Exception] = None
+    for attempt, delay in enumerate(delays, start=1):
+        try:
+            return await request_cb()
+        except _RetryableError as exc:  # pragma: no cover - simple control flow
+            last_exc = exc
+            if logger:
+                logger.warning(
+                    "cover.upload_retry",
+                    extra={
+                        "request_id": request_id,
+                        "operation": operation,
+                        "attempt": attempt,
+                        "error": str(exc),
+                    },
+                )
+        except httpx.TimeoutException as exc:
+            last_exc = exc
+            if logger:
+                logger.warning(
+                    "cover.upload_timeout",
+                    extra={
+                        "request_id": request_id,
+                        "operation": operation,
+                        "attempt": attempt,
+                        "error": str(exc),
+                    },
+                )
+        except httpx.HTTPError as exc:
+            last_exc = exc
+            if logger:
+                logger.warning(
+                    "cover.upload_http_error",
+                    extra={
+                        "request_id": request_id,
+                        "operation": operation,
+                        "attempt": attempt,
+                        "error": str(exc),
+                    },
+                )
+        if attempt < len(delays):
+            await asyncio.sleep(delay)
+    if isinstance(last_exc, _RetryableError) and getattr(last_exc, "response", None):
+        response = last_exc.response  # type: ignore[assignment]
+        assert response is not None
+        return response
+    raise CoverSourceUnavailableError(operation) from last_exc
+
+
+def _timeout() -> httpx.Timeout:
+    total = max(float(SUNO_TIMEOUT_SEC or 60), 1.0)
+    return httpx.Timeout(total=total)
+
+
+async def upload_stream(
+    data: bytes,
+    filename: str,
+    mime_type: Optional[str],
+    *,
+    request_id: str,
+    logger: Optional[logging.Logger] = None,
+) -> str:
+    """Upload audio bytes and return the KIE file identifier."""
+
+    if not data:
+        raise CoverSourceValidationError("empty-data")
+
+    headers = _auth_header()
+    url = _compose_upload_url(UPLOAD_STREAM_PATH)
+    timeout = _timeout()
+
+    async def _do_request() -> httpx.Response:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            try:
+                response = await client.post(
+                    url,
+                    headers=headers,
+                    files={
+                        "file": (
+                            filename or "audio.mp3",
+                            data,
+                            mime_type or "application/octet-stream",
+                        )
+                    },
+                )
+            except httpx.TimeoutException:
+                raise
+            except httpx.HTTPError as exc:
+                raise _RetryableError(str(exc)) from exc
+        if response.status_code in {429} or 500 <= response.status_code < 600:
+            raise _RetryableError(f"status:{response.status_code}", response=response)
+        if 400 <= response.status_code < 500:
+            raise CoverSourceClientError(f"status:{response.status_code}")
+        return response
+
+    response = await _request_with_retries(
+        "stream",
+        _do_request,
+        logger=logger,
+        request_id=request_id,
+    )
+
+    status = response.status_code
+    if status in {429} or 500 <= status < 600:
+        raise CoverSourceUnavailableError(f"status:{status}")
+
+    try:
+        payload = response.json()
+    except ValueError:
+        raise CoverSourceUnavailableError("invalid-json") from None
+
+    if not isinstance(payload, Mapping):
+        if isinstance(payload, MutableMapping):
+            payload = dict(payload)
+        else:
+            payload = {"data": payload}
+
+    kie_file_id = _extract_kie_file_id(payload)
+    if not kie_file_id:
+        raise CoverSourceUnavailableError("missing-kie-file-id")
+    return kie_file_id
+
+
+async def upload_url(
+    source_url: str,
+    *,
+    request_id: str,
+    logger: Optional[logging.Logger] = None,
+) -> str:
+    """Upload a remote URL and return the KIE file identifier."""
+
+    headers = {"Content-Type": "application/json"}
+    headers.update(_auth_header())
+    url = _compose_upload_url(UPLOAD_URL_PATH)
+    timeout = _timeout()
+
+    async def _do_request() -> httpx.Response:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            try:
+                response = await client.post(
+                    url,
+                    headers=headers,
+                    json={"url": source_url},
+                )
+            except httpx.TimeoutException:
+                raise
+            except httpx.HTTPError as exc:
+                raise _RetryableError(str(exc)) from exc
+        if response.status_code in {429} or 500 <= response.status_code < 600:
+            raise _RetryableError(f"status:{response.status_code}", response=response)
+        if 400 <= response.status_code < 500:
+            raise CoverSourceClientError(f"status:{response.status_code}")
+        return response
+
+    response = await _request_with_retries(
+        "url",
+        _do_request,
+        logger=logger,
+        request_id=request_id,
+    )
+
+    status = response.status_code
+    if status in {429} or 500 <= status < 600:
+        raise CoverSourceUnavailableError(f"status:{status}")
+
+    try:
+        payload = response.json()
+    except ValueError:
+        raise CoverSourceUnavailableError("invalid-json") from None
+
+    if not isinstance(payload, Mapping):
+        payload = {"data": payload}
+
+    kie_file_id = _extract_kie_file_id(payload)
+    if not kie_file_id:
+        raise CoverSourceUnavailableError("missing-kie-file-id")
+    return kie_file_id
+
+
+def validate_url(url: str) -> str:
+    parsed = urlparse(url.strip())
+    if parsed.scheme not in {"http", "https"}:
+        raise CoverSourceValidationError("invalid-scheme")
+    if not parsed.netloc:
+        raise CoverSourceValidationError("missing-host")
+    return url.strip()
+
+
+async def ensure_audio_url(url: str) -> str:
+    """Validate that the URL points to an audio resource."""
+
+    cleaned = validate_url(url)
+    parsed = urlparse(cleaned)
+    path = parsed.path.lower()
+    if any(path.endswith(ext) for ext in _ALLOWED_EXTENSIONS):
+        return cleaned
+
+    timeout = _timeout()
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.head(cleaned, follow_redirects=True)
+    except httpx.HTTPError:
+        raise CoverSourceValidationError("head-failed")
+
+    if response.status_code >= 400:
+        raise CoverSourceValidationError("head-status")
+
+    content_type = response.headers.get("Content-Type", "").lower()
+    if not content_type.startswith("audio/"):
+        raise CoverSourceValidationError("invalid-content-type")
+    return cleaned
+
+
+def validate_audio_file(
+    mime_type: Optional[str],
+    file_name: Optional[str],
+    file_size: Optional[int],
+) -> tuple[str, str]:
+    """Validate Telegram file metadata and return filename & mime."""
+
+    size = int(file_size or 0)
+    if size <= 0:
+        raise CoverSourceValidationError("empty-file")
+    if size > MAX_AUDIO_MB * 1024 * 1024:
+        raise CoverSourceValidationError("too-large")
+
+    mime = (mime_type or "").strip().lower()
+    name = (file_name or "").strip()
+
+    if mime and not mime.startswith("audio/"):
+        raise CoverSourceValidationError("invalid-mime")
+
+    if not mime:
+        lowered = name.lower()
+        if lowered.endswith(".mp3"):
+            mime = "audio/mpeg"
+        elif lowered.endswith(".wav"):
+            mime = "audio/wav"
+        else:
+            raise CoverSourceValidationError("unknown-mime")
+
+    if not name:
+        extension = ".mp3" if mime.endswith("mpeg") else ".wav"
+        name = f"cover{extension}"
+
+    return name, mime
+
+
+__all__ = [
+    "MAX_AUDIO_MB",
+    "CoverSourceError",
+    "CoverSourceValidationError",
+    "CoverSourceClientError",
+    "CoverSourceUnavailableError",
+    "upload_stream",
+    "upload_url",
+    "ensure_audio_url",
+    "validate_audio_file",
+]
+

--- a/utils/suno_state.py
+++ b/utils/suno_state.py
@@ -107,6 +107,9 @@ class SunoState:
     preset: Optional[str] = None
     cover_source_url: Optional[str] = None
     cover_source_label: Optional[str] = None
+    source_file_id: Optional[str] = None
+    source_url: Optional[str] = None
+    kie_file_id: Optional[str] = None
 
     @property
     def has_lyrics(self) -> bool:
@@ -127,6 +130,9 @@ class SunoState:
             "preset": self.preset,
             "cover_source_url": self.cover_source_url,
             "cover_source_label": self.cover_source_label,
+            "source_file_id": self.source_file_id,
+            "source_url": self.source_url,
+            "kie_file_id": self.kie_file_id,
         }
 
 
@@ -167,6 +173,17 @@ def _from_mapping(payload: Mapping[str, Any]) -> SunoState:
     raw_cover_label = payload.get("cover_source_label")
     if isinstance(raw_cover_label, str):
         state.cover_source_label = raw_cover_label.strip() or None
+    raw_source_file_id = payload.get("source_file_id")
+    if isinstance(raw_source_file_id, str):
+        state.source_file_id = raw_source_file_id.strip() or None
+    raw_source_url = payload.get("source_url")
+    if isinstance(raw_source_url, str):
+        state.source_url = raw_source_url.strip() or None
+    raw_kie_file_id = payload.get("kie_file_id")
+    if isinstance(raw_kie_file_id, str):
+        state.kie_file_id = raw_kie_file_id.strip() or None
+    if state.source_url is None and state.cover_source_url:
+        state.source_url = state.cover_source_url
     return state
 
 
@@ -211,15 +228,37 @@ def clear_style(state: SunoState) -> SunoState:
     return state
 
 
-def set_cover_source(state: SunoState, url: Optional[str], label: Optional[str] = None) -> SunoState:
+def set_cover_source(
+    state: SunoState,
+    url: Optional[str],
+    label: Optional[str] = None,
+    *,
+    file_id: Optional[str] = None,
+    source_url: Optional[str] = None,
+    kie_file_id: Optional[str] = None,
+) -> SunoState:
     state.cover_source_url = (url or "").strip() or None
     state.cover_source_label = (label or "").strip() or None
+    if file_id is not None:
+        text = str(file_id).strip()
+        state.source_file_id = text or None
+    if source_url is not None:
+        text = str(source_url).strip()
+        state.source_url = text or None
+    elif url is not None:
+        state.source_url = state.cover_source_url
+    if kie_file_id is not None:
+        text = str(kie_file_id).strip()
+        state.kie_file_id = text or None
     return state
 
 
 def clear_cover_source(state: SunoState) -> SunoState:
     state.cover_source_url = None
     state.cover_source_label = None
+    state.source_file_id = None
+    state.source_url = None
+    state.kie_file_id = None
     return state
 
 


### PR DESCRIPTION
## Summary
- add helpers to validate cover sources and upload them to the configured KIE endpoints
- persist uploaded source metadata in the Suno state and adjust the cover card to show the new status
- handle audio and URL inputs for the cover flow, update prompts to Russian, and only enable generation when the source is ready

## Testing
- pytest tests/test_suno_basic.py

------
https://chatgpt.com/codex/tasks/task_e_68dbfd9fe27c8322a31b54af98118c0e