### PR TITLE
Send start emoji and guard Suno generation idempotency

### DIFF
--- a/telegram_utils.py
+++ b/telegram_utils.py
@@ -716,6 +716,27 @@ async def safe_send_placeholder(bot: Any, chat_id: int, text: str) -> Optional[M
     )
 
 
+async def safe_send_sticker(
+    bot: Any,
+    chat_id: int,
+    sticker: str,
+    *,
+    req_id: Optional[str] = None,
+    max_attempts: int = 4,
+    **kwargs: Any,
+) -> Optional[Any]:
+    return await safe_send(
+        bot.send_sticker,
+        method_name="send_sticker",
+        kind="sticker",
+        req_id=req_id,
+        max_attempts=max_attempts,
+        chat_id=chat_id,
+        sticker=sticker,
+        **kwargs,
+    )
+
+
 async def run_ffmpeg(input_bytes: bytes, args: list[str], timeout: float = 40.0) -> bytes:
     ffmpeg_bin = (os.getenv("FFMPEG_BIN") or "ffmpeg").strip() or "ffmpeg"
     cmd = [ffmpeg_bin, *args]
@@ -839,6 +860,7 @@ __all__ = [
     "safe_send",
     "safe_send_text",
     "safe_send_placeholder",
+    "safe_send_sticker",
     "safe_edit_text",
     "safe_edit_markdown_v2",
     "run_ffmpeg",

--- a/tests/suno_test_utils.py
+++ b/tests/suno_test_utils.py
@@ -39,6 +39,14 @@ class FakeBot:
         self._next_message_id += 1
         return SimpleNamespace(message_id=message_id)
 
+    async def send_sticker(self, **kwargs):  # type: ignore[override]
+        payload = dict(kwargs)
+        payload.setdefault("_method", "send_sticker")
+        self.sent.append(payload)
+        message_id = self._next_message_id
+        self._next_message_id += 1
+        return SimpleNamespace(message_id=message_id)
+
     async def edit_message_text(self, **kwargs):  # type: ignore[override]
         self.edited.append(kwargs)
         return SimpleNamespace(message_id=kwargs.get("message_id"))

--- a/tests/test_start_idempotent_under_race.py
+++ b/tests/test_start_idempotent_under_race.py
@@ -1,0 +1,112 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from utils.suno_state import (
+    load as load_suno_state,
+    save as save_suno_state,
+    set_style as set_suno_style,
+    set_title as set_suno_title,
+)
+
+from tests.suno_test_utils import FakeBot, bot_module
+
+
+class FakeMessage:
+    def __init__(self, chat_id: int) -> None:
+        self.chat_id = chat_id
+
+    async def reply_text(self, *_args, **_kwargs):  # type: ignore[override]
+        return SimpleNamespace(message_id=401)
+
+
+class FakeCallback:
+    def __init__(self, chat_id: int) -> None:
+        self.data = "suno:start"
+        self.message = FakeMessage(chat_id)
+        self._answers: list[tuple[str | None, bool]] = []
+
+    async def answer(self, text: str | None = None, show_alert: bool = False):  # type: ignore[override]
+        self._answers.append((text, show_alert))
+
+
+def _prepare_state(ctx, chat_id: int, user_id: int) -> None:
+    state_dict = bot_module.state(ctx)
+    state_dict["mode"] = "suno"
+    suno_state = load_suno_state(ctx)
+    suno_state.mode = "instrumental"
+    set_suno_title(suno_state, "Race Song")
+    set_suno_style(suno_state, "chill")
+    save_suno_state(ctx, suno_state)
+    state_dict["suno_state"] = suno_state.to_dict()
+    start_msg_id = 555
+    suno_state.start_msg_id = start_msg_id
+    save_suno_state(ctx, suno_state)
+    state_dict["suno_state"] = suno_state.to_dict()
+    state_dict["suno_start_msg_id"] = start_msg_id
+    state_dict.setdefault("msg_ids", {})["suno_start"] = start_msg_id
+
+
+def test_start_idempotent_under_race(monkeypatch):
+    bot = FakeBot()
+    ctx = SimpleNamespace(bot=bot, user_data={})
+    chat_id = 42
+    user_id = 77
+    _prepare_state(ctx, chat_id, user_id)
+
+    monkeypatch.setattr(bot_module, "START_EMOJI_STICKER_ID", "race-sticker")
+    monkeypatch.setattr(bot_module, "START_EMOJI_FALLBACK", "🎬")
+
+    launch_calls: list[dict[str, object]] = []
+
+    async def fake_launch(chat_id_param, ctx_param, **kwargs):  # type: ignore[override]
+        launch_calls.append({"chat_id": chat_id_param, "user_id": kwargs.get("user_id")})
+
+    async def fake_notify(*_args, **_kwargs):  # type: ignore[override]
+        return None
+
+    sticker_calls = 0
+
+    async def controlled_sticker(bot_obj, chat, sticker, **kwargs):  # type: ignore[override]
+        nonlocal sticker_calls
+        sticker_calls += 1
+        await asyncio.sleep(0)
+        return await FakeBot.send_sticker(bot_obj, chat_id=chat, sticker=sticker, **kwargs)
+
+    monkeypatch.setattr(bot_module, "_launch_suno_generation", fake_launch)
+    monkeypatch.setattr(bot_module, "_suno_notify", fake_notify)
+    monkeypatch.setattr(bot_module, "safe_send_sticker", controlled_sticker)
+
+    update_one = SimpleNamespace(
+        callback_query=FakeCallback(chat_id),
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+    )
+    update_two = SimpleNamespace(
+        callback_query=FakeCallback(chat_id),
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+    )
+
+    async def _run_parallel() -> None:
+        await asyncio.gather(
+            bot_module.on_callback(update_one, ctx),
+            bot_module.on_callback(update_two, ctx),
+        )
+
+    asyncio.run(_run_parallel())
+
+    assert sticker_calls == 1
+    assert len([item for item in bot.sent if item.get("_method") == "send_sticker"]) == 1
+    assert len(launch_calls) == 1
+
+    suno_state_after = load_suno_state(ctx)
+    assert suno_state_after.start_clicked is True
+    assert suno_state_after.start_emoji_msg_id == 100

--- a/tests/test_start_redis_lock_blocks_duplicates.py
+++ b/tests/test_start_redis_lock_blocks_duplicates.py
@@ -1,0 +1,114 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from utils.suno_state import (
+    load as load_suno_state,
+    save as save_suno_state,
+    set_style as set_suno_style,
+    set_title as set_suno_title,
+)
+
+from tests.suno_test_utils import FakeBot, bot_module
+
+
+class FakeMessage:
+    def __init__(self, chat_id: int) -> None:
+        self.chat_id = chat_id
+
+    async def reply_text(self, *_args, **_kwargs):  # type: ignore[override]
+        return SimpleNamespace(message_id=402)
+
+
+class FakeCallback:
+    def __init__(self, chat_id: int) -> None:
+        self.data = "suno:start"
+        self.message = FakeMessage(chat_id)
+        self._answers: list[tuple[str | None, bool]] = []
+
+    async def answer(self, text: str | None = None, show_alert: bool = False):  # type: ignore[override]
+        self._answers.append((text, show_alert))
+
+
+def _ready_state(ctx, chat_id: int) -> None:
+    state_dict = bot_module.state(ctx)
+    state_dict["mode"] = "suno"
+    suno_state = load_suno_state(ctx)
+    suno_state.mode = "instrumental"
+    set_suno_title(suno_state, "Redis Song")
+    set_suno_style(suno_state, "lofi")
+    save_suno_state(ctx, suno_state)
+    state_dict["suno_state"] = suno_state.to_dict()
+    start_msg_id = 777
+    suno_state.start_msg_id = start_msg_id
+    save_suno_state(ctx, suno_state)
+    state_dict["suno_state"] = suno_state.to_dict()
+    state_dict["suno_start_msg_id"] = start_msg_id
+    state_dict.setdefault("msg_ids", {})["suno_start"] = start_msg_id
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self._stored: set[str] = set()
+
+    def set(self, key: str, value: str, *, nx: bool = False, ex: int | None = None):  # type: ignore[override]
+        if nx and key in self._stored:
+            return False
+        if nx:
+            self._stored.add(key)
+        return True
+
+
+def test_start_redis_lock_blocks_duplicates(monkeypatch):
+    bot = FakeBot()
+    shared_redis = FakeRedis()
+
+    ctx_one = SimpleNamespace(bot=bot, user_data={})
+    ctx_two = SimpleNamespace(bot=bot, user_data={})
+    chat_id = 808
+    user_id = 909
+    _ready_state(ctx_one, chat_id)
+    _ready_state(ctx_two, chat_id)
+
+    monkeypatch.setattr(bot_module, "START_EMOJI_STICKER_ID", "redis-sticker")
+    monkeypatch.setattr(bot_module, "START_EMOJI_FALLBACK", "🎬")
+    monkeypatch.setattr(bot_module, "redis_client", shared_redis)
+    monkeypatch.setattr(bot_module, "REDIS_LOCK_ENABLED", True)
+
+    async def fake_launch(chat_id_param, ctx_param, **kwargs):  # type: ignore[override]
+        return None
+
+    async def fake_notify(*_args, **_kwargs):  # type: ignore[override]
+        return None
+
+    monkeypatch.setattr(bot_module, "_launch_suno_generation", fake_launch)
+    monkeypatch.setattr(bot_module, "_suno_notify", fake_notify)
+
+    update_one = SimpleNamespace(
+        callback_query=FakeCallback(chat_id),
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+    )
+    update_two = SimpleNamespace(
+        callback_query=FakeCallback(chat_id),
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+    )
+
+    asyncio.run(bot_module.on_callback(update_one, ctx_one))
+    asyncio.run(bot_module.on_callback(update_two, ctx_two))
+
+    stickers = [item for item in bot.sent if item.get("_method") == "send_sticker"]
+    assert len(stickers) == 1
+
+    state_one = load_suno_state(ctx_one)
+    state_two = load_suno_state(ctx_two)
+    assert state_one.start_clicked is True
+    assert state_two.start_clicked is False

--- a/tests/test_start_sends_big_emoji_once.py
+++ b/tests/test_start_sends_big_emoji_once.py
@@ -1,0 +1,211 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from telegram.error import BadRequest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from texts import SUNO_STARTING_MESSAGE
+from utils.suno_state import (
+    load as load_suno_state,
+    save as save_suno_state,
+    set_style as set_suno_style,
+    set_title as set_suno_title,
+)
+
+from tests.suno_test_utils import FakeBot, bot_module
+
+
+class FakeMessage:
+    def __init__(self, chat_id: int) -> None:
+        self.chat_id = chat_id
+        self.replies: list[str] = []
+
+    async def reply_text(self, text: str, **_kwargs):  # type: ignore[override]
+        self.replies.append(text)
+        return SimpleNamespace(message_id=400)
+
+
+class FakeCallback:
+    def __init__(self, chat_id: int) -> None:
+        self.data = "suno:start"
+        self.message = FakeMessage(chat_id)
+        self._answered: list[tuple[str | None, bool]] = []
+
+    async def answer(self, text: str | None = None, show_alert: bool = False):  # type: ignore[override]
+        self._answered.append((text, show_alert))
+
+
+def _prepare_ready_context(ctx, chat_id: int, user_id: int) -> int:
+    state_dict = bot_module.state(ctx)
+    state_dict["mode"] = "suno"
+    suno_state = load_suno_state(ctx)
+    suno_state.mode = "instrumental"
+    set_suno_title(suno_state, "Ready Song")
+    set_suno_style(suno_state, "calm focus")
+    save_suno_state(ctx, suno_state)
+    state_dict["suno_state"] = suno_state.to_dict()
+    start_msg_id = 123
+    suno_state.start_msg_id = start_msg_id
+    save_suno_state(ctx, suno_state)
+    state_dict["suno_state"] = suno_state.to_dict()
+    state_dict["suno_start_msg_id"] = start_msg_id
+    msg_ids = state_dict.setdefault("msg_ids", {})
+    msg_ids["suno_start"] = start_msg_id
+    return start_msg_id
+
+
+def test_start_sends_big_emoji_once(monkeypatch):
+    bot = FakeBot()
+    ctx = SimpleNamespace(bot=bot, user_data={})
+    chat_id = 999
+    user_id = 555
+    start_msg_id = _prepare_ready_context(ctx, chat_id, user_id)
+
+    monkeypatch.setattr(bot_module, "START_EMOJI_STICKER_ID", "sticker-file-id")
+    monkeypatch.setattr(bot_module, "START_EMOJI_FALLBACK", "🎬")
+
+    launch_calls: list[dict[str, object]] = []
+
+    async def fake_launch(chat_id_param, ctx_param, **kwargs):  # type: ignore[override]
+        launch_calls.append({
+            "chat_id": chat_id_param,
+            "user_id": kwargs.get("user_id"),
+            "trigger": kwargs.get("trigger"),
+        })
+
+    notify_calls: list[str] = []
+
+    async def fake_notify(_ctx, _chat_id, text, **_kwargs):  # type: ignore[override]
+        notify_calls.append(text)
+        return None
+
+    monkeypatch.setattr(bot_module, "_launch_suno_generation", fake_launch)
+    monkeypatch.setattr(bot_module, "_suno_notify", fake_notify)
+
+    update = SimpleNamespace(
+        callback_query=FakeCallback(chat_id),
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+    )
+
+    asyncio.run(bot_module.on_callback(update, ctx))
+
+    sticker_entries = [item for item in bot.sent if item.get("_method") == "send_sticker"]
+    assert len(sticker_entries) == 1
+    assert sticker_entries[0]["sticker"] == "sticker-file-id"
+
+    suno_state_after = load_suno_state(ctx)
+    assert suno_state_after.start_clicked is True
+    assert suno_state_after.start_emoji_msg_id == 100
+    assert suno_state_after.start_msg_id is None
+
+    assert ctx.user_data["suno_state"]["start_clicked"] is True
+    assert ctx.user_data["suno_state"]["start_msg_id"] is None
+
+    assert launch_calls and launch_calls[0]["trigger"] == "start"
+    assert notify_calls, "summary notification should be sent"
+
+    # Second click should be ignored entirely.
+    second_update = SimpleNamespace(
+        callback_query=FakeCallback(chat_id),
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+    )
+
+    asyncio.run(bot_module.on_callback(second_update, ctx))
+
+    sticker_entries_after = [item for item in bot.sent if item.get("_method") == "send_sticker"]
+    assert len(sticker_entries_after) == 1
+    assert len(launch_calls) == 1
+
+
+def test_start_button_disabled_after_click(monkeypatch):
+    bot = FakeBot()
+    ctx = SimpleNamespace(bot=bot, user_data={})
+    chat_id = 111
+    user_id = 222
+    start_msg_id = _prepare_ready_context(ctx, chat_id, user_id)
+
+    monkeypatch.setattr(bot_module, "START_EMOJI_STICKER_ID", "sticker")
+    monkeypatch.setattr(bot_module, "START_EMOJI_FALLBACK", "🎬")
+
+    async def fake_launch(*_args, **_kwargs):  # type: ignore[override]
+        return None
+
+    async def fake_notify(*_args, **_kwargs):  # type: ignore[override]
+        return None
+
+    monkeypatch.setattr(bot_module, "_launch_suno_generation", fake_launch)
+    monkeypatch.setattr(bot_module, "_suno_notify", fake_notify)
+
+    update = SimpleNamespace(
+        callback_query=FakeCallback(chat_id),
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+    )
+
+    asyncio.run(bot_module.on_callback(update, ctx))
+
+    assert bot.edited, "start message should be edited"
+    edited_payload = bot.edited[-1]
+    assert edited_payload["message_id"] == start_msg_id
+    assert edited_payload["chat_id"] == chat_id
+    assert edited_payload["text"] == SUNO_STARTING_MESSAGE
+    assert edited_payload.get("reply_markup") is None
+
+    state_after = load_suno_state(ctx)
+    assert state_after.start_msg_id is None
+    assert state_after.start_clicked is True
+
+    state_dict = bot_module.state(ctx)
+    assert state_dict.get("suno_start_msg_id") is None
+    msg_ids = state_dict.get("msg_ids")
+    if isinstance(msg_ids, dict):
+        assert "suno_start" not in msg_ids
+
+
+def test_start_sticker_fallback_to_emoji(monkeypatch):
+    bot = FakeBot()
+    ctx = SimpleNamespace(bot=bot, user_data={})
+    chat_id = 333
+    user_id = 444
+    _prepare_ready_context(ctx, chat_id, user_id)
+
+    monkeypatch.setattr(bot_module, "START_EMOJI_STICKER_ID", "broken-sticker")
+    monkeypatch.setattr(bot_module, "START_EMOJI_FALLBACK", "🎬")
+
+    async def fake_launch(*_args, **_kwargs):  # type: ignore[override]
+        return None
+
+    async def fake_notify(*_args, **_kwargs):  # type: ignore[override]
+        return None
+
+    async def failing_sticker(*_args, **_kwargs):  # type: ignore[override]
+        raise BadRequest("sticker failed")
+
+    monkeypatch.setattr(bot_module, "_launch_suno_generation", fake_launch)
+    monkeypatch.setattr(bot_module, "_suno_notify", fake_notify)
+    monkeypatch.setattr(bot_module, "safe_send_sticker", failing_sticker)
+
+    update = SimpleNamespace(
+        callback_query=FakeCallback(chat_id),
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+    )
+
+    asyncio.run(bot_module.on_callback(update, ctx))
+
+    sticker_entries = [item for item in bot.sent if item.get("_method") == "send_sticker"]
+    assert not sticker_entries
+
+    fallback_messages = [item for item in bot.sent if item.get("text") == "🎬"]
+    assert len(fallback_messages) == 1
+
+    suno_state_after = load_suno_state(ctx)
+    assert suno_state_after.start_emoji_msg_id == 100

--- a/tests/test_start_with_state_flag_blocks_second_click.py
+++ b/tests/test_start_with_state_flag_blocks_second_click.py
@@ -1,0 +1,101 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from utils.suno_state import (
+    load as load_suno_state,
+    save as save_suno_state,
+    set_style as set_suno_style,
+    set_title as set_suno_title,
+)
+
+from tests.suno_test_utils import FakeBot, bot_module
+
+
+class FakeMessage:
+    def __init__(self, chat_id: int) -> None:
+        self.chat_id = chat_id
+
+    async def reply_text(self, *_args, **_kwargs):  # type: ignore[override]
+        return SimpleNamespace(message_id=403)
+
+
+class FakeCallback:
+    def __init__(self, chat_id: int) -> None:
+        self.data = "suno:start"
+        self.message = FakeMessage(chat_id)
+        self._answers: list[tuple[str | None, bool]] = []
+
+    async def answer(self, text: str | None = None, show_alert: bool = False):  # type: ignore[override]
+        self._answers.append((text, show_alert))
+
+
+def _setup(ctx, chat_id: int) -> None:
+    state_dict = bot_module.state(ctx)
+    state_dict["mode"] = "suno"
+    suno_state = load_suno_state(ctx)
+    suno_state.mode = "instrumental"
+    set_suno_title(suno_state, "Flag Song")
+    set_suno_style(suno_state, "calm")
+    save_suno_state(ctx, suno_state)
+    state_dict["suno_state"] = suno_state.to_dict()
+    start_msg_id = 909
+    suno_state.start_msg_id = start_msg_id
+    save_suno_state(ctx, suno_state)
+    state_dict["suno_state"] = suno_state.to_dict()
+    state_dict["suno_start_msg_id"] = start_msg_id
+    state_dict.setdefault("msg_ids", {})["suno_start"] = start_msg_id
+
+
+def test_start_with_state_flag_blocks_second_click(monkeypatch):
+    bot = FakeBot()
+    ctx = SimpleNamespace(bot=bot, user_data={})
+    chat_id = 202
+    user_id = 303
+    _setup(ctx, chat_id)
+
+    monkeypatch.setattr(bot_module, "START_EMOJI_STICKER_ID", "flag-sticker")
+    monkeypatch.setattr(bot_module, "START_EMOJI_FALLBACK", "🎬")
+    monkeypatch.setattr(bot_module, "redis_client", None)
+    monkeypatch.setattr(bot_module, "REDIS_LOCK_ENABLED", False)
+
+    async def fake_launch(*_args, **_kwargs):  # type: ignore[override]
+        return None
+
+    async def fake_notify(*_args, **_kwargs):  # type: ignore[override]
+        return None
+
+    monkeypatch.setattr(bot_module, "_launch_suno_generation", fake_launch)
+    monkeypatch.setattr(bot_module, "_suno_notify", fake_notify)
+
+    update = SimpleNamespace(
+        callback_query=FakeCallback(chat_id),
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+    )
+
+    asyncio.run(bot_module.on_callback(update, ctx))
+
+    stickers = [item for item in bot.sent if item.get("_method") == "send_sticker"]
+    assert len(stickers) == 1
+
+    state_after = load_suno_state(ctx)
+    assert state_after.start_clicked is True
+
+    second_update = SimpleNamespace(
+        callback_query=FakeCallback(chat_id),
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+    )
+
+    asyncio.run(bot_module.on_callback(second_update, ctx))
+
+    stickers_after = [item for item in bot.sent if item.get("_method") == "send_sticker"]
+    assert len(stickers_after) == 1

--- a/texts.py
+++ b/texts.py
@@ -40,6 +40,7 @@ SUNO_RU = {
     "suno.prompt.step.generic": "🎯 Уточните следующий параметр.",
     "suno.prompt.fill": "Заполните: {fields}",
     "suno.prompt.ready": "Все обязательные поля заполнены. Можно запускать генерацию.",
+    "suno.prompt.starting": "Запускаю генерацию…",
     "suno.error.upload_client": "⚠️ Не удалось загрузить источник. Проверьте файл/ссылку и попробуйте ещё раз.",
     "suno.error.upload_service": "⚠️ Сервис загрузки недоступен. Попробуйте позже.",
 }
@@ -57,3 +58,4 @@ def t(key: str, /, **kwargs: Any) -> str:
 
 SUNO_MODE_PROMPT = t("suno.prompt.mode_select")
 SUNO_START_READY_MESSAGE = t("suno.prompt.ready")
+SUNO_STARTING_MESSAGE = t("suno.prompt.starting")

--- a/ui_helpers.py
+++ b/ui_helpers.py
@@ -317,6 +317,8 @@ async def sync_suno_start_message(
     else:
         text = SUNO_START_READY_MESSAGE
         markup = suno_start_keyboard()
+        suno_state.start_clicked = False
+        suno_state.start_emoji_msg_id = None
         if isinstance(start_msg_id, int):
             try:
                 await safe_edit_message(
@@ -360,6 +362,7 @@ async def sync_suno_start_message(
             msg_ids.pop("suno_start", None)
 
     suno_state.start_msg_id = start_msg_id
+    state_dict["suno_state"] = suno_state.to_dict()
     return start_msg_id
 
 

--- a/utils/safe_send.py
+++ b/utils/safe_send.py
@@ -168,6 +168,17 @@ async def safe_send(
     return last_message
 
 
+async def safe_send_sticker(
+    bot: Bot,
+    chat_id: int,
+    sticker: str,
+    **kwargs,
+) -> Optional[Message]:
+    """Send a sticker with best-effort error propagation."""
+
+    return await bot.send_sticker(chat_id=chat_id, sticker=sticker, **kwargs)
+
+
 async def safe_delete_message(bot: Bot, chat_id: int, message_id: int) -> bool:
     """Delete a message while suppressing common Telegram errors."""
 
@@ -232,4 +243,10 @@ async def send_html_with_fallback(
         )
 
 
-__all__ = ["safe_send", "send_html_with_fallback", "sanitize_html", "safe_delete_message"]
+__all__ = [
+    "safe_send",
+    "safe_send_sticker",
+    "send_html_with_fallback",
+    "sanitize_html",
+    "safe_delete_message",
+]

--- a/utils/suno_state.py
+++ b/utils/suno_state.py
@@ -120,6 +120,8 @@ class SunoState:
     source_url: Optional[str] = None
     kie_file_id: Optional[str] = None
     start_msg_id: Optional[int] = None
+    start_clicked: bool = False
+    start_emoji_msg_id: Optional[int] = None
 
     @property
     def has_lyrics(self) -> bool:
@@ -145,6 +147,8 @@ class SunoState:
             "source_url": self.source_url,
             "kie_file_id": self.kie_file_id,
             "start_msg_id": self.start_msg_id,
+            "start_clicked": self.start_clicked,
+            "start_emoji_msg_id": self.start_emoji_msg_id,
         }
 
 
@@ -213,6 +217,14 @@ def _from_mapping(payload: Mapping[str, Any]) -> SunoState:
     raw_start_msg_id = payload.get("start_msg_id")
     if isinstance(raw_start_msg_id, int):
         state.start_msg_id = raw_start_msg_id
+    raw_start_clicked = payload.get("start_clicked")
+    if isinstance(raw_start_clicked, bool):
+        state.start_clicked = raw_start_clicked
+    elif isinstance(raw_start_clicked, (int, float)):
+        state.start_clicked = bool(raw_start_clicked)
+    raw_start_emoji = payload.get("start_emoji_msg_id")
+    if isinstance(raw_start_emoji, int):
+        state.start_emoji_msg_id = raw_start_emoji
     return state
 
 
@@ -315,6 +327,8 @@ def reset_suno_card_state(
     state.card_chat_id = card_chat_id
     state.last_card_hash = None
     state.start_msg_id = None
+    state.start_clicked = False
+    state.start_emoji_msg_id = None
     return state
 
 


### PR DESCRIPTION
## Summary
- send the configured start emoji before launching Suno generation and make the callback idempotent with a Redis guard
- persist new start state fields, reuse safe sticker sending helpers, and update the UI helpers
- add regression tests that exercise emoji delivery, fallback behaviour, state flagging, and Redis locking

## Testing
- pytest tests/test_start_sends_big_emoji_once.py tests/test_start_idempotent_under_race.py tests/test_start_redis_lock_blocks_duplicates.py tests/test_start_with_state_flag_blocks_second_click.py

------
https://chatgpt.com/codex/tasks/task_e_68dc305e5a948322bec946dac9216445