### PR TITLE
Restore main menu callbacks and reset wait flags

### DIFF
--- a/tests/test_main_menu.py
+++ b/tests/test_main_menu.py
@@ -41,7 +41,7 @@ def _assert_main_menu_payload(payload: dict, expected_balance: int) -> None:
         ["hub:video"],
         ["hub:image"],
         ["hub:music"],
-        ["hub:buy"],
+        ["hub:balance"],
         ["hub:lang"],
         ["hub:help"],
         ["hub:faq"],


### PR DESCRIPTION
## Summary
- clear wait-related redis keys and context state before running handlers to avoid stale locks
- update the main menu hub keyboard to expose the balance card and add a reusable balance renderer
- adjust main menu tests to the restored layout without welcome bonus messaging

## Testing
- pytest tests/test_main_menu.py

------
https://chatgpt.com/codex/tasks/task_e_68dd640b28088322904e46634c98c49c