### PR TITLE
Refactor hub routing and reset stuck waits

### DIFF
--- a/keyboards.py
+++ b/keyboards.py
@@ -2,6 +2,28 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 CB_FAQ_PREFIX = "faq:"
 CB_PM_PREFIX = "pm:"
+HUB_CALLBACK_PREFIX = "hub:"
+
+
+def hub_main_keyboard() -> InlineKeyboardMarkup:
+    rows = [
+        [
+            InlineKeyboardButton("🎬 Генерация видео", callback_data=f"{HUB_CALLBACK_PREFIX}video"),
+            InlineKeyboardButton(
+                "🎨 Генерация изображений", callback_data=f"{HUB_CALLBACK_PREFIX}image"
+            ),
+        ],
+        [
+            InlineKeyboardButton("🎧 Музыка", callback_data=f"{HUB_CALLBACK_PREFIX}music"),
+            InlineKeyboardButton("💎 Баланс", callback_data=f"{HUB_CALLBACK_PREFIX}balance"),
+        ],
+        [
+            InlineKeyboardButton("🌐 Язык", callback_data=f"{HUB_CALLBACK_PREFIX}lang"),
+            InlineKeyboardButton("❓ FAQ", callback_data=f"{HUB_CALLBACK_PREFIX}faq"),
+        ],
+        [InlineKeyboardButton("🆘 Поддержка", callback_data=f"{HUB_CALLBACK_PREFIX}help")],
+    ]
+    return InlineKeyboardMarkup(rows)
 
 
 _PM_LABELS = {

--- a/settings.py
+++ b/settings.py
@@ -202,6 +202,8 @@ UPLOAD_FALLBACK_ENABLED = bool(_APP_SETTINGS.UPLOAD_FALLBACK_ENABLED)
 
 # Feature toggles
 WELCOME_BONUS_ENABLED = False
+WELCOME_BONUS_AMOUNT = 0
+WELCOME_BONUS_TTL_DAYS = 0
 
 def _strip_optional(value: Optional[str]) -> Optional[str]:
     if value is None:

--- a/tests/test_anti_stuck.py
+++ b/tests/test_anti_stuck.py
@@ -1,0 +1,51 @@
+import asyncio
+import os
+import sys
+from types import SimpleNamespace
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+os.environ.setdefault("LEDGER_BACKEND", "memory")
+
+from tests.suno_test_utils import FakeBot, bot_module  # noqa: E402
+import telegram_utils  # noqa: E402
+
+
+def _make_update(user_id: int, chat_id: int, text: str) -> SimpleNamespace:
+    message = SimpleNamespace(text=text, caption=None, chat_id=chat_id)
+    return SimpleNamespace(
+        effective_user=SimpleNamespace(id=user_id),
+        effective_chat=SimpleNamespace(id=chat_id),
+        message=message,
+        effective_message=message,
+        callback_query=None,
+    )
+
+
+def test_menu_command_clears_wait_flags(monkeypatch):
+    ctx = SimpleNamespace(
+        bot=FakeBot(),
+        bot_data={"redis": object(), "redis_prefix": "test-prefix"},
+        user_data={},
+        chat_data={},
+        args=[],
+    )
+
+    clear_calls: list[tuple[object, int, str]] = []
+
+    async def fake_clear(redis_client, user_id, prefix):
+        clear_calls.append((redis_client, user_id, prefix))
+        return 1
+
+    monkeypatch.setattr(telegram_utils, "clear_wait_flags", fake_clear)
+
+    handler = telegram_utils.with_state_reset(bot_module.on_menu)
+    update = _make_update(user_id=111, chat_id=777, text="/menu")
+
+    asyncio.run(handler(update, ctx))
+
+    assert clear_calls == [(ctx.bot_data["redis"], 111, "test-prefix")]
+    sent_menu = [payload for payload in ctx.bot.sent if isinstance(payload, dict)]
+    assert sent_menu, "menu should be rendered after reset"

--- a/tests/test_main_menu.py
+++ b/tests/test_main_menu.py
@@ -37,11 +37,15 @@ def _assert_main_menu_payload(payload: dict, expected_balance: int) -> None:
     assert payload.get("parse_mode") == bot_module.ParseMode.HTML
     markup = payload["reply_markup"]
     rows = markup.inline_keyboard
+    for row in rows:
+        for btn in row:
+            assert btn.callback_data.startswith("hub:"), "callback prefix must be hub:"
+            assert len(btn.callback_data.encode("utf-8")) <= 64, "callback data too long"
     assert [[btn.callback_data for btn in row] for row in rows] == [
-        ["go:video", "go:image"],
-        ["go:music", "go:balance"],
-        ["go:lang", "go:help"],
-        ["go:faq"],
+        ["hub:video", "hub:image"],
+        ["hub:music", "hub:balance"],
+        ["hub:lang", "hub:faq"],
+        ["hub:help"],
     ]
 
 


### PR DESCRIPTION
## Summary
- normalize hub callbacks to the new `hub:*` prefix and route them through a dedicated `hub_router`
- add Redis wait-flag helpers, context resets, and TTL updates to prevent lingering wait states
- update handler registration, keyboards, and tests to cover anti-stuck behavior and short callbacks

## Testing
- pytest tests/test_main_menu.py tests/test_handler_registration.py tests/test_anti_stuck.py

------
https://chatgpt.com/codex/tasks/task_e_68dd72233b2883229708bd933cff7c47