### PR TITLE
Fix logging sanitization and root health endpoint

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -13511,10 +13511,17 @@ async def run_bot_async() -> None:
     if not KIE_BASE_URL:   raise RuntimeError("KIE_BASE_URL is not set")
     if not KIE_API_KEY:    raise RuntimeError("KIE_API_KEY is not set")
 
-    application = (ApplicationBuilder()
-                   .token(TELEGRAM_TOKEN)
-                   .rate_limiter(AIORateLimiter())
-                   .build())
+    application = (
+        ApplicationBuilder()
+        .token(TELEGRAM_TOKEN)
+        .rate_limiter(AIORateLimiter())
+        .build()
+    )
+
+    # python-telegram-bot v20+ no longer exposes a built-in ``logger``
+    # attribute on :class:`Application`. Downstream helpers expect it, so we
+    # provide a compatible adapter that points to the main bot logger.
+    setattr(application, "logger", log)
 
     try:
         register_handlers(application)

--- a/suno_web.py
+++ b/suno_web.py
@@ -245,9 +245,9 @@ async def _middleware(request: Request, call_next):  # type: ignore[override]
     return response
 
 
-@app.get("/")
-def root() -> dict[str, bool]:
-    return {"ok": True}
+@app.api_route("/", methods=["GET", "HEAD"], include_in_schema=False)
+def root() -> JSONResponse:
+    return JSONResponse({"ok": True, "service": "veo3-bot"})
 
 
 @app.get("/healthz")

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -15,7 +15,7 @@ def test_build_log_extra_wraps_fields() -> None:
     ctx = payload["ctx"]
     assert ctx["command"] == "menu"
     assert ctx["meta"] == {"foo": "bar"}
-    assert ctx["field_name"] == "test"
+    assert ctx["ctx_name"] == "test"
 
 
 def test_logging_extra_name_not_crash(caplog) -> None:
@@ -26,5 +26,5 @@ def test_logging_extra_name_not_crash(caplog) -> None:
     target = next((record for record in caplog.records if record.message == "check"), None)
     assert target is not None
     ctx = getattr(target, "ctx")
-    assert ctx["field_name"] == "menu"
+    assert ctx["ctx_name"] == "menu"
     assert ctx["user"] == 123


### PR DESCRIPTION
## Summary
- sanitize logging extras based on actual LogRecord attributes to avoid Python 3.13 KeyError crashes
- expose the main bot logger on the telegram Application and update tests to reflect the new ctx_* prefixes
- add a combined GET/HEAD root endpoint that returns JSON for Render health probes

## Testing
- pytest tests/test_logging_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68de4de30b2083229dda036e6d0de582