### PR TITLE
Restore main menu flow and clean wait handling

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -43,6 +43,8 @@ class _AppSettings(BaseModel):
     WELCOME_BONUS: int = Field(default=10, ge=0)
     WELCOME_BONUS_ENABLED: bool = Field(default=True)
     WELCOME_BONUS_REDIS_KEY: str = Field(default="user:{uid}:welcome_bonus_v1")
+    WELCOME_BONUS_AMOUNT: Optional[int] = Field(default=None)
+    WELCOME_BONUS_KEY_TTL_DAYS: Optional[int] = Field(default=None)
 
     KIE_BASE_URL: str = Field(default="https://api.kie.ai")
     KIE_API_KEY: Optional[str] = Field(default=None)
@@ -210,6 +212,18 @@ if _welcome_bonus_key_template.startswith(f"{REDIS_PREFIX}:"):
     WELCOME_BONUS_REDIS_KEY = _welcome_bonus_key_template
 else:
     WELCOME_BONUS_REDIS_KEY = f"{REDIS_PREFIX}:{_welcome_bonus_key_template}"
+
+WELCOME_BONUS_AMOUNT = int(
+    max(
+        0,
+        _APP_SETTINGS.WELCOME_BONUS_AMOUNT
+        if _APP_SETTINGS.WELCOME_BONUS_AMOUNT is not None
+        else WELCOME_BONUS,
+    )
+)
+WELCOME_BONUS_KEY_TTL_DAYS = int(
+    max(1, _APP_SETTINGS.WELCOME_BONUS_KEY_TTL_DAYS or 3650)
+)
 
 
 def _strip_optional(value: Optional[str]) -> Optional[str]:

--- a/telegram_utils.py
+++ b/telegram_utils.py
@@ -191,6 +191,24 @@ def build_hub_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(rows)
 
 
+async def send_html(bot, chat_id: int, text: str, **kwargs):
+    """Send an HTML-formatted message with sane defaults."""
+
+    return await bot.send_message(
+        chat_id=chat_id,
+        text=text,
+        parse_mode=ParseMode.HTML,
+        disable_web_page_preview=True,
+        **kwargs,
+    )
+
+
+def escape(value: Optional[str]) -> str:
+    """Escape ``value`` for safe HTML rendering without touching quotes."""
+
+    return html.escape(value or "", quote=False)
+
+
 def _extract_status(exc: BaseException) -> Optional[int]:
     for attr in ("status_code", "code", "error_code"):
         value = getattr(exc, attr, None)


### PR DESCRIPTION
## Summary
- unify HTML messaging helpers to use a single `send_html` entry point and `escape` helper for dynamic content safety
- connect welcome bonus configuration to Redis TTL controls and rebuild the main menu cards, commands, and callback routers
- drop `ApplicationHandlerStop` usage, rely on safe handler wrappers, and guard text handler flow when wait states are active

## Testing
- pytest tests/test_main_menu_bonus.py tests/test_handler_registration.py tests/test_hub_menu.py

------
https://chatgpt.com/codex/tasks/task_e_68dd4a31abc483229f2de7885aefa5ce