### PR TITLE
Stabilize Suno start flow and audio delivery

### DIFF
--- a/tests/test_start_msg_appears_and_disappears.py
+++ b/tests/test_start_msg_appears_and_disappears.py
@@ -35,6 +35,8 @@ def test_start_msg_appears_and_disappears():
     )
     assert result_initial is None
     assert not bot.sent
+    assert state_dict["suno_can_start"] is False
+    assert state_dict.get("suno_start_button_sent_ts") is None
 
     # Ready state should trigger a new message.
     result_ready = asyncio.run(
@@ -52,6 +54,9 @@ def test_start_msg_appears_and_disappears():
     assert bot.sent[-1]["text"] == SUNO_START_READY_MESSAGE
     assert state_dict["suno_start_msg_id"] == result_ready
     assert suno_state.start_msg_id == result_ready
+    assert state_dict["suno_can_start"] is True
+    button_ts = state_dict.get("suno_start_button_sent_ts")
+    assert isinstance(button_ts, int) and button_ts > 0
 
     # Losing readiness should remove the message.
     result_hidden = asyncio.run(
@@ -69,3 +74,5 @@ def test_start_msg_appears_and_disappears():
     assert bot.deleted[-1]["message_id"] == result_ready
     assert state_dict.get("suno_start_msg_id") is None
     assert suno_state.start_msg_id is None
+    assert state_dict["suno_can_start"] is False
+    assert state_dict.get("suno_start_button_sent_ts") is None


### PR DESCRIPTION
## Summary
- make the Suno start button idempotent with new Redis flags, ensure the sticker + "Запускаю генерацию…" message fire once, and hide the button after click
- skip strict lyrics retries for user-supplied texts and reset start flags when tasks finish
- deliver generated audio with tagged filenames plus a document duplicate, updating the integration tests for the new behaviour

## Testing
- pytest tests/test_start_msg_appears_and_disappears.py tests/test_start_sends_big_emoji_once.py tests/test_start_with_state_flag_blocks_second_click.py tests/test_audio_send_integration.py tests/test_audio_filename_transliterate.py

------
https://chatgpt.com/codex/tasks/task_e_68dc5e6bb2ac8322b027e176a7e2801d