### PR TITLE
Refactor logging and handler instrumentation

### DIFF
--- a/suno/callbacks.py
+++ b/suno/callbacks.py
@@ -10,6 +10,7 @@ from flask import Blueprint, Response, current_app, jsonify, request
 
 from .service import SunoService
 from .store import InMemoryTaskStore, TaskStore
+from logging_utils import build_log_extra
 
 logger = logging.getLogger("suno.callbacks")
 
@@ -239,7 +240,7 @@ def music_callback() -> Response:
     log_level = logging.INFO
     if not callback.task_id or callback.type == "error" or (callback.code and callback.code != 200):
         log_level = logging.WARNING
-    logger.log(log_level, "suno music callback received", extra={"meta": meta})
+    logger.log(log_level, "suno music callback received", **build_log_extra({"meta": meta}))
     return _handle("handle_music_callback", callback)
 
 

--- a/suno/cover_source.py
+++ b/suno/cover_source.py
@@ -22,6 +22,7 @@ from settings import (
     UPLOAD_STREAM_PATH,
     UPLOAD_URL_PATH,
 )
+from logging_utils import build_log_extra
 
 MAX_AUDIO_MB = 50
 _ALLOWED_EXTENSIONS = {".mp3", ".wav"}
@@ -122,7 +123,7 @@ def _log_try(
     payload = {"request_id": request_id, "kind": kind, "host": host, "path": path, "attempt": attempt}
     if extra:
         payload.update(extra)
-    logger.info("cover_upload_try", extra=payload)
+    logger.info("cover_upload_try", **build_log_extra(payload))
 
 
 def _log_fail(
@@ -152,7 +153,7 @@ def _log_fail(
         payload["reason"] = reason
     if body:
         payload["body"] = body
-    logger.warning("cover_upload_fail", extra=payload)
+    logger.warning("cover_upload_fail", **build_log_extra(payload))
 
 
 def _log_ok(
@@ -167,7 +168,7 @@ def _log_ok(
         return
     logger.info(
         "cover_upload_ok",
-        extra={"request_id": request_id, "kind": kind, "host": host, "kie_file_id": kie_file_id},
+        **build_log_extra({"request_id": request_id, "kind": kind, "host": host, "kie_file_id": kie_file_id}),
     )
 
 

--- a/suno/tempfiles.py
+++ b/suno/tempfiles.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 from settings import TMP_CLEANUP_HOURS
+from logging_utils import build_log_extra
 
 log = logging.getLogger("suno.tempfiles")
 
@@ -50,7 +51,7 @@ def cleanup_old_directories(now: Optional[float] = None) -> None:
         try:
             shutil.rmtree(entry, ignore_errors=True)
         except Exception:  # pragma: no cover - defensive
-            log.warning("failed to cleanup directory", extra={"meta": {"path": str(entry)}})
+            log.warning("failed to cleanup directory", **build_log_extra({"meta": {"path": str(entry)}}))
 
 
 def schedule_unlink(path: Path, delay: float = _CLEAN_DELAY) -> None:
@@ -62,7 +63,7 @@ def schedule_unlink(path: Path, delay: float = _CLEAN_DELAY) -> None:
         except FileNotFoundError:
             return
         except Exception:  # pragma: no cover - defensive
-            log.debug("unable to delete file", extra={"meta": {"path": str(path)}})
+            log.debug("unable to delete file", **build_log_extra({"meta": {"path": str(path)}}))
         parent = path.parent
         try:
             if parent != BASE_DIR and parent.exists() and not any(parent.iterdir()):

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -10,18 +10,18 @@ from logging_utils import build_log_extra, get_logger
 
 
 def test_build_log_extra_wraps_fields() -> None:
-    payload = build_log_extra(None, None, command="/menu", meta={"foo": "bar"}, name="test")
-    assert set(payload.keys()) == {"ctx"}
-    ctx = payload["ctx"]
-    assert ctx["command"] == "menu"
-    assert ctx["meta"] == {"foo": "bar"}
-    assert ctx["ctx_name"] == "test"
+    payload = build_log_extra({"name": "x"}, user_id=1)
+    assert set(payload.keys()) == {"extra"}
+    extra = payload["extra"]
+    assert "name" not in extra
+    assert extra["ctx_name"] == "x"
+    assert extra["ctx_user_id"] == 1
 
 
 def test_logging_extra_name_not_crash(caplog) -> None:
     logger = get_logger("veo3-bot-test")
     with caplog.at_level(logging.DEBUG, logger="veo3-bot-test"):
-        logger.debug("check", extra={"name": "menu", "user": 123})
+        logger.debug("check", **build_log_extra({"name": "menu", "user": 123}))
 
     target = next((record for record in caplog.records if record.message == "check"), None)
     assert target is not None

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -7,6 +7,8 @@ import logging
 import random
 from typing import Any, Awaitable, Callable, Optional, TypeVar
 
+from logging_utils import build_log_extra
+
 T = TypeVar("T")
 
 
@@ -78,13 +80,13 @@ async def request_with_retries(
             if logger:
                 logger.warning(
                     "api.retry",  # noqa: TRY400 - structured logging key
-                    extra={
+                    **build_log_extra({
                         **log_extra,
                         "attempt": attempt,
                         "max_attempts": attempts,
                         "delay": round(delay, 3),
                         "error": str(exc),
-                    },
+                    }),
                 )
             total_delay += delay
             if delay > 0:

--- a/utils/safe_send.py
+++ b/utils/safe_send.py
@@ -13,6 +13,7 @@ from telegram.constants import ParseMode
 from telegram.error import BadRequest
 
 from utils.html_render import html_to_plain
+from logging_utils import build_log_extra
 
 logger = logging.getLogger(__name__)
 
@@ -190,18 +191,18 @@ async def safe_delete_message(bot: Bot, chat_id: int, message_id: int) -> bool:
         if "message to delete not found" in message or "message can't be deleted" in message:
             logger.debug(
                 "safe_delete.skip",
-                extra={"chat_id": chat_id, "message_id": message_id, "error": str(exc)},
+                **build_log_extra({"chat_id": chat_id, "message_id": message_id, "error": str(exc)}),
             )
             return False
         logger.debug(
             "safe_delete.bad_request",
-            extra={"chat_id": chat_id, "message_id": message_id, "error": str(exc)},
+            **build_log_extra({"chat_id": chat_id, "message_id": message_id, "error": str(exc)}),
         )
         return False
     except Exception as exc:  # pragma: no cover - network issues
         logger.warning(
             "safe_delete.error",
-            extra={"chat_id": chat_id, "message_id": message_id, "error": repr(exc)},
+            **build_log_extra({"chat_id": chat_id, "message_id": message_id, "error": repr(exc)}),
         )
         return False
 
@@ -229,7 +230,7 @@ async def send_html_with_fallback(
         message = str(exc).lower()
         if "can't parse entities" not in message and "parse entities" not in message:
             raise
-        logger.warning("pm.html_fallback", extra={"exc": repr(exc)})
+        logger.warning("pm.html_fallback", **build_log_extra({"exc": repr(exc)}))
         logger.info("pm.render.fallback")
         plain = html_to_plain(sanitized)
         if not plain:

--- a/utils/telegram_safe.py
+++ b/utils/telegram_safe.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, Tuple
 
 from telegram.constants import ParseMode
 from telegram.error import BadRequest
+from logging_utils import build_log_extra
 
 
 _logger = logging.getLogger("telegram-safe")
@@ -65,7 +66,7 @@ async def safe_edit_message(
     if _MessageHashes.get(key) == new_hashes:
         _logger.info(
             "card_edit_noop",
-            extra={"chat_id": chat_id, "message_id": message_id},
+            **build_log_extra({"chat_id": chat_id, "message_id": message_id}),
         )
         return False
 
@@ -85,7 +86,7 @@ async def safe_edit_message(
         if "message is not modified" in lowered:
             _logger.info(
                 "card_edit_ignored_same_content",
-                extra={"chat_id": chat_id, "message_id": message_id},
+                **build_log_extra({"chat_id": chat_id, "message_id": message_id}),
             )
             _store_hashes(key, new_hashes)
             return False

--- a/voice_service.py
+++ b/voice_service.py
@@ -8,6 +8,8 @@ import random
 import time
 from typing import Optional
 
+from logging_utils import build_log_extra
+
 try:  # pragma: no cover - optional runtime dependency
     import openai  # type: ignore
 except Exception:  # pragma: no cover - library might be unavailable
@@ -85,13 +87,13 @@ def transcribe(audio_bytes: bytes, mime: Optional[str], lang_hint: Optional[str]
             elapsed = time.time() - started
             log.info(
                 "voice.transcribe.success",
-                extra={
+                **build_log_extra({
                     "meta": {
                         "attempt": attempt,
                         "elapsed_ms": int(elapsed * 1000),
                         "lang": lang_hint,
                     }
-                },
+                }),
             )
             if isinstance(response, dict):
                 text = str(response.get("text", ""))
@@ -106,13 +108,13 @@ def transcribe(audio_bytes: bytes, mime: Optional[str], lang_hint: Optional[str]
             should_retry = attempt < _MAX_ATTEMPTS and _should_retry(exc)
             log.warning(
                 "voice.transcribe.error",
-                extra={
+                **build_log_extra({
                     "meta": {
                         "attempt": attempt,
                         "will_retry": should_retry,
                         "error_type": type(exc).__name__,
                     }
-                },
+                }),
             )
             if not should_retry:
                 break


### PR DESCRIPTION
## Summary
- add a sanitized `build_log_extra` helper and pipe all logging extras through it
- store the bot logger in `bot_data`, instrument menu/help/faq/balance handlers, and harden the async error handler
- update auxiliary modules to fetch the logger from context and use the new logging helper, plus emit health check logs

## Testing
- `pytest tests/test_logging_utils.py tests/test_handler_registration.py`


------
https://chatgpt.com/codex/tasks/task_e_68de56f62da8832281db9034ef7e9420