### PR TITLE
Add Suno audio post-processing with metadata support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ prometheus-client>=0.20,<1.0
 openai==0.28.1
 redis==5.0.7
 aiohttp>=3.9.5,<4.0
+mutagen>=1.47.0
 
 # PostgreSQL + пул соединений
 psycopg[binary]>=3.2,<3.3

--- a/tests/test_audio_filename_transliterate.py
+++ b/tests/test_audio_filename_transliterate.py
@@ -1,0 +1,40 @@
+import asyncio
+import importlib
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+audio_post = importlib.import_module("utils.audio_post")
+
+MP3_BYTES = b"ID3\x03\x00\x00\x00\x00\x00\x00" + b"\x00" * 16
+
+def test_audio_filename_transliterate(monkeypatch, tmp_path):
+    async def fake_fetch(url: str, *, timeout=audio_post._DEFAULT_TIMEOUT):  # type: ignore[attr-defined]
+        assert url == "https://example.com/audio.mp3"
+        return MP3_BYTES, "audio/mpeg"
+
+    def fake_task_directory(_: str) -> Path:
+        target = tmp_path / "audio"
+        target.mkdir(parents=True, exist_ok=True)
+        return target
+
+    async def _run() -> None:
+        monkeypatch.setattr(audio_post, "_fetch_bytes", fake_fetch)
+        monkeypatch.setattr("suno.tempfiles.task_directory", fake_task_directory)
+
+        local_path, meta = await audio_post.prepare_audio_file(
+            "https://example.com/audio.mp3",
+            title="Путешествие по неону",
+            cover_url=None,
+            default_artist="Best VEO3",
+            max_name=10,
+            tags_enabled=False,
+            embed_cover_enabled=False,
+            transliterate=True,
+        )
+
+        assert meta["file_name"] == "Puteshestv.mp3"
+        assert Path(local_path).exists()
+        Path(local_path).unlink(missing_ok=True)
+
+    asyncio.run(_run())

--- a/tests/test_audio_send_integration.py
+++ b/tests/test_audio_send_integration.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+from suno.service import SunoService
+
+
+def test_send_audio_uses_prepared_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("AUDIO_TAGS_ENABLED", "true")
+    monkeypatch.setenv("AUDIO_DEFAULT_ARTIST", "Tester")
+    monkeypatch.setenv("AUDIO_EMBED_COVER_ENABLED", "true")
+    monkeypatch.setenv("AUDIO_FILENAME_TRANSLITERATE", "true")
+    monkeypatch.setenv("AUDIO_FILENAME_MAX", "32")
+    monkeypatch.setenv("TELEGRAM_TOKEN", "dummy")
+
+    prepared_path = tmp_path / "prepared.mp3"
+    prepared_path.write_bytes(b"mp3")
+
+    service = SunoService()
+
+    def fake_prepare(*_, **__):
+        return str(prepared_path), {
+            "file_name": "Prepared.mp3",
+            "title": "Song",
+            "performer": "Tester",
+        }
+
+    calls: dict[str, object] = {}
+
+    def fake_send_file(
+        method: str,
+        field: str,
+        chat_id: int,
+        local_path: Path,
+        *,
+        caption,
+        reply_to,
+        extra,
+        file_name,
+    ) -> bool:
+        calls["method"] = method
+        calls["file_name"] = file_name
+        calls["extra"] = extra
+        calls["chat_id"] = chat_id
+        calls["path"] = local_path
+        return True
+
+    def fail_send_audio_request(*args, **kwargs):  # pragma: no cover - defensive
+        raise AssertionError("send_audio_request should not be called")
+
+    monkeypatch.setattr("utils.audio_post.prepare_audio_file_sync", fake_prepare)
+    monkeypatch.setattr("suno.service.prepare_audio_file_sync", fake_prepare)
+    monkeypatch.setattr(service, "_send_file", fake_send_file)
+    monkeypatch.setattr("suno.service.schedule_unlink", lambda path: None)
+    monkeypatch.setattr("telegram_utils.send_audio_request", fail_send_audio_request)
+
+    success, reason = service._send_audio_url_with_retry(
+        chat_id=123,
+        audio_url="https://example.com/audio.mp3",
+        caption="Caption",
+        reply_to=None,
+        title="Title",
+        thumb="https://example.com/cover.png",
+        base_dir=tmp_path,
+        take_id="take1",
+    )
+
+    assert success is True
+    assert reason is None
+    assert calls["method"] == "sendAudio"
+    assert calls["file_name"] == "Prepared.mp3"
+    assert calls["extra"] == {"title": "Song", "performer": "Tester"}
+    assert calls["path"] == prepared_path

--- a/tests/test_audio_tags_fallback_on_error.py
+++ b/tests/test_audio_tags_fallback_on_error.py
@@ -1,0 +1,44 @@
+import asyncio
+import importlib
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+audio_post = importlib.import_module("utils.audio_post")
+
+MP3_BYTES = b"ID3\x03\x00\x00\x00\x00\x00\x00" + b"\x00" * 16
+
+
+def test_audio_tags_fallback_on_error(monkeypatch, tmp_path):
+    async def fake_fetch(url: str, *, timeout=audio_post._DEFAULT_TIMEOUT):  # type: ignore[attr-defined]
+        return MP3_BYTES, "audio/mpeg"
+
+    def fake_task_directory(_: str) -> Path:
+        target = tmp_path / "audio"
+        target.mkdir(parents=True, exist_ok=True)
+        return target
+
+    def boom(*_, **__):
+        raise RuntimeError("id3 failed")
+
+    async def _run() -> None:
+        monkeypatch.setattr(audio_post, "_fetch_bytes", fake_fetch)
+        monkeypatch.setattr("suno.tempfiles.task_directory", fake_task_directory)
+        monkeypatch.setattr(audio_post, "_apply_id3_tags", boom)
+
+        local_path, meta = await audio_post.prepare_audio_file(
+            "https://example.com/audio.mp3",
+            title="Fallback",
+            cover_url=None,
+            default_artist="Artist",
+            max_name=40,
+            tags_enabled=True,
+            embed_cover_enabled=False,
+            transliterate=False,
+        )
+
+        assert Path(local_path).exists()
+        assert meta["title"] == "Fallback"
+        Path(local_path).unlink(missing_ok=True)
+
+    asyncio.run(_run())

--- a/tests/test_audio_tags_with_cover_ok.py
+++ b/tests/test_audio_tags_with_cover_ok.py
@@ -1,0 +1,56 @@
+import asyncio
+import importlib
+from pathlib import Path
+import sys
+
+from mutagen.id3 import ID3
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+audio_post = importlib.import_module("utils.audio_post")
+
+MP3_BYTES = b"ID3\x03\x00\x00\x00\x00\x00\x00" + b"\x00" * 16
+PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n"
+    b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+    b"\x00\x00\x00\x0bIDATx\x9cc`\x00\x00\x00\x02\x00\x01\xe2!\xbc3"
+    b"\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+def test_audio_tags_with_cover_ok(monkeypatch, tmp_path):
+    async def fake_fetch(url: str, *, timeout=audio_post._DEFAULT_TIMEOUT):  # type: ignore[attr-defined]
+        if url.endswith("audio.mp3"):
+            return MP3_BYTES, "audio/mpeg"
+        if url.endswith("cover.png"):
+            return PNG_BYTES, "image/png"
+        raise AssertionError("unexpected url")
+
+    def fake_task_directory(_: str) -> Path:
+        target = tmp_path / "audio"
+        target.mkdir(parents=True, exist_ok=True)
+        return target
+
+    async def _run() -> None:
+        monkeypatch.setattr(audio_post, "_fetch_bytes", fake_fetch)
+        monkeypatch.setattr("suno.tempfiles.task_directory", fake_task_directory)
+
+        local_path, meta = await audio_post.prepare_audio_file(
+            "https://example.com/audio.mp3",
+            title="Neon City",
+            cover_url="https://example.com/cover.png",
+            default_artist="Best VEO3",
+            max_name=40,
+            tags_enabled=True,
+            embed_cover_enabled=True,
+            transliterate=False,
+        )
+
+        id3 = ID3(local_path)
+        assert id3.getall("TIT2")[0].text[0] == "Neon City"
+        assert id3.getall("TPE1")[0].text[0] == "Best VEO3"
+        apic_frames = id3.getall("APIC")
+        assert apic_frames and apic_frames[0].mime == "image/png"
+        assert meta["file_name"] == "Neon_City.mp3"
+        Path(local_path).unlink(missing_ok=True)
+
+    asyncio.run(_run())

--- a/utils/audio_post.py
+++ b/utils/audio_post.py
@@ -1,0 +1,237 @@
+"""Audio post-processing helpers for Suno tracks."""
+
+from __future__ import annotations
+
+import asyncio
+import imghdr
+import logging
+import os
+import re
+import unicodedata
+import uuid
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+from urllib.parse import urlparse
+
+import aiohttp
+from aiohttp import ClientError, ClientTimeout
+from mutagen.id3 import APIC, ID3, ID3NoHeaderError, TIT2, TPE1
+
+log = logging.getLogger("audio.post")
+
+_DEFAULT_TIMEOUT = ClientTimeout(total=60)
+_FILENAME_PATTERN = re.compile(r"[^A-Za-z0-9._-]+")
+
+_TRANSLIT_MAP_BASE = {
+    "а": "a",
+    "б": "b",
+    "в": "v",
+    "г": "g",
+    "д": "d",
+    "е": "e",
+    "ё": "e",
+    "ж": "zh",
+    "з": "z",
+    "и": "i",
+    "й": "j",
+    "к": "k",
+    "л": "l",
+    "м": "m",
+    "н": "n",
+    "о": "o",
+    "п": "p",
+    "р": "r",
+    "с": "s",
+    "т": "t",
+    "у": "u",
+    "ф": "f",
+    "х": "h",
+    "ц": "ts",
+    "ч": "ch",
+    "ш": "sh",
+    "щ": "sch",
+    "ъ": "",
+    "ы": "y",
+    "ь": "",
+    "э": "e",
+    "ю": "yu",
+    "я": "ya",
+}
+
+_TRANSLIT_MAP: Dict[int, str] = {ord(k): v for k, v in _TRANSLIT_MAP_BASE.items()}
+_TRANSLIT_MAP.update({ord(k.upper()): v.capitalize() for k, v in _TRANSLIT_MAP_BASE.items()})
+
+
+async def _fetch_bytes(url: str, *, timeout: ClientTimeout = _DEFAULT_TIMEOUT) -> Tuple[bytes, Optional[str]]:
+    parsed = urlparse(url)
+    if parsed.scheme in {"", "file"}:
+        path = Path(parsed.path)
+        data = await asyncio.to_thread(path.read_bytes)
+        return data, None
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        try:
+            async with session.get(url) as response:
+                response.raise_for_status()
+                content_type = response.headers.get("Content-Type")
+                data = await response.read()
+                return data, content_type
+        except (ClientError, asyncio.TimeoutError) as exc:
+            log.warning("audio.fetch_failed", extra={"meta": {"url": url, "err": str(exc)}})
+            raise
+
+
+def _transliterate(text: str) -> str:
+    normalized = unicodedata.normalize("NFKD", text)
+    translated = normalized.translate(_TRANSLIT_MAP)
+    cleaned = "".join(ch for ch in translated if unicodedata.category(ch) != "Mn")
+    return cleaned
+
+
+def _normalize_filename(
+    title: Optional[str], *, max_name: int, transliterate: bool
+) -> str:
+    base = (title or "track").strip()
+    if not base:
+        base = "track"
+    if transliterate:
+        base = _transliterate(base)
+    base = unicodedata.normalize("NFKC", base)
+    base = base.replace(os.sep, " ").replace("/", " ")
+    base = _FILENAME_PATTERN.sub("_", base)
+    base = re.sub(r"_+", "_", base)
+    base = base.strip("._- ") or "track"
+    if max_name > 0 and len(base) > max_name:
+        base = base[:max_name].rstrip("._- ") or base[:max_name]
+    return f"{base or 'track'}.mp3"
+
+
+def _guess_cover_mime(data: bytes, declared: Optional[str]) -> Optional[str]:
+    if declared:
+        lowered = declared.split(";")[0].strip().lower()
+        if lowered in {"image/jpeg", "image/jpg", "image/png"}:
+            return "image/jpeg" if "jpeg" in lowered or "jpg" in lowered else "image/png"
+    kind = imghdr.what(None, h=data)
+    if kind == "jpeg":
+        return "image/jpeg"
+    if kind == "png":
+        return "image/png"
+    return None
+
+
+def _apply_id3_tags(
+    path: Path,
+    *,
+    title: str,
+    artist: str,
+    cover: Optional[Tuple[bytes, Optional[str]]],
+) -> None:
+    try:
+        tags = ID3(path)
+    except ID3NoHeaderError:
+        tags = ID3()
+    tags.delall("TIT2")
+    tags.delall("TPE1")
+    tags.add(TIT2(encoding=3, text=title))
+    tags.add(TPE1(encoding=3, text=[artist]))
+    if cover and cover[0]:
+        mime = _guess_cover_mime(cover[0], cover[1])
+        if mime:
+            tags.delall("APIC")
+            tags.add(
+                APIC(
+                    encoding=3,
+                    mime=mime,
+                    type=3,
+                    desc="Cover",
+                    data=cover[0],
+                )
+            )
+    tags.save(path, v2_version=3)
+
+
+async def prepare_audio_file(
+    mp3_url: str,
+    title: Optional[str],
+    cover_url: Optional[str],
+    *,
+    default_artist: str,
+    max_name: int,
+    tags_enabled: bool,
+    embed_cover_enabled: bool,
+    transliterate: bool,
+) -> Tuple[str, Dict[str, Optional[str]]]:
+    file_name = _normalize_filename(title, max_name=max_name, transliterate=transliterate)
+    from suno.tempfiles import task_directory
+
+    target_dir = task_directory("audio")
+    target_path = target_dir / f"{uuid.uuid4().hex}.mp3"
+
+    mp3_bytes, _ = await _fetch_bytes(mp3_url)
+    await asyncio.to_thread(target_path.write_bytes, mp3_bytes)
+
+    meta: Dict[str, Optional[str]] = {"file_name": file_name}
+    final_title = (title or "Untitled").strip() or "Untitled"
+    final_artist = (default_artist or "Best VEO3").strip() or "Best VEO3"
+    if tags_enabled:
+        meta.update({"title": final_title, "performer": final_artist})
+        cover_data: Optional[Tuple[bytes, Optional[str]]] = None
+        if embed_cover_enabled and cover_url:
+            try:
+                cover_data = await _fetch_bytes(cover_url)
+            except Exception as exc:
+                log.warning(
+                    "audio.cover.fetch_failed",
+                    exc_info=True,
+                    extra={"meta": {"url": cover_url, "err": str(exc)}},
+                )
+                cover_data = None
+        try:
+            await asyncio.to_thread(
+                _apply_id3_tags,
+                target_path,
+                title=final_title,
+                artist=final_artist,
+                cover=cover_data,
+            )
+        except Exception as exc:
+            log.warning(
+                "audio.id3.write_failed",
+                exc_info=True,
+                extra={"meta": {"path": str(target_path), "err": str(exc)}},
+            )
+    return str(target_path), meta
+
+
+def prepare_audio_file_sync(
+    mp3_url: str,
+    title: Optional[str],
+    cover_url: Optional[str],
+    *,
+    default_artist: str,
+    max_name: int,
+    tags_enabled: bool,
+    embed_cover_enabled: bool,
+    transliterate: bool,
+) -> Tuple[str, Dict[str, Optional[str]]]:
+    try:
+        return asyncio.run(
+            prepare_audio_file(
+                mp3_url,
+                title,
+                cover_url,
+                default_artist=default_artist,
+                max_name=max_name,
+                tags_enabled=tags_enabled,
+                embed_cover_enabled=embed_cover_enabled,
+                transliterate=transliterate,
+            )
+        )
+    except RuntimeError as exc:  # pragma: no cover - defensive
+        if "asyncio.run" in str(exc):
+            raise RuntimeError(
+                "prepare_audio_file_sync cannot be called from a running event loop"
+            ) from exc
+        raise
+
+
+__all__ = ["prepare_audio_file", "prepare_audio_file_sync"]


### PR DESCRIPTION
## Summary
- add an async audio post-processing helper that downloads Suno MP3s, normalizes filenames, writes ID3 tags, and optionally embeds cover art
- integrate the helper into the Suno Telegram delivery flow with custom filename support and add the mutagen dependency
- add regression tests for filename transliteration, tagging success and failure cases, and Telegram upload integration

## Testing
- pytest tests/test_audio_filename_transliterate.py tests/test_audio_tags_with_cover_ok.py tests/test_audio_tags_fallback_on_error.py tests/test_audio_send_integration.py


------
https://chatgpt.com/codex/tasks/task_e_68dc3ec95770832295bc748fcd5aa92e