### PR TITLE
Add support ticket flow and welcome bonus automation

### DIFF
--- a/roles.py
+++ b/roles.py
@@ -1,0 +1,42 @@
+"""Role helpers for privileged accounts."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+_log = logging.getLogger("roles")
+
+
+def _env_int(name: str, default: int = 0) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    text = raw.strip()
+    if not text:
+        return default
+    try:
+        return int(text)
+    except ValueError:
+        _log.warning("Invalid integer for %s: %s", name, text)
+        return default
+
+
+SUPPORT_USER_ID: int = _env_int("SUPPORT_USER_ID", 0)
+
+
+def is_support(user_id: Any) -> bool:
+    """Return ``True`` if ``user_id`` matches the configured support account."""
+
+    if user_id is None:
+        return False
+    try:
+        numeric_id = int(user_id)
+    except (TypeError, ValueError):
+        return False
+    if SUPPORT_USER_ID <= 0:
+        return False
+    return numeric_id == SUPPORT_USER_ID
+
+
+__all__ = ["SUPPORT_USER_ID", "is_support"]

--- a/utils/input_state.py
+++ b/utils/input_state.py
@@ -5,7 +5,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, Mapping, Optional, Tuple
+from typing import Any, Dict, Mapping, Optional, Tuple, Literal
 
 import time
 
@@ -29,6 +29,7 @@ class WaitKind(str, Enum):
     SUNO_STYLE = "suno_style"
     SUNO_LYRICS = "suno_lyrics"
     MJ_PROMPT = "mj_prompt"
+    SUPPORT_TICKET = "support_ticket"
 
 
 def classify_wait_input(text: Optional[str]) -> Tuple[bool, Optional[str]]:
@@ -227,6 +228,7 @@ def set_wait(
         "suno_style",
         "suno_lyrics",
         "banana_prompt",
+        "support_ticket",
     ],
     card_msg_id: Optional[int],
     *,


### PR DESCRIPTION
## Summary
- grant the configurable welcome bonus during the first interaction and avoid duplicate notifications
- add inline support entry points, ticket forwarding, and reply handling for the support account
- gate reply callbacks by support role and wire the new helpers into the command/callback registry

## Testing
- python -m compileall bot.py utils/input_state.py roles.py

------
https://chatgpt.com/codex/tasks/task_e_68dcfea7a5fc83229a789d12b9fd9ba0