### PR TITLE
Ensure slash commands reset state and clean waits

### DIFF
--- a/telegram_utils.py
+++ b/telegram_utils.py
@@ -24,7 +24,7 @@ from telegram.constants import ParseMode
 from telegram.error import BadRequest, Forbidden, NetworkError, RetryAfter, TelegramError, TimedOut
 
 from metrics import telegram_send_total
-from redis_utils import clear_all_waits
+from redis_utils import reset_user_state as redis_reset_user_state
 from settings import REDIS_PREFIX
 
 log = logging.getLogger("telegram.utils")
@@ -132,7 +132,7 @@ async def reset_user_state(update: Any = None, context: Any = None) -> int:
 
     deleted = 0
     if redis_client:
-        deleted = await clear_all_waits(redis_client, user_id, prefix=redis_prefix)
+        deleted = await redis_reset_user_state(redis_client, redis_prefix, user_id)
         BOT_LOG.debug(
             "state.reset | user=%s deleted=%s prefix=%s",
             user_id,

--- a/tests/test_anti_stuck.py
+++ b/tests/test_anti_stuck.py
@@ -1,4 +1,5 @@
 import asyncio
+import fnmatch
 import os
 import sys
 from types import SimpleNamespace
@@ -9,6 +10,7 @@ if ROOT not in sys.path:
 
 os.environ.setdefault("LEDGER_BACKEND", "memory")
 
+from redis_utils import cleanup_stale_waits
 from tests.suno_test_utils import FakeBot, bot_module  # noqa: E402
 import telegram_utils  # noqa: E402
 
@@ -33,19 +35,76 @@ def test_menu_command_clears_wait_flags(monkeypatch):
         args=[],
     )
 
-    clear_calls: list[tuple[object, int, str | None]] = []
+    clear_calls: list[tuple[object, int, str]] = []
 
-    async def fake_clear(redis_client, user_id, *, prefix=None):
-        clear_calls.append((redis_client, user_id, prefix))
+    async def fake_reset(redis_client, prefix: str, user_id: int):
+        clear_calls.append((redis_client, prefix, user_id))
         return 1
 
-    monkeypatch.setattr(telegram_utils, "clear_all_waits", fake_clear)
+    monkeypatch.setattr(telegram_utils, "redis_reset_user_state", fake_reset)
 
     handler = telegram_utils.with_state_reset(bot_module.on_menu)
     update = _make_update(user_id=111, chat_id=777, text="/menu")
 
     asyncio.run(handler(update, ctx))
 
-    assert clear_calls == [(ctx.bot_data["redis"], 111, "test-prefix")]
+    assert clear_calls == [(ctx.bot_data["redis"], "test-prefix", 111)]
     sent_menu = [payload for payload in ctx.bot.sent if isinstance(payload, dict)]
     assert sent_menu, "menu should be rendered after reset"
+
+
+class _CleanupRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.ttl_map: dict[str, float] = {}
+        self.deleted: list[str] = []
+
+    def iscan(self, match: str):
+        async def _generator():
+            for key in list(self.store.keys()):
+                if fnmatch.fnmatch(key, match):
+                    yield key
+        return _generator()
+
+    def scan_iter(self, pattern: str):
+        for key in list(self.store.keys()):
+            if fnmatch.fnmatch(key, pattern):
+                yield key
+
+    async def delete(self, *keys: str) -> int:
+        removed = 0
+        for key in keys:
+            if key in self.store:
+                removed += 1
+                self.store.pop(key, None)
+                self.ttl_map.pop(key, None)
+                self.deleted.append(key)
+        return removed
+
+    async def ttl(self, key: str) -> float:
+        if key not in self.store:
+            return -2
+        return self.ttl_map.get(key, -1)
+
+
+def test_cleanup_stale_waits_removes_stuck_entries():
+    fake_redis = _CleanupRedis()
+    fake_redis.store = {
+        "pref:wait:100:prompt": "1",
+        "pref:wait:session:100:prompt": "1",
+        "pref:wait:200:prompt": "1",
+    }
+    fake_redis.ttl_map = {
+        "pref:wait:100:prompt": -1,  # no expiry — must be removed
+        "pref:wait:session:100:prompt": 5000,  # excessive ttl — must be removed
+        "pref:wait:200:prompt": 300,  # healthy
+    }
+
+    deleted = asyncio.run(cleanup_stale_waits(fake_redis, "pref", max_ttl_seconds=900))
+
+    assert deleted == 2
+    assert fake_redis.deleted == [
+        "pref:wait:100:prompt",
+        "pref:wait:session:100:prompt",
+    ]
+    assert "pref:wait:200:prompt" in fake_redis.store


### PR DESCRIPTION
## Summary
- reset user wait/FSM state for slash commands and log dispatch details to unblock navigation
- extend Redis utilities and schedule a watchdog job to purge stale wait keys
- register updated command descriptions with BotFather and cover behaviour with new tests

## Testing
- pytest tests/test_state_reset.py tests/test_anti_stuck.py tests/test_handler_registration.py

------
https://chatgpt.com/codex/tasks/task_e_68dd90bccb6c8322b0ec68534037b114