### PR TITLE
Implement stateless go router for main menu

### DIFF
--- a/tests/test_main_menu.py
+++ b/tests/test_main_menu.py
@@ -38,13 +38,10 @@ def _assert_main_menu_payload(payload: dict, expected_balance: int) -> None:
     markup = payload["reply_markup"]
     rows = markup.inline_keyboard
     assert [[btn.callback_data for btn in row] for row in rows] == [
-        ["hub:video"],
-        ["hub:image"],
-        ["hub:music"],
-        ["hub:balance"],
-        ["hub:lang"],
-        ["hub:help"],
-        ["hub:faq"],
+        ["go:video", "go:image"],
+        ["go:music", "go:balance"],
+        ["go:lang", "go:help"],
+        ["go:faq"],
     ]
 
 


### PR DESCRIPTION
## Summary
- replace hub-based navigation with a unified go:* callback router and stateless main menu renderer
- update menu and card keyboards to use the new go:* payloads and refreshed copy
- adjust the main menu test to assert the new layout and callbacks

## Testing
- pytest tests/test_main_menu.py

------
https://chatgpt.com/codex/tasks/task_e_68dd697e84f48322b08d12837161a14d