### PR TITLE
Improve telemetry logging and callback safety

### DIFF
--- a/tests/test_faq.py
+++ b/tests/test_faq.py
@@ -28,8 +28,13 @@ def setup_function():
 
 def test_faq_command_sends_intro_and_keyboard():
     bot = FakeBot()
-    message = SimpleNamespace(chat=SimpleNamespace(id=101), chat_id=101)
-    update = SimpleNamespace(effective_message=message)
+    chat = SimpleNamespace(id=101)
+    message = SimpleNamespace(chat=chat, chat_id=101)
+    update = SimpleNamespace(
+        effective_message=message,
+        effective_user=SimpleNamespace(id=1),
+        effective_chat=chat,
+    )
     ctx = SimpleNamespace(bot=bot)
 
     root_calls = []
@@ -55,13 +60,18 @@ def test_faq_callback_sends_section_text():
     section_calls = []
     configure_faq(on_section_view=lambda key: section_calls.append(key))
 
+    chat = SimpleNamespace(id=202)
     query = SimpleNamespace(
         data=f"{CB_FAQ_PREFIX}veo",
         answer=fake_answer,
-        message=SimpleNamespace(chat=SimpleNamespace(id=202), message_id=55),
+        message=SimpleNamespace(chat=chat, message_id=55),
         bot=bot,
     )
-    update = SimpleNamespace(callback_query=query, effective_user=None)
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_user=SimpleNamespace(id=2),
+        effective_chat=chat,
+    )
     ctx = SimpleNamespace(bot=bot)
 
     asyncio.run(faq_callback(update, ctx))
@@ -86,13 +96,18 @@ def test_faq_callback_back_calls_main_menu():
     async def fake_answer():
         pass
 
+    chat = SimpleNamespace(id=303)
     query = SimpleNamespace(
         data=f"{CB_FAQ_PREFIX}back",
         answer=fake_answer,
         edit_message_text=None,
-        message=SimpleNamespace(chat=SimpleNamespace(id=303), message_id=10),
+        message=SimpleNamespace(chat=chat, message_id=10),
     )
-    update = SimpleNamespace(callback_query=query, effective_user=None)
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_user=SimpleNamespace(id=3),
+        effective_chat=chat,
+    )
     ctx = SimpleNamespace(bot=bot)
 
     asyncio.run(faq_callback(update, ctx))
@@ -115,12 +130,17 @@ def test_faq_callback_unknown_section_returns_fallback():
     async def fake_answer():
         pass
 
+    chat = SimpleNamespace(id=404)
     query = SimpleNamespace(
         data=f"{CB_FAQ_PREFIX}unknown",
         answer=fake_answer,
-        message=SimpleNamespace(chat=SimpleNamespace(id=404), message_id=77),
+        message=SimpleNamespace(chat=chat, message_id=77),
     )
-    update = SimpleNamespace(callback_query=query, effective_user=None)
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_user=SimpleNamespace(id=4),
+        effective_chat=chat,
+    )
     ctx = SimpleNamespace(bot=bot)
 
     asyncio.run(faq_callback(update, ctx))

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -12,10 +12,10 @@ from logging_utils import build_log_extra, get_logger
 def test_build_log_extra_wraps_fields() -> None:
     payload = build_log_extra({"name": "x"}, user_id=1)
     assert set(payload.keys()) == {"extra"}
-    extra = payload["extra"]
-    assert "name" not in extra
-    assert extra["ctx_name"] == "x"
-    assert extra["ctx_user_id"] == 1
+    meta = payload["extra"]["meta"]
+    assert "name" not in meta
+    assert meta["ctx_name"] == "x"
+    assert meta["ctx_user_id"] == 1
 
 
 def test_logging_extra_name_not_crash(caplog) -> None:
@@ -25,6 +25,6 @@ def test_logging_extra_name_not_crash(caplog) -> None:
 
     target = next((record for record in caplog.records if record.message == "check"), None)
     assert target is not None
-    ctx = getattr(target, "ctx")
-    assert ctx["ctx_name"] == "menu"
-    assert ctx["user"] == 123
+    meta = getattr(target, "meta")
+    assert meta["ctx_name"] == "menu"
+    assert meta["ctx_user"] == 123

--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -2,7 +2,11 @@ import asyncio
 
 from telegram.constants import ParseMode
 
-from telegram_utils import sanitize_html, safe_send
+import logging
+from types import SimpleNamespace
+
+from logging_utils import get_logger
+from telegram_utils import SafeSendResult, sanitize_html, safe_send, safe_send_text
 
 
 def test_sanitize_html_replaces_br_and_strips_tags() -> None:
@@ -38,3 +42,39 @@ def test_safe_send_sanitizes_html_payload() -> None:
     assert captured
     payload = captured[0]
     assert payload["text"] == "line1\nline2"
+
+
+def test_safe_send_text_logs_success(caplog) -> None:
+    class DummyBot:
+        async def send_message(self, **kwargs):
+            return SimpleNamespace(message_id=777)
+
+    logger = get_logger("test.safe_send")
+    context = SimpleNamespace(
+        bot=DummyBot(),
+        application=SimpleNamespace(bot_data={"logger": logger}),
+    )
+
+    with caplog.at_level(logging.INFO, logger="test.safe_send"):
+        result = asyncio.run(safe_send_text(context, 123, "hello", parse_mode=None))
+    assert isinstance(result, SafeSendResult)
+    assert result.ok is True
+    assert any(record.message == "send.ok" for record in caplog.records)
+
+
+def test_safe_send_text_logs_failure(caplog) -> None:
+    class DummyBot:
+        async def send_message(self, **kwargs):
+            raise RuntimeError("boom")
+
+    logger = get_logger("test.safe_send")
+    context = SimpleNamespace(
+        bot=DummyBot(),
+        application=SimpleNamespace(bot_data={"logger": logger}),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="test.safe_send"):
+        result = asyncio.run(safe_send_text(context, 123, "hello", parse_mode=None))
+    assert isinstance(result, SafeSendResult)
+    assert result.ok is False
+    assert any(record.message == "send.fail" for record in caplog.records)

--- a/tests/test_voice_service.py
+++ b/tests/test_voice_service.py
@@ -14,6 +14,7 @@ if str(ROOT) not in sys.path:
 
 import voice_service
 from voice_service import VoiceTranscribeError, transcribe
+from telegram_utils import SafeSendResult
 
 
 class _FakeRateLimitError(Exception):
@@ -122,6 +123,7 @@ def test_handle_voice_success(monkeypatch, bot_module):
 
     async def fake_safe_send_text(bot, chat_id, text, **kwargs):
         sends.append(text)
+        return SafeSendResult(True, None, None)
 
     async def fake_run_ffmpeg(data, args):
         ffmpeg_calls.append(args)
@@ -245,7 +247,10 @@ def test_handle_voice_transcribe_error(monkeypatch, bot_module):
     monkeypatch.setattr(bot_module, "ensure_user_record", fake_ensure_user_record)
     monkeypatch.setattr(bot_module, "safe_send_placeholder", fake_safe_send_placeholder)
     monkeypatch.setattr(bot_module, "safe_edit_markdown_v2", fake_safe_edit)
-    monkeypatch.setattr(bot_module, "safe_send_text", MagicMock())
+    async def fake_safe_send_text(*args, **kwargs):
+        return SafeSendResult(True, None, None)
+
+    monkeypatch.setattr(bot_module, "safe_send_text", fake_safe_send_text)
     monkeypatch.setattr(bot_module, "run_ffmpeg", fake_run_ffmpeg)
     monkeypatch.setattr(bot_module, "_download_telegram_file", fake_download)
     monkeypatch.setattr(bot_module, "voice_transcribe", fake_voice_transcribe)


### PR DESCRIPTION
## Summary
- add a context-aware logging helper and enrich build_log_extra with update metadata
- rewrite safe_send_text to log send outcomes, consume the new helper in ping and callbacks, and keep the unknown handler stable across reloads
- update FAQ callbacks to answer promptly and extend the test suite for the new diagnostics helpers

## Testing
- pytest tests/test_logging_utils.py tests/test_telegram_utils.py tests/test_voice_service.py tests/test_handler_registration.py tests/test_faq.py

------
https://chatgpt.com/codex/tasks/task_e_68de5eedb8e88322a28b384c50aa6013