### PR TITLE
Improve Telegram command routing and diagnostics

### DIFF
--- a/tests/test_handler_registration.py
+++ b/tests/test_handler_registration.py
@@ -1,8 +1,12 @@
 """Tests for Telegram handler registration and reply button wiring."""
 
+import asyncio
+import logging
 import os
 import sys
+from types import SimpleNamespace
 from typing import Dict
+from unittest.mock import AsyncMock
 
 from telegram.ext import AIORateLimiter, ApplicationBuilder, CommandHandler, MessageHandler
 
@@ -12,6 +16,9 @@ if ROOT not in sys.path:
 
 os.environ.setdefault("SUNO_API_TOKEN", "test-token")
 os.environ.setdefault("LEDGER_BACKEND", "memory")
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
+
+import bot
 
 from bot import (  # noqa: E402
     MENU_BTN_BALANCE,
@@ -28,11 +35,14 @@ from bot import (  # noqa: E402
     handle_video_entry,
     prompt_master_command,
     register_handlers,
+    unknown_command,
 )
 def _build_application():
-    return (
+    application = (
         ApplicationBuilder().token("123:ABC").rate_limiter(AIORateLimiter()).build()
     )
+    application.logger = logging.getLogger("test.bot")
+    return application
 
 
 def test_chat_and_prompt_master_handlers_registered() -> None:
@@ -73,15 +83,16 @@ def test_chat_and_prompt_master_handlers_registered() -> None:
         "help",
         "faq",
         "my_balance",
+        "ping",
     }
     missing = expected_commands - commands
     assert not missing, f"commands not registered: {sorted(missing)}"
 
-    def has_state_reset(callback) -> bool:
+    def has_pre_reset(callback) -> bool:
         seen = set()
         current = callback
         while current and current not in seen:
-            if getattr(current, "__with_state_reset__", False):
+            if getattr(current, "__pre_command_reset__", False):
                 return True
             seen.add(current)
             current = getattr(current, "__wrapped__", None)
@@ -90,7 +101,18 @@ def test_chat_and_prompt_master_handlers_registered() -> None:
     for command_name in expected_commands:
         handler = command_handlers.get(command_name)
         assert handler is not None, f"handler missing for /{command_name}"
-        assert has_state_reset(handler.callback), f"/{command_name} must reset state"
+        assert has_pre_reset(handler.callback), f"/{command_name} must reset state"
+
+    unknown_present = False
+    for handlers in application.handlers.values():
+        for handler in handlers:
+            if isinstance(handler, MessageHandler) and getattr(handler, "callback", None) is unknown_command:
+                unknown_present = True
+                break
+        if unknown_present:
+            break
+
+    assert unknown_present, "unknown command handler must be registered"
 
     assert any(pattern.startswith("^pm:") for pattern in callback_patterns)
     assert "^hub:.*" in callback_patterns
@@ -133,3 +155,67 @@ def test_reply_button_routes_match_expected() -> None:
         MENU_BTN_CHAT: handle_chat_entry,
         MENU_BTN_BALANCE: handle_balance_entry,
     }
+
+
+def _find_command_handler(application, command: str) -> CommandHandler:
+    for handlers in application.handlers.values():
+        for handler in handlers:
+            if isinstance(handler, CommandHandler) and command in handler.commands:
+                return handler
+    raise AssertionError(f"handler not found for /{command}")
+
+
+def test_help_command_dispatches_and_resets(monkeypatch) -> None:
+    application = _build_application()
+
+    reset_mock = AsyncMock(return_value=0)
+    monkeypatch.setattr(bot, "reset_user_state_safely", reset_mock)
+
+    dispatched: list[object] = []
+
+    async def fake_safe_dispatch(fn, update, context, *args, **kwargs):
+        dispatched.append(fn)
+        return None
+
+    monkeypatch.setattr(bot, "safe_dispatch", fake_safe_dispatch)
+
+    register_handlers(application)
+
+    handler = _find_command_handler(application, "help")
+
+    message = SimpleNamespace(text="/help")
+    update = SimpleNamespace(
+        effective_message=message,
+        effective_user=SimpleNamespace(id=111),
+        effective_chat=SimpleNamespace(id=222),
+    )
+    context = SimpleNamespace(application=application)
+
+    asyncio.run(handler.callback(update, context))
+
+    reset_mock.assert_awaited_once_with(user_id=111, chat_id=222)
+    assert dispatched == [bot.on_help]
+
+
+def test_unknown_command_replies_with_menu(monkeypatch) -> None:
+    reset_mock = AsyncMock(return_value=0)
+    monkeypatch.setattr(bot, "reset_user_state_safely", reset_mock)
+
+    replies: list[str] = []
+
+    class DummyMessage(SimpleNamespace):
+        async def reply_text(self, text: str, **_kwargs) -> None:  # type: ignore[override]
+            replies.append(text)
+
+    message = DummyMessage(text="/abracadabra")
+    update = SimpleNamespace(
+        effective_message=message,
+        effective_user=SimpleNamespace(id=555),
+        effective_chat=SimpleNamespace(id=777),
+    )
+    context = SimpleNamespace(application=SimpleNamespace(logger=bot.log))
+
+    asyncio.run(bot.unknown_command(update, context))
+
+    reset_mock.assert_awaited_once_with(user_id=555, chat_id=777)
+    assert replies == ["Неизвестная команда. Нажмите /menu"]


### PR DESCRIPTION
## Summary
- centralize command handler registration with pre-command reset, unknown command replies, and a diagnostic /ping
- publish command lists to BotFather during startup and log registered commands on boot
- add a dedicated Redis helper for clearing wait/fsm keys and extend tests to cover the new command flow

## Testing
- `pytest tests/test_handler_registration.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd96d661e0832280c4632ffd8fef3e