### PR TITLE
Restore main menu routing and wait-state reset

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -199,6 +199,10 @@ REDIS_PREFIX = (os.getenv("REDIS_PREFIX") or "suno:prod").strip() or "suno:prod"
 SUNO_LOG_KEY = f"{REDIS_PREFIX}:suno:logs"
 UPLOAD_FALLBACK_ENABLED = bool(_APP_SETTINGS.UPLOAD_FALLBACK_ENABLED)
 
+
+# Feature toggles
+WELCOME_BONUS_ENABLED = False
+
 def _strip_optional(value: Optional[str]) -> Optional[str]:
     if value is None:
         return None

--- a/tests/test_handler_registration.py
+++ b/tests/test_handler_registration.py
@@ -58,7 +58,23 @@ def test_chat_and_prompt_master_handlers_registered() -> None:
 
     assert "chat" in commands
     assert "prompt_master" in commands
+
+    expected_commands = {
+        "start",
+        "menu",
+        "video",
+        "image",
+        "music",
+        "buy",
+        "lang",
+        "help",
+        "faq",
+    }
+    missing = expected_commands - commands
+    assert not missing, f"commands not registered: {sorted(missing)}"
+
     assert any(pattern.startswith("^pm:") for pattern in callback_patterns)
+    assert any("hub" in pattern and pattern.startswith("^(?:hub") for pattern in callback_patterns)
 
 
 def test_reply_button_routes_match_expected() -> None:

--- a/tests/test_main_menu.py
+++ b/tests/test_main_menu.py
@@ -38,13 +38,13 @@ def _assert_main_menu_payload(payload: dict, expected_balance: int) -> None:
     markup = payload["reply_markup"]
     rows = markup.inline_keyboard
     assert [[btn.callback_data for btn in row] for row in rows] == [
-        ["menu:video"],
-        ["menu:image"],
-        ["menu:music"],
-        ["menu:buy"],
-        ["menu:lang"],
-        ["menu:help"],
-        ["menu:faq"],
+        ["hub:video"],
+        ["hub:image"],
+        ["hub:music"],
+        ["hub:buy"],
+        ["hub:lang"],
+        ["hub:help"],
+        ["hub:faq"],
     ]
 
 


### PR DESCRIPTION
## Summary
- add a with_state_reset decorator that clears Redis wait flags before running handlers and falls back to the main menu on failure
- switch the main menu and submenus back to hub:* callbacks with consistent HTML sending helpers and disable the welcome bonus
- expose Redis wait_* helpers and update unit tests for command registration and menu rendering

## Testing
- pytest tests/test_main_menu.py tests/test_handler_registration.py

------
https://chatgpt.com/codex/tasks/task_e_68dd60cb15088322995d48885a808c93