### PR TITLE
Handle Suno cover source uploads and start guard

### DIFF
--- a/tests/suno_test_utils.py
+++ b/tests/suno_test_utils.py
@@ -1,0 +1,89 @@
+import asyncio
+import importlib
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+os.environ.setdefault("SUNO_API_BASE", "https://example.com")
+os.environ.setdefault("SUNO_API_TOKEN", "token")
+os.environ.setdefault("SUNO_CALLBACK_URL", "https://callback.example")
+os.environ.setdefault("SUNO_CALLBACK_SECRET", "secret")
+os.environ.setdefault("TELEGRAM_TOKEN", "dummy-token")
+os.environ.setdefault("KIE_API_KEY", "test-key")
+os.environ.setdefault("KIE_BASE_URL", "https://example.com")
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
+os.environ.setdefault("LEDGER_BACKEND", "memory")
+os.environ.setdefault("LOG_JSON", "false")
+os.environ.setdefault("LOG_LEVEL", "WARNING")
+
+bot_module = importlib.import_module("bot")
+
+
+class FakeBot:
+    def __init__(self) -> None:
+        self.sent: list[dict[str, object]] = []
+        self.edited: list[dict[str, object]] = []
+        self.deleted: list[dict[str, object]] = []
+        self._next_message_id = 100
+
+    async def send_message(self, **kwargs):  # type: ignore[override]
+        self.sent.append(kwargs)
+        message_id = self._next_message_id
+        self._next_message_id += 1
+        return SimpleNamespace(message_id=message_id)
+
+    async def edit_message_text(self, **kwargs):  # type: ignore[override]
+        self.edited.append(kwargs)
+        return SimpleNamespace(message_id=kwargs.get("message_id"))
+
+    async def delete_message(self, *args, **kwargs):  # type: ignore[override]
+        if args:
+            chat_id = args[0] if len(args) > 0 else kwargs.get("chat_id")
+            message_id = args[1] if len(args) > 1 else kwargs.get("message_id")
+            payload = {"chat_id": chat_id, "message_id": message_id}
+        else:
+            payload = kwargs
+        self.deleted.append(payload)
+        return True
+
+    async def send_chat_action(self, **_kwargs):  # type: ignore[override]
+        return None
+
+    async def get_file(self, file_id: str):  # type: ignore[override]
+        return SimpleNamespace(file_path=f"audio/{file_id}.mp3")
+
+
+class DummyMessage:
+    def __init__(self, text: str, chat_id: int) -> None:
+        self.text = text
+        self.chat_id = chat_id
+        self.replies: list[str] = []
+        self.voice = None
+        self.audio = None
+
+    async def reply_text(self, text: str, **_kwargs):  # type: ignore[override]
+        self.replies.append(text)
+        return SimpleNamespace(message_id=900 + len(self.replies))
+
+
+def setup_cover_context(chat_id: int = 777):
+    bot = FakeBot()
+    ctx = SimpleNamespace(bot=bot, user_data={})
+    state_dict = bot_module.state(ctx)
+    asyncio.run(bot_module.refresh_suno_card(ctx, chat_id=chat_id, state_dict=state_dict, price=bot_module.PRICE_SUNO))
+    return ctx, state_dict, bot
+
+
+__all__ = [
+    "DummyMessage",
+    "FakeBot",
+    "bot_module",
+    "setup_cover_context",
+]

--- a/tests/test_cover_upload_invalid.py
+++ b/tests/test_cover_upload_invalid.py
@@ -1,0 +1,126 @@
+import asyncio
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from suno.cover_source import CoverSourceClientError, CoverSourceUnavailableError, CoverSourceValidationError
+from utils.suno_state import load as load_suno_state
+
+from tests.suno_test_utils import DummyMessage, bot_module, setup_cover_context
+
+
+class InvalidAudio:
+    def __init__(self) -> None:
+        self.file_id = "bad123"
+        self.file_name = "track.txt"
+        self.mime_type = "text/plain"
+        self.file_size = 1024
+        self.duration = 2
+
+
+def _prepare_cover_state(ctx, state_dict, chat_id):
+    state_dict["mode"] = "suno"
+    asyncio.run(bot_module._music_begin_flow(chat_id, ctx, state_dict, flow="cover", user_id=77))
+
+
+def test_cover_upload_invalid_url(monkeypatch):
+    ctx, state_dict, _bot = setup_cover_context()
+    chat_id = 888
+    _prepare_cover_state(ctx, state_dict, chat_id)
+
+    async def fake_ensure(_url: str) -> str:
+        raise CoverSourceValidationError("bad-url")
+
+    monkeypatch.setattr(bot_module, "ensure_cover_audio_url", fake_ensure)
+
+    message = DummyMessage("not a link", chat_id)
+    result = asyncio.run(
+        bot_module._cover_process_url_input(
+            ctx,
+            chat_id,
+            message,
+            state_dict,
+            message.text,
+            user_id=77,
+        )
+    )
+
+    assert result is True
+    assert message.replies[-1] == bot_module._COVER_INVALID_INPUT_MESSAGE
+    assert load_suno_state(ctx).kie_file_id is None
+
+
+def test_cover_upload_invalid_audio(monkeypatch):
+    ctx, state_dict, _bot = setup_cover_context()
+    chat_id = 889
+    _prepare_cover_state(ctx, state_dict, chat_id)
+
+    message = DummyMessage("", chat_id)
+    message.audio = InvalidAudio()
+
+    result = asyncio.run(
+        bot_module._cover_process_audio_input(
+            ctx,
+            chat_id,
+            message,
+            state_dict,
+            message.audio,
+            user_id=77,
+        )
+    )
+
+    assert result is True
+    assert message.replies[-1] == bot_module._COVER_INVALID_INPUT_MESSAGE
+    assert load_suno_state(ctx).kie_file_id is None
+
+
+def test_cover_upload_service_errors(monkeypatch):
+    ctx, state_dict, _bot = setup_cover_context()
+    chat_id = 890
+    _prepare_cover_state(ctx, state_dict, chat_id)
+
+    async def fake_ensure(url: str) -> str:
+        return url
+
+    async def fake_upload(_url: str, **_kwargs) -> str:
+        raise CoverSourceClientError("status:400")
+
+    monkeypatch.setattr(bot_module, "ensure_cover_audio_url", fake_ensure)
+    monkeypatch.setattr(bot_module, "upload_cover_url", fake_upload)
+
+    message = DummyMessage("https://example.com/track.mp3", chat_id)
+    result = asyncio.run(
+        bot_module._cover_process_url_input(
+            ctx,
+            chat_id,
+            message,
+            state_dict,
+            message.text,
+            user_id=77,
+        )
+    )
+
+    assert result is True
+    assert message.replies[-1] == bot_module._COVER_UPLOAD_CLIENT_ERROR_MESSAGE
+
+    async def fake_upload_unavailable(_url: str, **_kwargs) -> str:
+        raise CoverSourceUnavailableError("status:503")
+
+    monkeypatch.setattr(bot_module, "upload_cover_url", fake_upload_unavailable)
+    message_error = DummyMessage("https://example.com/track.mp3", chat_id)
+    result_error = asyncio.run(
+        bot_module._cover_process_url_input(
+            ctx,
+            chat_id,
+            message_error,
+            state_dict,
+            message_error.text,
+            user_id=77,
+        )
+    )
+
+    assert result_error is True
+    assert message_error.replies[-1] == bot_module._COVER_UPLOAD_SERVICE_ERROR_MESSAGE

--- a/tests/test_cover_upload_stream_ok.py
+++ b/tests/test_cover_upload_stream_ok.py
@@ -1,0 +1,84 @@
+import asyncio
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from ui_helpers import render_suno_card
+from utils.suno_state import load as load_suno_state, save as save_suno_state, set_style as set_suno_style, set_title as set_suno_title
+
+from tests.suno_test_utils import DummyMessage, bot_module, setup_cover_context
+
+
+class DummyAudio:
+    def __init__(self) -> None:
+        self.file_id = "file123"
+        self.file_name = "demo.mp3"
+        self.mime_type = "audio/mpeg"
+        self.file_size = 1024
+        self.duration = 10
+
+
+def test_cover_upload_stream_ok(monkeypatch):
+    ctx, state_dict, _bot = setup_cover_context()
+    chat_id = 555
+    state_dict["mode"] = "suno"
+
+    asyncio.run(bot_module._music_begin_flow(chat_id, ctx, state_dict, flow="cover", user_id=51))
+
+    suno_state = load_suno_state(ctx)
+    set_suno_title(suno_state, "Ocean waves")
+    set_suno_style(suno_state, "calm ambient")
+    save_suno_state(ctx, suno_state)
+    state_dict["suno_state"] = suno_state.to_dict()
+
+    captured: dict[str, object] = {}
+
+    async def fake_download(url: str, **_kwargs) -> bytes:
+        captured["download_url"] = url
+        return b"1234"
+
+    async def fake_upload(data: bytes, filename: str, mime_type: str, **_kwargs) -> str:
+        captured["uploaded_bytes"] = data
+        captured["filename"] = filename
+        captured["mime"] = mime_type
+        return "kie-audio-999"
+
+    monkeypatch.setattr(bot_module, "_download_telegram_file", fake_download)
+    monkeypatch.setattr(bot_module, "upload_cover_stream", fake_upload)
+
+    message = DummyMessage("", chat_id)
+    message.audio = DummyAudio()
+
+    result = asyncio.run(
+        bot_module._cover_process_audio_input(
+            ctx,
+            chat_id,
+            message,
+            state_dict,
+            message.audio,
+            user_id=51,
+        )
+    )
+
+    assert result is True
+    assert message.replies[-1] == "🎧 Источник загружен. Можно продолжать."
+    assert captured["filename"] == "demo.mp3"
+    assert captured["mime"] == "audio/mpeg"
+    assert captured["uploaded_bytes"] == b"1234"
+
+    updated_state = load_suno_state(ctx)
+    assert updated_state.kie_file_id == "kie-audio-999"
+    assert updated_state.cover_source_label == "demo.mp3"
+
+    text, _markup, ready = render_suno_card(
+        updated_state,
+        price=bot_module.PRICE_SUNO,
+        balance=None,
+        generating=False,
+        waiting_enqueue=False,
+    )
+    assert "загружено ✅ (id: kie-audio-999)" in text
+    assert ready is True

--- a/tests/test_cover_upload_url_ok.py
+++ b/tests/test_cover_upload_url_ok.py
@@ -1,0 +1,70 @@
+import asyncio
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from ui_helpers import render_suno_card
+from utils.suno_state import load as load_suno_state, save as save_suno_state, set_style as set_suno_style, set_title as set_suno_title
+
+from tests.suno_test_utils import DummyMessage, bot_module, setup_cover_context
+
+
+def test_cover_upload_url_ok(monkeypatch):
+    ctx, state_dict, _bot = setup_cover_context()
+    chat_id = 777
+    state_dict["mode"] = "suno"
+
+    asyncio.run(bot_module._music_begin_flow(chat_id, ctx, state_dict, flow="cover", user_id=42))
+
+    suno_state = load_suno_state(ctx)
+    set_suno_title(suno_state, "My Cover")
+    set_suno_style(suno_state, "ambient dream pop")
+    save_suno_state(ctx, suno_state)
+    state_dict["suno_state"] = suno_state.to_dict()
+
+    captured: dict[str, str] = {}
+
+    async def fake_upload(url: str, **_kwargs) -> str:
+        captured["uploaded"] = url
+        return "kie-test-123"
+
+    async def fake_ensure(url: str) -> str:
+        captured["ensured"] = url
+        return url
+
+    monkeypatch.setattr(bot_module, "upload_cover_url", fake_upload)
+    monkeypatch.setattr(bot_module, "ensure_cover_audio_url", fake_ensure)
+
+    message = DummyMessage("https://example.com/song.mp3", chat_id)
+    result = asyncio.run(
+        bot_module._cover_process_url_input(
+            ctx,
+            chat_id,
+            message,
+            state_dict,
+            message.text,
+            user_id=42,
+        )
+    )
+
+    assert result is True
+    assert message.replies[-1] == "🎧 Источник загружен. Можно продолжать."
+    assert captured["uploaded"] == "https://example.com/song.mp3"
+    assert captured["ensured"] == "https://example.com/song.mp3"
+
+    updated_state = load_suno_state(ctx)
+    assert updated_state.kie_file_id == "kie-test-123"
+    assert updated_state.source_url == "https://example.com/song.mp3"
+
+    text, _markup, ready = render_suno_card(
+        updated_state,
+        price=bot_module.PRICE_SUNO,
+        balance=None,
+        generating=False,
+        waiting_enqueue=False,
+    )
+    assert "загружено ✅ (id: kie-test-123)" in text
+    assert ready is True

--- a/tests/test_no_style_preview_guard.py
+++ b/tests/test_no_style_preview_guard.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from utils.suno_state import SunoState, set_style as set_suno_style
+
+from tests.suno_test_utils import bot_module
+
+
+def test_no_style_preview_guard(monkeypatch):
+    state = SunoState(mode="instrumental")
+    set_suno_style(state, "dream pop with long description" * 3)
+
+    monkeypatch.delattr(bot_module, "suno_style_preview", raising=False)
+
+    summary = bot_module._suno_summary_text(state)
+    assert "dream pop" in summary

--- a/tests/test_start_calls_existing_handler.py
+++ b/tests/test_start_calls_existing_handler.py
@@ -1,0 +1,89 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from utils.suno_state import load as load_suno_state, save as save_suno_state, set_style as set_suno_style, set_title as set_suno_title
+
+from tests.suno_test_utils import FakeBot, bot_module
+
+
+class FakeMessage:
+    def __init__(self, chat_id: int) -> None:
+        self.chat_id = chat_id
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **_kwargs):  # type: ignore[override]
+        self.replies.append(text)
+        return SimpleNamespace(message_id=400)
+
+
+class FakeCallback:
+    def __init__(self, chat_id: int) -> None:
+        self.data = "suno:start"
+        self.message = FakeMessage(chat_id)
+        self._answered: list[tuple[str | None, bool]] = []
+
+    async def answer(self, text: str | None = None, show_alert: bool = False):  # type: ignore[override]
+        self._answered.append((text, show_alert))
+
+
+def test_start_calls_existing_handler(monkeypatch):
+    bot = FakeBot()
+    ctx = SimpleNamespace(bot=bot, user_data={})
+    state_dict = bot_module.state(ctx)
+
+    chat_id = 999
+    user_id = 555
+    state_dict["mode"] = "suno"
+
+    suno_state = load_suno_state(ctx)
+    suno_state.mode = "instrumental"
+    set_suno_title(suno_state, "Ready Song")
+    set_suno_style(suno_state, "ambient focus")
+    save_suno_state(ctx, suno_state)
+    state_dict["suno_state"] = suno_state.to_dict()
+
+    captured: dict[str, object] = {}
+
+    async def fake_launch(chat_id_param, ctx_param, **kwargs):  # type: ignore[override]
+        captured["launch"] = {
+            "chat_id": chat_id_param,
+            "user_id": kwargs.get("user_id"),
+            "trigger": kwargs.get("trigger"),
+        }
+
+    async def fake_notify(*_args, **_kwargs):  # type: ignore[override]
+        return None
+
+    def fake_acquire(_user_id: int) -> bool:
+        captured.setdefault("acquired", True)
+        return True
+
+    def fake_release(_user_id: int) -> None:
+        captured["released"] = True
+
+    monkeypatch.setattr(bot_module, "_launch_suno_generation", fake_launch)
+    monkeypatch.setattr(bot_module, "_suno_notify", fake_notify)
+    monkeypatch.setattr(bot_module, "_acquire_suno_lock", fake_acquire)
+    monkeypatch.setattr(bot_module, "_release_suno_lock", fake_release)
+
+    update = SimpleNamespace(
+        callback_query=FakeCallback(chat_id),
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+    )
+
+    asyncio.run(bot_module.on_callback(update, ctx))
+
+    assert "launch" in captured
+    launch_meta = captured["launch"]
+    assert launch_meta["chat_id"] == chat_id
+    assert launch_meta["user_id"] == user_id
+    assert launch_meta["trigger"] == "start"
+    assert captured.get("acquired") is True
+    assert captured.get("released") is True

--- a/tests/test_start_msg_appears_and_disappears.py
+++ b/tests/test_start_msg_appears_and_disappears.py
@@ -1,0 +1,71 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from texts import SUNO_START_READY_MESSAGE
+from ui_helpers import sync_suno_start_message
+from utils.suno_state import SunoState
+
+from tests.suno_test_utils import FakeBot
+
+
+def test_start_msg_appears_and_disappears():
+    bot = FakeBot()
+    ctx = SimpleNamespace(bot=bot)
+    suno_state = SunoState(mode="cover")
+    state_dict = {"suno_state": suno_state.to_dict(), "msg_ids": {}}
+    chat_id = 123
+
+    # Initial call without readiness should not send anything.
+    result_initial = asyncio.run(
+        sync_suno_start_message(
+            ctx,
+            chat_id,
+            state_dict,
+            suno_state=suno_state,
+            ready=False,
+            generating=False,
+            waiting_enqueue=False,
+        )
+    )
+    assert result_initial is None
+    assert not bot.sent
+
+    # Ready state should trigger a new message.
+    result_ready = asyncio.run(
+        sync_suno_start_message(
+            ctx,
+            chat_id,
+            state_dict,
+            suno_state=suno_state,
+            ready=True,
+            generating=False,
+            waiting_enqueue=False,
+        )
+    )
+    assert isinstance(result_ready, int)
+    assert bot.sent[-1]["text"] == SUNO_START_READY_MESSAGE
+    assert state_dict["suno_start_msg_id"] == result_ready
+    assert suno_state.start_msg_id == result_ready
+
+    # Losing readiness should remove the message.
+    result_hidden = asyncio.run(
+        sync_suno_start_message(
+            ctx,
+            chat_id,
+            state_dict,
+            suno_state=suno_state,
+            ready=False,
+            generating=False,
+            waiting_enqueue=False,
+        )
+    )
+    assert result_hidden is None
+    assert bot.deleted[-1]["message_id"] == result_ready
+    assert state_dict.get("suno_start_msg_id") is None
+    assert suno_state.start_msg_id is None


### PR DESCRIPTION
## Summary
- accept Suno cover source URLs or audio files while tracking the new waiting state and uploaded kie_file_id
- harden summary rendering when the optional style preview helper is missing and ensure start message lifecycle logic is reusable
- add targeted pytest coverage for cover uploads, start button behaviour, and the preview guard

## Testing
- pytest tests/test_cover_upload_url_ok.py tests/test_cover_upload_stream_ok.py tests/test_cover_upload_invalid.py tests/test_start_msg_appears_and_disappears.py tests/test_start_calls_existing_handler.py tests/test_no_style_preview_guard.py

------
https://chatgpt.com/codex/tasks/task_e_68dc17fe08bc8322bc93573a83e3b964