### PR TITLE
Fix logging context handling and bot error recovery

### DIFF
--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -14,6 +14,8 @@ def test_logging_extra_name_not_crash(caplog) -> None:
     with caplog.at_level(logging.DEBUG, logger="veo3-bot-test"):
         logger.debug("check", extra={"name": "menu", "user": 123})
 
-    assert any(record.message == "check" for record in caplog.records)
-    assert any(getattr(record, "extra_name", None) == "menu" for record in caplog.records)
-    assert any(getattr(record, "user", None) == 123 for record in caplog.records)
+    target = next((record for record in caplog.records if record.message == "check"), None)
+    assert target is not None
+    assert getattr(target, "extra_name", None) == "menu"
+    assert getattr(target, "user", None) == 123
+    assert hasattr(target, "cmd") and getattr(target, "cmd") is None


### PR DESCRIPTION
## Summary
- add a context-aware LoggerAdapter that enforces safe log record fields and installs default context attributes
- update bot error handling to reuse a shared log-context helper and send the new fallback message
- refresh the logging utility test for the new adapter behaviour

## Testing
- pytest tests/test_logging_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68dda80dfdc083228556917be719f992