### PR TITLE
Revamp Suno flow prompts and cover handling

### DIFF
--- a/tests/test_music_flow.py
+++ b/tests/test_music_flow.py
@@ -68,6 +68,18 @@ def test_instrumental_auto_style_default() -> None:
         bot_module._music_begin_flow(chat_id, ctx, state_dict, flow="instrumental", user_id=42)
     )
 
+    title_message = DummyMessage("Dreamscape")
+    asyncio.run(
+        bot_module._handle_suno_waiting_input(
+            ctx,
+            chat_id,
+            title_message,
+            state_dict,
+            bot_module.WAIT_SUNO_TITLE,
+            user_id=42,
+        )
+    )
+
     message = DummyMessage("")
     asyncio.run(
         bot_module._handle_suno_waiting_input(
@@ -81,7 +93,7 @@ def test_instrumental_auto_style_default() -> None:
     )
     suno_state = bot_module.load_suno_state(ctx)
     assert suno_state.style == bot_module._INSTRUMENTAL_DEFAULT_STYLE
-    assert state_dict.get("suno_step") == "title"
+    assert state_dict.get("suno_step") == "ready"
     assert any("стиль по умолчанию" in reply for reply in message.replies)
 
 
@@ -91,6 +103,18 @@ def test_lyrics_manual_and_auto_generation() -> None:
 
     asyncio.run(
         bot_module._music_begin_flow(chat_id, ctx, state_dict, flow="lyrics", user_id=99)
+    )
+
+    title_msg = DummyMessage("City Lights")
+    asyncio.run(
+        bot_module._handle_suno_waiting_input(
+            ctx,
+            chat_id,
+            title_msg,
+            state_dict,
+            bot_module.WAIT_SUNO_TITLE,
+            user_id=99,
+        )
     )
 
     # manual lyrics
@@ -112,6 +136,17 @@ def test_lyrics_manual_and_auto_generation() -> None:
     # restart flow to test auto lyrics
     asyncio.run(
         bot_module._music_begin_flow(chat_id, ctx, state_dict, flow="lyrics", user_id=99)
+    )
+    title_msg_auto = DummyMessage("City Lights")
+    asyncio.run(
+        bot_module._handle_suno_waiting_input(
+            ctx,
+            chat_id,
+            title_msg_auto,
+            state_dict,
+            bot_module.WAIT_SUNO_TITLE,
+            user_id=99,
+        )
     )
     auto_msg = DummyMessage("")
     asyncio.run(
@@ -151,6 +186,18 @@ def test_cover_upload_flow_accepts_audio() -> None:
         bot_module._music_begin_flow(chat_id, ctx, state_dict, flow="cover", user_id=7)
     )
     state_dict["mode"] = "suno"
+
+    title_cover_msg = DummyMessage("Cover Song", chat_id)
+    asyncio.run(
+        bot_module._handle_suno_waiting_input(
+            ctx,
+            chat_id,
+            title_cover_msg,
+            state_dict,
+            bot_module.WAIT_SUNO_TITLE,
+            user_id=7,
+        )
+    )
 
     class Audio:
         def __init__(self) -> None:

--- a/texts.py
+++ b/texts.py
@@ -32,18 +32,14 @@ SUNO_RU = {
     "suno.lyrics_source.ai": "✨ Сгенерировать ИИ",
     "suno.prompt.mode_select": "Выберите режим генерации",
     "suno.prompt.step.title": (
-        "Шаг {index}/{total} (название): Введите короткое название трека. "
-        "Отправьте /cancel, чтобы остановить.\n"
+        "Введите короткое название трека. Отправьте /cancel, чтобы остановить.\n"
         "Сейчас: “{current}”"
     ),
     "suno.prompt.step.style": (
-        "Шаг {index}/{total} (стиль): Опишите стиль/теги (например, „эмбиент, мягкие барабаны“). "
-        "Отправьте /cancel, чтобы остановить.\n"
-        "Сейчас: “{current}”"
+        "Шаг {index}/{total} (стиль): Опишите стиль/теги (например, «эмбиент, мягкие барабаны»). "
+        "Отправьте /cancel, чтобы остановить."
     ),
-    "suno.prompt.step.lyrics": (
-        "Шаг {index}/{total} (текст): Пришлите текст песни сообщением."
-    ),
+    "suno.prompt.step.lyrics": "Пришлите текст песни одним сообщением.",
     "suno.prompt.step.source": (
         f"Шаг {{index}}/{{total}} (источник): Пришлите аудио-файл (mp3/wav, до {MAX_AUDIO_MB} МБ) "
         "или ссылку на аудио (http/https)."
@@ -52,8 +48,12 @@ SUNO_RU = {
     "suno.prompt.fill": "Заполните: {fields}",
     "suno.prompt.ready": "Все обязательные поля заполнены. Можно запускать генерацию.",
     "suno.prompt.starting": "Запускаю генерацию…",
-    "suno.error.upload_client": "⚠️ Не удалось загрузить источник. Проверьте файл/ссылку и попробуйте ещё раз.",
-    "suno.error.upload_service": "⚠️ Сервис загрузки недоступен. Попробуйте позже.",
+    "suno.error.upload_client": (
+        "⚠️ Не удалось принять аудио. Пришлите mp3/wav (до {MAX_AUDIO_MB} МБ) или ссылку http/https."
+    ),
+    "suno.error.upload_service": (
+        "⚠️ Не удалось принять аудио. Пришлите mp3/wav (до {MAX_AUDIO_MB} МБ) или ссылку http/https."
+    ),
 }
 
 

--- a/utils/suno_state.py
+++ b/utils/suno_state.py
@@ -16,7 +16,7 @@ from utils.suno_modes import get_mode_config as get_suno_mode_config
 TITLE_MAX_LENGTH = 300
 STYLE_MAX_LENGTH = 500
 LYRICS_MAX_LENGTH = 2000
-LYRICS_PREVIEW_LIMIT = 160
+LYRICS_PREVIEW_LIMIT = 80
 _STORAGE_KEY = "suno_state"
 
 


### PR DESCRIPTION
## Summary
- centralize Suno state snapshotting and add step metadata to keep prompts, ready state, and start button synchronized across modes
- rework flow hints via new sync_suno_prompt routine, update RU texts, and tighten cover source handling with friendlier errors
- refresh tests to follow the new Title → Source → Style sequence and ensure cover uploads advance correctly

## Testing
- pytest tests/test_music_flow.py
- pytest tests/test_suno_flow.py
- pytest tests/test_suno_basic.py

------
https://chatgpt.com/codex/tasks/task_e_68dd044949b4832284574625e44e1e92