### PR TITLE
Align Suno flow prompts and cover uploads

### DIFF
--- a/tests/test_cover_upload_stream_ok.py
+++ b/tests/test_cover_upload_stream_ok.py
@@ -80,5 +80,5 @@ def test_cover_upload_stream_ok(monkeypatch):
         generating=False,
         waiting_enqueue=False,
     )
-    assert "загружено ✅ (id: kie-audio-999)" in text
+    assert "Источник: <i>🎧 Файл</i>" in text
     assert ready is True

--- a/tests/test_cover_upload_url_ok.py
+++ b/tests/test_cover_upload_url_ok.py
@@ -66,5 +66,5 @@ def test_cover_upload_url_ok(monkeypatch):
         generating=False,
         waiting_enqueue=False,
     )
-    assert "загружено ✅ (id: kie-test-123)" in text
+    assert "Источник: <i>🔗 Ссылка</i>" in text
     assert ready is True

--- a/tests/test_start_button_once.py
+++ b/tests/test_start_button_once.py
@@ -1,0 +1,122 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+from tests.suno_test_utils import DummyMessage, FakeBot, bot_module
+
+
+def _collect_start_buttons(bot: FakeBot) -> list[dict[str, object]]:
+    buttons: list[dict[str, object]] = []
+    for payload in bot.sent:
+        if not isinstance(payload, dict):
+            continue
+        markup = payload.get("reply_markup")
+        if not markup or not getattr(markup, "inline_keyboard", None):
+            continue
+        button = markup.inline_keyboard[0][0]
+        if getattr(button, "text", "") == "▶️ Начать генерацию":
+            buttons.append(payload)
+    return buttons
+
+
+def test_start_button_rendered_once(monkeypatch):
+    chat_id = 1200
+    user_id = 1300
+    bot = FakeBot()
+    ctx = SimpleNamespace(bot=bot, user_data={})
+
+    asyncio.run(
+        bot_module._music_begin_flow(
+            chat_id,
+            ctx,
+            bot_module.state(ctx),
+            flow="instrumental",
+            user_id=user_id,
+        )
+    )
+
+    state_dict = bot_module.state(ctx)
+
+    waiting = state_dict.get("suno_waiting_state")
+    assert waiting == bot_module.WAIT_SUNO_TITLE
+    asyncio.run(
+        bot_module._handle_suno_waiting_input(
+            ctx,
+            chat_id,
+            DummyMessage("Skyline", chat_id),
+            state_dict,
+            waiting,
+            user_id=user_id,
+        )
+    )
+
+    waiting = state_dict.get("suno_waiting_state")
+    assert waiting == bot_module.WAIT_SUNO_STYLE
+    asyncio.run(
+        bot_module._handle_suno_waiting_input(
+            ctx,
+            chat_id,
+            DummyMessage("Dream pop", chat_id),
+            state_dict,
+            waiting,
+            user_id=user_id,
+        )
+    )
+
+    start_buttons = _collect_start_buttons(bot)
+    assert len(start_buttons) == 1
+
+    asyncio.run(bot_module.refresh_suno_card(ctx, chat_id, state_dict, price=bot_module.PRICE_SUNO))
+    assert len(_collect_start_buttons(bot)) == 1
+
+    start_msg_id = state_dict.get("suno_start_msg_id")
+    assert isinstance(start_msg_id, int)
+
+    monkeypatch.setattr(bot_module, "START_EMOJI_STICKER_ID", "sticker-one")
+
+    async def fake_launch(*_args, **_kwargs):  # type: ignore[override]
+        return None
+
+    async def fake_notify(*_args, **_kwargs):  # type: ignore[override]
+        return None
+
+    monkeypatch.setattr(bot_module, "_launch_suno_generation", fake_launch)
+    monkeypatch.setattr(bot_module, "_suno_notify", fake_notify)
+
+    callback = SimpleNamespace(
+        data="suno:start",
+        message=SimpleNamespace(chat_id=chat_id, replies=[]),
+        _answered=[],
+    )
+
+    async def answer(text: str | None = None, show_alert: bool = False):  # type: ignore[override]
+        callback._answered.append((text, show_alert))
+
+    callback.answer = answer
+
+    update = SimpleNamespace(
+        callback_query=callback,
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+    )
+
+    asyncio.run(bot_module.on_callback(update, ctx))
+
+    disabled_buttons = [
+        payload
+        for payload in bot.edited
+        if payload.get("message_id") == start_msg_id
+        and getattr(payload.get("reply_markup"), "inline_keyboard", None)
+    ]
+    assert disabled_buttons
+    disabled_button = disabled_buttons[-1]["reply_markup"].inline_keyboard[0][0]
+    assert disabled_button.text == "⏳ Идёт генерация…"
+
+    assert len(_collect_start_buttons(bot)) == 1

--- a/tests/test_start_sends_big_emoji_once.py
+++ b/tests/test_start_sends_big_emoji_once.py
@@ -68,7 +68,6 @@ def test_click_sends_correct_sticker_and_not_prinyato_again(monkeypatch):
     start_msg_id = _prepare_ready_context(ctx, chat_id, user_id)
 
     monkeypatch.setattr(bot_module, "START_EMOJI_STICKER_ID", "sticker-file-id")
-    monkeypatch.setattr(bot_module, "START_EMOJI_FALLBACK", "🎬")
 
     launch_calls: list[dict[str, object]] = []
 
@@ -155,7 +154,6 @@ def test_second_click_blocked(monkeypatch):
     start_msg_id = _prepare_ready_context(ctx, chat_id, user_id)
 
     monkeypatch.setattr(bot_module, "START_EMOJI_STICKER_ID", "sticker")
-    monkeypatch.setattr(bot_module, "START_EMOJI_FALLBACK", "🎬")
 
     async def fake_launch(*_args, **_kwargs):  # type: ignore[override]
         return None
@@ -192,7 +190,7 @@ def test_second_click_blocked(monkeypatch):
         assert msg_ids.get("suno_start") == start_msg_id
 
 
-def test_start_sticker_fallback_to_emoji(monkeypatch):
+def test_start_sticker_failure_no_fallback(monkeypatch):
     bot = FakeBot()
     ctx = SimpleNamespace(bot=bot, user_data={})
     chat_id = 333
@@ -200,7 +198,6 @@ def test_start_sticker_fallback_to_emoji(monkeypatch):
     _prepare_ready_context(ctx, chat_id, user_id)
 
     monkeypatch.setattr(bot_module, "START_EMOJI_STICKER_ID", "broken-sticker")
-    monkeypatch.setattr(bot_module, "START_EMOJI_FALLBACK", "🎬")
 
     async def fake_launch(*_args, **_kwargs):  # type: ignore[override]
         return None
@@ -227,9 +224,9 @@ def test_start_sticker_fallback_to_emoji(monkeypatch):
     assert not sticker_entries
 
     fallback_messages = [item for item in bot.sent if item.get("text") == "🎬"]
-    assert len(fallback_messages) == 1
+    assert not fallback_messages
 
     assert bot.edited, "start message should still be edited when sticker fails"
 
     suno_state_after = load_suno_state(ctx)
-    assert suno_state_after.start_emoji_msg_id == 100
+    assert suno_state_after.start_emoji_msg_id is None

--- a/tests/test_suno_cover_upload.py
+++ b/tests/test_suno_cover_upload.py
@@ -1,0 +1,127 @@
+import asyncio
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+from suno.cover_source import CoverSourceUnavailableError
+from tests.suno_test_utils import DummyMessage, bot_module, setup_cover_context
+
+
+class DummyAudio:
+    def __init__(self) -> None:
+        self.file_id = "cover-audio"
+        self.file_name = "cover.mp3"
+        self.mime_type = "audio/mpeg"
+        self.file_size = 4096
+        self.duration = 12
+
+
+def _prepare_state(chat_id: int):
+    ctx, state_dict, bot = setup_cover_context(chat_id=chat_id)
+    asyncio.run(
+        bot_module._music_begin_flow(
+            chat_id,
+            ctx,
+            state_dict,
+            flow="cover",
+            user_id=333,
+        )
+    )
+    return ctx, state_dict, bot
+
+
+def test_cover_upload_base64_fallback(monkeypatch):
+    ctx, state_dict, bot = _prepare_state(1001)
+
+    captured: dict[str, object] = {}
+
+    async def fake_download(url: str, **_kwargs) -> bytes:
+        captured["download"] = url
+        return b"AUDIO"
+
+    async def fail_stream(*_args, **_kwargs):
+        raise CoverSourceUnavailableError("stream")
+
+    async def fail_url(*_args, **_kwargs):
+        raise CoverSourceUnavailableError("url")
+
+    async def ok_base64(data: bytes, *_args, **_kwargs) -> str:
+        captured["base64"] = data
+        return "kie-cover-base64"
+
+    monkeypatch.setattr(bot_module, "_download_telegram_file", fake_download)
+    monkeypatch.setattr(bot_module, "upload_cover_stream", fail_stream)
+    monkeypatch.setattr(bot_module, "upload_cover_url", fail_url)
+    monkeypatch.setattr(bot_module, "upload_cover_base64", ok_base64)
+
+    audio = DummyAudio()
+    message = DummyMessage("", 1001)
+    message.audio = audio
+
+    result = asyncio.run(
+        bot_module._cover_process_audio_input(
+            ctx,
+            1001,
+            message,
+            state_dict,
+            audio,
+            user_id=333,
+        )
+    )
+
+    assert result is True
+    assert message.replies[-1] == "✅ Принято"
+    assert "base64" in captured
+    assert captured["base64"] == b"AUDIO"
+
+    payloads = []
+    payloads.extend(item for item in bot.sent if isinstance(item, dict))
+    payloads.extend(item for item in bot.edited if isinstance(item, dict))
+    assert any("Источник: <i>🎧 Файл</i>" in item.get("text", "") for item in payloads)
+
+
+def test_cover_upload_service_unavailable(monkeypatch):
+    monkeypatch.setenv("SUNO_API_BASE", "https://service.local")
+    monkeypatch.setenv("TELEGRAM_TOKEN", "token-real")
+    monkeypatch.setattr(bot_module, "TELEGRAM_TOKEN", "token-real")
+    ctx, state_dict, _bot = _prepare_state(1002)
+
+    async def fake_download(_url: str, **_kwargs) -> bytes:
+        return b"data"
+
+    async def fail_stream(*_args, **_kwargs):
+        raise CoverSourceUnavailableError("stream")
+
+    async def fail_url(*_args, **_kwargs):
+        raise CoverSourceUnavailableError("url")
+
+    async def fail_base64(*_args, **_kwargs):
+        raise CoverSourceUnavailableError("base64")
+
+    monkeypatch.setattr(bot_module, "_download_telegram_file", fake_download)
+    monkeypatch.setattr(bot_module, "upload_cover_stream", fail_stream)
+    monkeypatch.setattr(bot_module, "upload_cover_url", fail_url)
+    monkeypatch.setattr(bot_module, "upload_cover_base64", fail_base64)
+
+    audio = DummyAudio()
+    message = DummyMessage("", 1002)
+    message.audio = audio
+
+    result = asyncio.run(
+        bot_module._cover_process_audio_input(
+            ctx,
+            1002,
+            message,
+            state_dict,
+            audio,
+            user_id=333,
+        )
+    )
+
+    assert result is True
+    assert message.replies[-1] == bot_module._COVER_UPLOAD_SERVICE_ERROR_MESSAGE

--- a/tests/test_suno_prompt_steps.py
+++ b/tests/test_suno_prompt_steps.py
@@ -11,7 +11,6 @@ if str(ROOT) not in sys.path:
 
 from texts import SUNO_START_READY_MESSAGE, t
 from tests.suno_test_utils import DummyMessage, bot_module, setup_cover_context
-from utils.suno_state import LYRICS_MAX_LENGTH
 
 
 def _capture_prompt(bot, start_index: int) -> tuple[str, int]:
@@ -34,30 +33,30 @@ def _capture_prompt(bot, start_index: int) -> tuple[str, int]:
     [
         (
             "instrumental",
-            ["Calm focus", "Night Drive"],
+            ["Night Drive", "Calm focus"],
             [
-                t("suno.prompt.step.style", index=1, total=2, current="—"),
-                t("suno.prompt.step.title", index=2, total=2, current="—"),
+                t("suno.prompt.step.title", index=1, total=2, current="—"),
+                t("suno.prompt.step.style", index=2, total=2, current="—"),
                 SUNO_START_READY_MESSAGE,
             ],
         ),
         (
             "lyrics",
-            ["Dream pop", "City Lights", "First line\nSecond line"],
+            ["City Lights", "Dream pop", "First line\nSecond line"],
             [
-                t("suno.prompt.step.style", index=1, total=3, current="—"),
-                t("suno.prompt.step.title", index=2, total=3, current="—"),
-                t("suno.prompt.step.lyrics", index=3, total=3, current="—", limit=LYRICS_MAX_LENGTH),
+                t("suno.prompt.step.title", index=1, total=3, current="—"),
+                t("suno.prompt.step.style", index=2, total=3, current="—"),
+                t("suno.prompt.step.lyrics", index=3, total=3),
                 SUNO_START_READY_MESSAGE,
             ],
         ),
         (
             "cover",
-            ["https://example.com/audio.mp3", "Ambient chill", "Cover Title"],
+            ["Cover Title", "https://example.com/audio.mp3", "Ambient chill"],
             [
-                t("suno.prompt.step.source", index=1, total=3, current="—"),
-                t("suno.prompt.step.style", index=2, total=3, current="—"),
-                t("suno.prompt.step.title", index=3, total=3, current="—"),
+                t("suno.prompt.step.title", index=1, total=3, current="—"),
+                t("suno.prompt.step.source", index=2, total=3),
+                t("suno.prompt.step.style", index=3, total=3, current="—"),
                 SUNO_START_READY_MESSAGE,
             ],
         ),
@@ -89,6 +88,12 @@ def test_next_step_prompt_flow_per_mode(monkeypatch, mode, inputs, expected):
         )
     )
 
+    if mode == "lyrics":
+        suno_state = bot_module.load_suno_state(ctx)
+        bot_module.set_suno_lyrics_source(suno_state, bot_module.LyricsSource.USER)
+        bot_module.save_suno_state(ctx, suno_state)
+        state_dict["suno_state"] = suno_state.to_dict()
+
     prompts: list[str] = []
     last_index = 0
     prompt, last_index = _capture_prompt(bot, last_index)
@@ -111,4 +116,60 @@ def test_next_step_prompt_flow_per_mode(monkeypatch, mode, inputs, expected):
         prompt, last_index = _capture_prompt(bot, last_index)
         prompts.append(prompt)
 
+    assert prompts == expected
+
+
+def test_lyrics_step_skips_when_ai(monkeypatch):
+    async def fake_ensure(url_text: str) -> str:
+        return url_text
+
+    async def fake_upload(url_text: str, **_kwargs) -> str:
+        return "kie-file"
+
+    monkeypatch.setattr(bot_module, "ensure_cover_audio_url", fake_ensure)
+    monkeypatch.setattr(bot_module, "upload_cover_url", fake_upload)
+
+    chat_id = 920
+    ctx, state_dict, bot = setup_cover_context(chat_id=chat_id)
+    bot.sent.clear()
+    bot.edited.clear()
+
+    user_id = 1930
+    asyncio.run(
+        bot_module._music_begin_flow(
+            chat_id,
+            ctx,
+            state_dict,
+            flow="lyrics",
+            user_id=user_id,
+        )
+    )
+
+    prompts: list[str] = []
+    last_index = 0
+    prompt, last_index = _capture_prompt(bot, last_index)
+    prompts.append(prompt)
+
+    for value in ("City Lights", "Dream pop"):
+        waiting_field = state_dict.get("suno_waiting_state")
+        assert isinstance(waiting_field, str)
+        message = DummyMessage(value, chat_id)
+        asyncio.run(
+            bot_module._handle_suno_waiting_input(
+                ctx,
+                chat_id,
+                message,
+                state_dict,
+                waiting_field,
+                user_id=user_id,
+            )
+        )
+        prompt, last_index = _capture_prompt(bot, last_index)
+        prompts.append(prompt)
+
+    expected = [
+        t("suno.prompt.step.title", index=1, total=3, current="—"),
+        t("suno.prompt.step.style", index=2, total=3, current="—"),
+        SUNO_START_READY_MESSAGE,
+    ]
     assert prompts == expected

--- a/tests/test_suno_text_source.py
+++ b/tests/test_suno_text_source.py
@@ -1,0 +1,106 @@
+import asyncio
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+from tests.suno_test_utils import DummyMessage, bot_module, setup_cover_context
+
+
+def _find_card_text(bot) -> str:
+    sources = []
+    sources.extend(payload for payload in bot.sent if isinstance(payload, dict))
+    sources.extend(payload for payload in bot.edited if isinstance(payload, dict))
+    for payload in reversed(sources):
+        text = payload.get("text") if isinstance(payload, dict) else None
+        if isinstance(text, str) and "Источник текста" in text:
+            return text
+    return ""
+
+
+def test_user_lyrics_persist_and_display():
+    chat_id = 950
+    user_id = 1010
+    ctx, state_dict, bot = setup_cover_context(chat_id=chat_id)
+
+    asyncio.run(
+        bot_module._music_begin_flow(
+            chat_id,
+            ctx,
+            state_dict,
+            flow="lyrics",
+            user_id=user_id,
+        )
+    )
+
+    suno_state = bot_module.load_suno_state(ctx)
+    bot_module.set_suno_lyrics_source(suno_state, bot_module.LyricsSource.USER)
+    bot_module.save_suno_state(ctx, suno_state)
+    state_dict["suno_state"] = suno_state.to_dict()
+
+    waiting_field = state_dict.get("suno_waiting_state")
+    assert waiting_field == bot_module.WAIT_SUNO_TITLE
+
+    message = DummyMessage("City Lights", chat_id)
+    asyncio.run(
+        bot_module._handle_suno_waiting_input(
+            ctx,
+            chat_id,
+            message,
+            state_dict,
+            waiting_field,
+            user_id=user_id,
+        )
+    )
+
+    waiting_field = state_dict.get("suno_waiting_state")
+    assert waiting_field == bot_module.WAIT_SUNO_STYLE
+
+    style_msg = DummyMessage("Dream pop", chat_id)
+    asyncio.run(
+        bot_module._handle_suno_waiting_input(
+            ctx,
+            chat_id,
+            style_msg,
+            state_dict,
+            waiting_field,
+            user_id=user_id,
+        )
+    )
+
+    prompt_texts = [
+        item.get("text")
+        for item in bot.sent
+        if isinstance(item, dict) and isinstance(item.get("text"), str)
+    ]
+    assert any("Шаг 3/3 (текст)" in text for text in prompt_texts)
+
+    waiting_field = state_dict.get("suno_waiting_state") or bot_module.WAIT_SUNO_LYRICS
+    state_dict["suno_waiting_state"] = waiting_field
+
+    lyrics_value = "Line one\nLine two"
+    lyrics_msg = DummyMessage(lyrics_value, chat_id)
+    asyncio.run(
+        bot_module._handle_suno_waiting_input(
+            ctx,
+            chat_id,
+            lyrics_msg,
+            state_dict,
+            waiting_field,
+            user_id=user_id,
+        )
+    )
+
+    updated_state = bot_module.load_suno_state(ctx)
+    assert updated_state.lyrics == lyrics_value
+    assert updated_state.lyrics_source == bot_module.LyricsSource.USER
+    assert updated_state.lyrics_hash is not None
+    assert not state_dict.get("suno_auto_lyrics_pending")
+    assert state_dict.get("suno_current_req_id") is None
+
+    card_text = _find_card_text(bot)
+    assert "Источник текста: <i>🧾 Мой текст</i>" in card_text

--- a/texts.py
+++ b/texts.py
@@ -42,9 +42,7 @@ SUNO_RU = {
         "Сейчас: “{current}”"
     ),
     "suno.prompt.step.lyrics": (
-        "Шаг {index}/{total} (текст): Пришлите текст песни (до {limit} символов) или отправьте /skip, "
-        "чтобы сгенерировать автоматически.\n"
-        "Сейчас: “{current}”"
+        "Шаг {index}/{total} (текст): Пришлите текст песни сообщением."
     ),
     "suno.prompt.step.source": (
         f"Шаг {{index}}/{{total}} (источник): Пришлите аудио-файл (mp3/wav, до {MAX_AUDIO_MB} МБ) "

--- a/ui_helpers.py
+++ b/ui_helpers.py
@@ -240,12 +240,10 @@ def render_suno_card(
     lyrics_preview_value = suno_lyrics_preview(suno_state.lyrics)
     lyrics_value = html.escape(lyrics_preview_value) if lyrics_preview_value else "—"
 
-    if suno_state.kie_file_id:
-        source_value = f"загружено ✅ (id: {html.escape(suno_state.kie_file_id)})"
-    elif suno_state.cover_source_label:
-        source_value = html.escape(suno_state.cover_source_label)
-    elif suno_state.cover_source_url:
-        source_value = html.escape(suno_state.cover_source_url)
+    if suno_state.source_file_id:
+        source_value = "🎧 Файл"
+    elif suno_state.cover_source_url or suno_state.source_url:
+        source_value = "🔗 Ссылка"
     else:
         source_value = "—"
 

--- a/utils/suno_state.py
+++ b/utils/suno_state.py
@@ -184,10 +184,11 @@ def _from_mapping(payload: Mapping[str, Any]) -> SunoState:
     else:
         mode = "lyrics" if bool(payload.get("has_lyrics")) else "instrumental"
     state = SunoState(mode=mode)
-    state.lyrics_source = _parse_lyrics_source(payload.get("lyrics_source"))
+    parsed_source = _parse_lyrics_source(payload.get("lyrics_source"))
     set_title(state, payload.get("title"))
     set_style(state, payload.get("style"))
     set_lyrics(state, payload.get("lyrics"))
+    state.lyrics_source = parsed_source
     raw_hash = payload.get("lyrics_hash")
     if isinstance(raw_hash, str) and raw_hash.strip():
         state.lyrics_hash = raw_hash.strip()


### PR DESCRIPTION
## Summary
- enforce title-first Suno prompt flow with updated Russian step messaging, skip the lyrics step when AI text is selected, and refresh the card after every answer
- persist user-supplied lyrics with the correct source marker, simplify the generation trigger to send only the required sticker, and display cover sources as file or link in the card
- harden cover upload fallbacks and add dedicated tests for prompt order, lyrics persistence, cover uploads, and the start button behaviour

## Testing
- pytest tests/test_suno_prompt_steps.py tests/test_suno_text_source.py tests/test_suno_cover_upload.py tests/test_cover_upload_stream_ok.py tests/test_cover_upload_url_ok.py tests/test_start_sends_big_emoji_once.py tests/test_start_button_once.py

------
https://chatgpt.com/codex/tasks/task_e_68dcf60f23fc832298d9f2290a530933