### PR TITLE
Restore menu callbacks and reset stuck states

### DIFF
--- a/keyboards.py
+++ b/keyboards.py
@@ -7,6 +7,7 @@ HUB_CALLBACK_PREFIX = "hub:"
 
 def hub_main_keyboard() -> InlineKeyboardMarkup:
     rows = [
+        [InlineKeyboardButton("🧠 Prompt-Master", callback_data=f"{HUB_CALLBACK_PREFIX}prompt")],
         [
             InlineKeyboardButton("🎬 Генерация видео", callback_data=f"{HUB_CALLBACK_PREFIX}video"),
             InlineKeyboardButton(
@@ -14,12 +15,14 @@ def hub_main_keyboard() -> InlineKeyboardMarkup:
             ),
         ],
         [
-            InlineKeyboardButton("🎧 Музыка", callback_data=f"{HUB_CALLBACK_PREFIX}music"),
-            InlineKeyboardButton("💎 Баланс", callback_data=f"{HUB_CALLBACK_PREFIX}balance"),
+            InlineKeyboardButton(
+                "🎵 Генерация музыки", callback_data=f"{HUB_CALLBACK_PREFIX}music"
+            ),
+            InlineKeyboardButton("💬 Обычный чат", callback_data=f"{HUB_CALLBACK_PREFIX}chat"),
         ],
         [
+            InlineKeyboardButton("💎 Баланс", callback_data=f"{HUB_CALLBACK_PREFIX}balance"),
             InlineKeyboardButton("🌐 Язык", callback_data=f"{HUB_CALLBACK_PREFIX}lang"),
-            InlineKeyboardButton("❓ FAQ", callback_data=f"{HUB_CALLBACK_PREFIX}faq"),
         ],
         [InlineKeyboardButton("🆘 Поддержка", callback_data=f"{HUB_CALLBACK_PREFIX}help")],
     ]

--- a/tests/test_handler_registration.py
+++ b/tests/test_handler_registration.py
@@ -68,13 +68,12 @@ def test_chat_and_prompt_master_handlers_registered() -> None:
         "buy",
         "lang",
         "help",
-        "faq",
     }
     missing = expected_commands - commands
     assert not missing, f"commands not registered: {sorted(missing)}"
 
     assert any(pattern.startswith("^pm:") for pattern in callback_patterns)
-    assert any(pattern.startswith("^hub:") for pattern in callback_patterns)
+    assert "^hub:.*" in callback_patterns
 
     command_groups = {
         group

--- a/tests/test_hub_menu.py
+++ b/tests/test_hub_menu.py
@@ -12,19 +12,24 @@ def test_build_hub_keyboard_layout():
     keyboard = build_hub_keyboard()
     rows = keyboard.inline_keyboard
 
-    assert len(rows) == 2
-    assert all(len(row) == 3 for row in rows)
-
     expected = [
-        ("🎬", "hub:video"),
-        ("🎨", "hub:image"),
-        ("🎵", "hub:music"),
-        ("🧠", "hub:prompt"),
-        ("💬", "hub:chat"),
-        ("💎", "hub:balance"),
+        [("🧠 Prompt-Master", "hub:prompt")],
+        [
+            ("🎬 Генерация видео", "hub:video"),
+            ("🎨 Генерация изображений", "hub:image"),
+        ],
+        [
+            ("🎵 Генерация музыки", "hub:music"),
+            ("💬 Обычный чат", "hub:chat"),
+        ],
+        [
+            ("💎 Баланс", "hub:balance"),
+            ("🌐 Язык", "hub:lang"),
+        ],
+        [("🆘 Поддержка", "hub:help")],
     ]
 
-    actual = [(button.text, button.callback_data) for row in rows for button in row]
+    actual = [[(button.text, button.callback_data) for button in row] for row in rows]
 
     assert actual == expected
 
@@ -32,14 +37,4 @@ def test_build_hub_keyboard_layout():
 def test_build_hub_text_contains_balance_and_link():
     text = build_hub_text(123)
 
-    assert text.startswith("👋 Добро пожаловать!")
-    assert "💎 Ваш баланс: 123" in text
-
-    link_marker = "[канал с промптами]("
-    assert link_marker in text
-    start = text.index(link_marker) + len(link_marker)
-    end = text.index(")", start)
-    url = text[start:end]
-
-    assert url
-    assert url.strip() != ""
+    assert text == "<b>🏠 Главное меню</b>\nВыберите нужный раздел:"

--- a/tests/test_main_menu.py
+++ b/tests/test_main_menu.py
@@ -42,9 +42,10 @@ def _assert_main_menu_payload(payload: dict, expected_balance: int) -> None:
             assert btn.callback_data.startswith("hub:"), "callback prefix must be hub:"
             assert len(btn.callback_data.encode("utf-8")) <= 64, "callback data too long"
     assert [[btn.callback_data for btn in row] for row in rows] == [
+        ["hub:prompt"],
         ["hub:video", "hub:image"],
-        ["hub:music", "hub:balance"],
-        ["hub:lang", "hub:faq"],
+        ["hub:music", "hub:chat"],
+        ["hub:balance", "hub:lang"],
         ["hub:help"],
     ]
 
@@ -65,7 +66,7 @@ def test_menu_command(monkeypatch):
         payload
         for payload in bot.sent
         if isinstance(payload, dict)
-        and payload.get("text", "").startswith("👋 Добро пожаловать!")
+        and payload.get("text", "") == bot_module._build_main_menu_text(0)
     ]
 
     assert menu_messages, "main menu message should be sent"
@@ -97,7 +98,7 @@ def test_start_flow_without_bonus(monkeypatch):
         payload
         for payload in bot.sent
         if isinstance(payload, dict)
-        and payload.get("text", "").startswith("👋 Добро пожаловать!")
+        and payload.get("text", "") == bot_module._build_main_menu_text(0)
     ]
     assert menu_messages, "main menu message should be sent"
     _assert_main_menu_payload(menu_messages[-1], expected_balance=0)

--- a/tests/test_state_reset.py
+++ b/tests/test_state_reset.py
@@ -1,0 +1,61 @@
+import asyncio
+import fnmatch
+from types import SimpleNamespace
+
+from tests.suno_test_utils import FakeBot, bot_module
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.deleted: list[str] = []
+
+    def scan_iter(self, pattern: str):
+        for key in list(self.store.keys()):
+            if fnmatch.fnmatch(key, pattern):
+                yield key
+
+    def delete(self, *keys: str) -> int:
+        removed = 0
+        for key in keys:
+            if key in self.store:
+                removed += 1
+                self.store.pop(key, None)
+                self.deleted.append(key)
+        return removed
+
+
+def _make_update(user_id: int = 99, chat_id: int = 77) -> SimpleNamespace:
+    message = SimpleNamespace(text="/menu", caption=None, chat_id=chat_id)
+    return SimpleNamespace(
+        effective_user=SimpleNamespace(id=user_id),
+        effective_chat=SimpleNamespace(id=chat_id),
+        message=message,
+        effective_message=message,
+        callback_query=None,
+    )
+
+
+def test_menu_command_clears_wait_keys():
+    fake_redis = FakeRedis()
+    fake_redis.store = {
+        "test:wait:99:prompt": "1",
+        "test:fsm:99:state": "1",
+        "test:wait:42:other": "1",
+    }
+
+    ctx = SimpleNamespace(
+        bot=FakeBot(),
+        user_data={},
+        args=[],
+        bot_data={"redis": fake_redis, "redis_prefix": "test"},
+    )
+
+    update = _make_update()
+
+    asyncio.run(bot_module.on_menu(update, ctx))
+
+    assert "test:wait:99:prompt" not in fake_redis.store
+    assert "test:fsm:99:state" not in fake_redis.store
+    assert "test:wait:42:other" in fake_redis.store
+    assert set(fake_redis.deleted) == {"test:wait:99:prompt", "test:fsm:99:state"}


### PR DESCRIPTION
## Summary
- add redis helpers and reset_user_state decorator support to clear wait/fsm keys with debug logging
- streamline the main menu copy and inline keyboards around hub:* callbacks and update hub router logging
- expand tests for handler registration, menu layout, and state reset to guard against regressions

## Testing
- pytest tests/test_handler_registration.py tests/test_main_menu.py tests/test_state_reset.py

------
https://chatgpt.com/codex/tasks/task_e_68dd7988c1708322bee9a1558ce79dcb