### PR TITLE
Improve command telemetry and fallback replies

### DIFF
--- a/logging_utils.py
+++ b/logging_utils.py
@@ -450,6 +450,7 @@ def configure_logging(app_name: str) -> None:
         logging.captureWarnings(True)
         for noisy in ("httpx", "urllib3", "aiogram", "telegram", "uvicorn", "gunicorn", "pydantic"):
             logging.getLogger(noisy).setLevel(logging.WARNING)
+        logging.getLogger("telegram.request").setLevel(logging.DEBUG)
         _CONFIGURED = True
         _install_record_factory_defaults()
 

--- a/telegram_utils.py
+++ b/telegram_utils.py
@@ -216,10 +216,16 @@ def with_state_reset(
 
 
 async def reply_system_error(update: Any, context: Any) -> None:
+    def _mark_sent() -> None:
+        chat_data = getattr(context, "chat_data", None)
+        if isinstance(chat_data, MutableMapping):
+            chat_data["_last_command_reply_sent"] = True
+
     message = getattr(update, "effective_message", None)
     if message is not None:
         with suppress(Exception):
             await message.reply_text(SYSTEM_ERROR_TEXT)
+            _mark_sent()
         return
 
     chat_id = getattr(getattr(update, "effective_chat", None), "id", None)
@@ -232,6 +238,7 @@ async def reply_system_error(update: Any, context: Any) -> None:
         return
     with suppress(Exception):
         await bot.send_message(chat_id=target, text=SYSTEM_ERROR_TEXT)
+        _mark_sent()
 
 
 async def safe_dispatch(


### PR DESCRIPTION
## Summary
- add a bot.send safe_send_text helper with structured send.ok/send.fail logging and automatic user fallback replies
- send hub cards through the safe helper, track command responses, and add command-level fallback messaging plus an unknown-command responder
- log telegram.request traffic at DEBUG and reuse safe sending from the global error handler and system error replies

## Testing
- PYTHONPATH=. pytest tests/test_telegram_utils.py
- PYTHONPATH=. pytest tests/test_prompt_master_ptb.py

------
https://chatgpt.com/codex/tasks/task_e_68de6a8ab67483229f93665d71595a47