### PR TITLE
Replace imghdr cover detection with Pillow

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ DATABASE_URL=postgresql://user:password@host:5432/database
 pytest -q
 ```
 
+> **Note:** Python 3.13 удалил модуль `imghdr` (PEP 594). Проект использует
+> Pillow для определения типа обложек и совместим как с Python 3.12, так и с
+> 3.13+.
+
 Проверка callback вручную:
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ openai==0.28.1
 redis==5.0.7
 aiohttp>=3.9.5,<4.0
 mutagen>=1.47.0
+Pillow>=10.0
 
 # PostgreSQL + пул соединений
 psycopg[binary]>=3.2,<3.3

--- a/tests/test_audio_tags_with_cover_ok.py
+++ b/tests/test_audio_tags_with_cover_ok.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import importlib
 from pathlib import Path
 import sys
@@ -9,11 +10,8 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 audio_post = importlib.import_module("utils.audio_post")
 
 MP3_BYTES = b"ID3\x03\x00\x00\x00\x00\x00\x00" + b"\x00" * 16
-PNG_BYTES = (
-    b"\x89PNG\r\n\x1a\n"
-    b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
-    b"\x00\x00\x00\x0bIDATx\x9cc`\x00\x00\x00\x02\x00\x01\xe2!\xbc3"
-    b"\x00\x00\x00\x00IEND\xaeB`\x82"
+PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
 )
 
 

--- a/tests/test_image_detect.py
+++ b/tests/test_image_detect.py
@@ -1,0 +1,48 @@
+import base64
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from utils.image_detect import detect_image_ext, is_image  # noqa: E402
+
+_JPEG = base64.b64decode(
+    "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDA"
+    "QkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQE"
+    "BAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY"
+    "3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5uf"
+    "o6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSM"
+    "zUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm"
+    "6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDi6KKK+ZP3E//Z"
+)
+_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+)
+_WEBP = base64.b64decode(
+    "UklGRjwAAABXRUJQVlA4IDAAAADQAQCdASoBAAEAAUAmJaACdLoB+AADsAD+8ut//NgVzXPv9//S4P0uD9Lg/9KQAAA="
+)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [_JPEG, _PNG, _WEBP],
+)
+def test_is_image_true(payload):
+    assert is_image(payload)
+
+
+def test_is_image_false():
+    assert not is_image(b"not an image")
+
+
+@pytest.mark.parametrize(
+    "payload, expected",
+    [(_JPEG, "jpg"), (_PNG, "png"), (_WEBP, "webp")],
+)
+def test_detect_image_ext(payload, expected):
+    assert detect_image_ext(payload) == expected
+
+
+def test_detect_image_ext_invalid_returns_none():
+    assert detect_image_ext(b"garbage") is None

--- a/utils/image_detect.py
+++ b/utils/image_detect.py
@@ -1,0 +1,36 @@
+"""Utilities for detecting and validating image data."""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+from PIL import Image
+
+SUPPORTED = {"JPEG": "jpg", "PNG": "png", "WEBP": "webp"}
+
+
+def detect_image_ext(data: bytes) -> str | None:
+    """Return a file extension (without dot) for supported images.
+
+    The detection uses Pillow formats to support Python 3.13 where ``imghdr``
+    has been removed. ``None`` is returned when detection fails or when the
+    image format is not whitelisted.
+    """
+
+    try:
+        with Image.open(BytesIO(data)) as im:
+            fmt = (im.format or "").upper()
+            return SUPPORTED.get(fmt)
+    except Exception:
+        return None
+
+
+def is_image(data: bytes) -> bool:
+    """Return ``True`` when the byte sequence represents a valid image."""
+
+    try:
+        with Image.open(BytesIO(data)) as im:
+            im.verify()
+        return True
+    except Exception:
+        return False


### PR DESCRIPTION
## Summary
- replace imghdr usage with a Pillow-powered image detector and guard cover embedding on real images
- add regression coverage for image detection and adjust audio cover test data to use a valid PNG sample
- document the Python 3.13 change and add Pillow as a dependency for deployment

## Testing
- pytest tests/test_image_detect.py
- pytest tests/test_audio_tags_with_cover_ok.py tests/test_audio_tags_fallback_on_error.py tests/test_cover_upload_invalid.py

------
https://chatgpt.com/codex/tasks/task_e_68dc6486dfac83229bc9a32a4f2514c4