### PR TITLE
Add telemetry metadata for help responses

### DIFF
--- a/handlers/help_handler.py
+++ b/handlers/help_handler.py
@@ -60,7 +60,11 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         disable_web_page_preview=True,
     )
 
-    payload: dict[str, object] = {}
+    payload: dict[str, object] = {
+        "message_type": "text",
+        "text_length": len(text),
+        "reply_markup_type": type(markup).__name__,
+    }
     if result.message_id is not None:
         payload["message_id"] = result.message_id
     if result.description:


### PR DESCRIPTION
## Summary
- capture the message type, text length, and markup type when logging /help replies

## Testing
- pytest tests/test_help_handler.py

------
https://chatgpt.com/codex/tasks/task_e_68de97579c6c8322bc4eddc178d3fa23