### PR TITLE
Fix logging adapter for Telegram bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,11 +10,13 @@ import logging
 import os
 import warnings
 
-from logging_utils import configure_logging, log_environment
+from logging_utils import configure_logging, get_logger, log_environment
 
 os.environ.setdefault("PYTHONUNBUFFERED", "1")
 
-logger = logging.getLogger(__name__)
+logger = get_logger("veo3-bot.bot")
+log = get_logger("veo3-bot")
+singleton_log = get_logger("veo3-bot.singleton")
 logging.basicConfig(level=logging.INFO)
 
 configure_logging("bot")
@@ -814,7 +816,7 @@ def _load_suno_config() -> SunoConfig:
         has_key=has_key,
     )
     if enabled:
-        logging.getLogger("veo3-bot").info(
+        log.info(
             "suno configuration",
             extra={
                 "meta": {
@@ -978,8 +980,6 @@ POLL_TIMEOUT_SECS  = int(_env("POLL_TIMEOUT_SECS", str(20 * 60)))
 KIE_STRICT_POLLING = _env("KIE_STRICT_POLLING", "false").lower() == "true"
 
 logging.getLogger("kie").setLevel(logging.INFO)
-log = logging.getLogger("veo3-bot")
-singleton_log = logging.getLogger("veo3-bot.singleton")
 
 _SAFE_HANDLER_ERROR_TEXT = "⚠️ Системная ошибка. Попробуйте ещё раз."
 
@@ -1074,7 +1074,7 @@ def safe_handler(callback: Callable[..., Any]) -> Callable[..., Awaitable[Any]]:
             clean_name = command_name.lstrip("/") if isinstance(command_name, str) else command_name
             log.debug(
                 "command.dispatch",
-                extra={"name": clean_name, "user": user_id},
+                extra={"cmd_name": clean_name, "user_id": user_id},
             )
         if callback_data:
             bot_logger.debug("callback.dispatch | data=%s user=%s", callback_data, user_id)

--- a/tests/test_handler_registration.py
+++ b/tests/test_handler_registration.py
@@ -1,7 +1,6 @@
 """Tests for Telegram handler registration and reply button wiring."""
 
 import asyncio
-import logging
 import os
 import sys
 from types import SimpleNamespace
@@ -41,7 +40,6 @@ def _build_application():
     application = (
         ApplicationBuilder().token("123:ABC").rate_limiter(AIORateLimiter()).build()
     )
-    application.logger = logging.getLogger("test.bot")
     return application
 
 

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,19 @@
+import logging
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from logging_utils import get_logger
+
+
+def test_logging_extra_name_not_crash(caplog) -> None:
+    logger = get_logger("veo3-bot-test")
+    with caplog.at_level(logging.DEBUG, logger="veo3-bot-test"):
+        logger.debug("check", extra={"name": "menu", "user": 123})
+
+    assert any(record.message == "check" for record in caplog.records)
+    assert any(getattr(record, "extra_name", None) == "menu" for record in caplog.records)
+    assert any(getattr(record, "user", None) == 123 for record in caplog.records)


### PR DESCRIPTION
## Summary
- add a SafeLoggerAdapter helper to sanitize reserved LogRecord fields and expose a shared get_logger factory
- switch the Telegram bot to the shared safe loggers and update command dispatch metadata to avoid reserved keys
- cover the adapter with a regression test and refresh handler registration tests

## Testing
- pytest tests/test_logging_utils.py tests/test_handler_registration.py

------
https://chatgpt.com/codex/tasks/task_e_68dda35b00e883229c62e692b31c5cfb