### PR TITLE
Reset Suno card on mode switch and fix cover uploads

### DIFF
--- a/ui_helpers.py
+++ b/ui_helpers.py
@@ -288,7 +288,7 @@ def render_suno_card(
         if suno_state.kie_file_id:
             source_info = f"загружено ✅ (id: {html.escape(suno_state.kie_file_id)})"
         else:
-            source_info = "не загружен"
+            source_info = "—"
         lines = ["🎚️ <b>Ковер</b>"]
         lines.append(f"✏️ Название: {title_display}")
         lines.append(f"🎧 Источник: {source_info}")

--- a/utils/suno_state.py
+++ b/utils/suno_state.py
@@ -268,6 +268,32 @@ def clear_cover_source(state: SunoState) -> SunoState:
     return state
 
 
+def reset_suno_card_state(
+    state: SunoState,
+    mode: Literal["instrumental", "lyrics", "cover"],
+    *,
+    card_message_id: Optional[int] = None,
+    card_chat_id: Optional[int] = None,
+) -> SunoState:
+    state.mode = mode
+    state.title = None
+    state.style = None
+    state.lyrics = None
+    state.preset = None
+    state.cover_source_url = None
+    state.cover_source_label = None
+    state.source_file_id = None
+    state.source_url = None
+    state.kie_file_id = None
+    state.card_message_id = card_message_id
+    state.card_text_hash = None
+    state.card_markup_hash = None
+    state.card_chat_id = card_chat_id
+    state.last_card_hash = None
+    state.start_msg_id = None
+    return state
+
+
 def set_lyrics(state: SunoState, value: Optional[str]) -> SunoState:
     state.lyrics = _clean_lyrics(value)
     return state
@@ -422,4 +448,5 @@ __all__ = [
     "set_title",
     "style_preview",
     "clear_cover_source",
+    "reset_suno_card_state",
 ]


### PR DESCRIPTION
## Summary
- reset the saved Suno card state whenever a mode is selected so fields start empty and any stray start message is cleared safely
- update the cover flow to log structured upload events, surface friendly errors, and persist KIE identifiers while showing placeholders in the card
- add a reusable helper for safely deleting Telegram messages used when resetting the card

## Testing
- `pytest tests/test_music_flow.py::test_cover_upload_flow_accepts_audio -q` *(fails: download/upload stubs not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc128f40f88322b456e1dcd46651c2