### PR TITLE
Add localized support command and menu entry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ PROMPTS_CHANNEL_URL=https://t.me/bestveo3promts
 STARS_BUY_URL=https://t.me/PremiumBot
 PROMO_ENABLED=true
 DEV_MODE=false
+SUPPORT_USERNAME=BestAi_Support
+SUPPORT_USER_ID=7223448532
 
 # OpenAI / Prompt Master (optional)
 OPENAI_API_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- Добавлены команды `/help` и `/support` с локализованным сообщением поддержки и кнопкой перехода в `@BestAi_Support`.
+- Конфигурация контакта поддержки вынесена в переменные окружения `SUPPORT_USERNAME` и `SUPPORT_USER_ID`.
+
 ## v0.7.1-suno-stable
 - Prefix Suno request IDs with the initiating user ID for idempotent reuse.
 - Expand enqueue retry jitter to ±30% and align max delay with 15s budget.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,16 @@ PROMPTS_CHANNEL_URL=https://t.me/bestveo3promts
 STARS_BUY_URL=https://t.me/PremiumBot
 PROMO_ENABLED=true
 DEV_MODE=false
+SUPPORT_USERNAME=BestAi_Support
+SUPPORT_USER_ID=7223448532
 
 # OpenAI / Prompt Master (optional)
 OPENAI_API_KEY=
+
+## Support
+
+- Команды `/help` и `/support` отправляют локализованное сообщение с кнопкой, которая ведёт в чат поддержки `https://t.me/BestAi_Support` (значение формируется из `SUPPORT_USERNAME`).
+- Переменные окружения `SUPPORT_USERNAME` и `SUPPORT_USER_ID` позволяют быстро сменить контакт поддержки без изменений в кодовой базе.
 
 # KIE API configuration
 KIE_API_KEY=

--- a/bot.py
+++ b/bot.py
@@ -54,6 +54,7 @@ from handlers import (
     configure_faq,
     faq_callback,
     faq_command,
+    help_command,
     get_pm_prompt,
     prompt_master_callback,
     prompt_master_handle_text,
@@ -3731,6 +3732,7 @@ MENU_BTN_SUNO = "🎵 Генерация музыки"
 MENU_BTN_PM = "🧠 Prompt-Master"
 MENU_BTN_CHAT = "💬 Обычный чат"
 MENU_BTN_BALANCE = "💎 Баланс"
+MENU_BTN_SUPPORT = "🆘 ПОДДЕРЖКА"
 BALANCE_CARD_STATE_KEY = "last_ui_msg_id_balance"
 LEDGER_PAGE_SIZE = 10
 
@@ -3761,6 +3763,7 @@ def main_menu_kb() -> ReplyKeyboardMarkup:
         [KeyboardButton(MENU_BTN_PM)],
         [KeyboardButton(MENU_BTN_CHAT)],
         [KeyboardButton(MENU_BTN_BALANCE)],
+        [KeyboardButton(MENU_BTN_SUPPORT)],
     ]
     return ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
 
@@ -8862,12 +8865,9 @@ async def lang_command(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     await message.reply_text("🌍 Переключение языка будет доступно в ближайшее время.")
 
 
-async def help_command(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+async def help_command_entry(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     await ensure_user_record(update)
-    message = update.effective_message
-    if message is None:
-        return
-    await message.reply_text("🆘 Поддержка появится скоро. Напишите сюда свой вопрос, и мы ответим позже.")
+    await help_command(update, ctx)
 
 
 async def faq_command_entry(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
@@ -11754,7 +11754,7 @@ PRIORITY_COMMAND_SPECS: List[tuple[tuple[str, ...], Any]] = [
     (("video", "veo"), video_command),
     (("music", "suno"), suno_command),
     (("balance",), balance_command),
-    (("help",), help_command),
+    (("help", "support"), help_command_entry),
 ]
 
 ADDITIONAL_COMMAND_SPECS: List[tuple[tuple[str, ...], Any]] = [
@@ -11796,6 +11796,7 @@ REPLY_BUTTON_ROUTES: List[tuple[str, Callable[[Update, ContextTypes.DEFAULT_TYPE
     (MENU_BTN_PM, prompt_master_command),
     (MENU_BTN_CHAT, handle_chat_entry),
     (MENU_BTN_BALANCE, handle_balance_entry),
+    (MENU_BTN_SUPPORT, help_command_entry),
 ]
 
 
@@ -11803,6 +11804,7 @@ LABEL_COMMAND_ROUTES: Dict[str, Callable[[Update, ContextTypes.DEFAULT_TYPE], Aw
     "veo.card": handle_video_entry,
     "mj.card": handle_image_entry,
     "balance.show": handle_balance_entry,
+    "help.open": help_command_entry,
 }
 
 

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,6 +1,7 @@
 """Public handler shortcuts."""
 
 from .faq_handler import configure_faq, faq_callback, faq_command
+from .help_handler import help_command, support_command
 from .prompt_master_handler import (
     clear_pm_prompts,
     get_pm_prompt,
@@ -16,7 +17,9 @@ __all__ = [
     "configure_faq",
     "faq_callback",
     "faq_command",
+    "help_command",
     "get_pm_prompt",
+    "support_command",
     "prompt_master_callback",
     "prompt_master_handle_text",
     "prompt_master_open",

--- a/handlers/help_handler.py
+++ b/handlers/help_handler.py
@@ -1,0 +1,96 @@
+"""Handlers for the /help and /support commands."""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import ContextTypes
+
+from settings import SUPPORT_USER_ID, SUPPORT_USERNAME
+from texts import help_text
+from utils.logging_extra import build_log_extra
+from utils.telegram_safe import safe_send_text
+
+logger = logging.getLogger("bot.commands.help")
+
+
+def _support_url(username: str) -> str:
+    clean = username.lstrip("@") or "BestAi_Support"
+    return f"https://t.me/{clean}"
+
+
+def _resolve_language(update: Update) -> Optional[str]:
+    user = getattr(update, "effective_user", None)
+    return getattr(user, "language_code", None)
+
+
+async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send localized support information to the user."""
+
+    logger.info("update.received", extra=build_log_extra(update))
+    logger.info("command.dispatch", extra=build_log_extra(update, ctx_command="/help"))
+
+    chat = update.effective_chat
+    if chat is None:
+        logger.warning(
+            "send.fail",
+            extra=build_log_extra(
+                update,
+                ctx_command="/help",
+                message_type="text",
+                reason="no_chat",
+            ),
+        )
+        return
+
+    language_code = _resolve_language(update)
+    text, button_label = help_text(language_code, SUPPORT_USERNAME)
+    markup = InlineKeyboardMarkup(
+        [[InlineKeyboardButton(button_label, url=_support_url(SUPPORT_USERNAME))]]
+    )
+
+    result = await safe_send_text(
+        context,
+        chat_id=chat.id,
+        text=text,
+        reply_markup=markup,
+        parse_mode=None,
+        disable_web_page_preview=True,
+    )
+
+    base_kwargs = dict(
+        ctx_command="/help",
+        message_type="text",
+        text_length=len(text),
+        support_user_id=SUPPORT_USER_ID,
+        support_username=SUPPORT_USERNAME,
+    )
+
+    if result.ok:
+        logger.info(
+            "send.ok",
+            extra=build_log_extra(
+                update,
+                message_id=result.message_id,
+                **base_kwargs,
+            ),
+        )
+        return
+
+    error = result.error
+    logger.warning(
+        "send.fail",
+        extra=build_log_extra(
+            update,
+            error=str(error) if error else "unknown",
+            error_type=error.__class__.__name__ if error else None,
+            **base_kwargs,
+        ),
+    )
+
+
+support_command = help_command
+
+
+__all__ = ["help_command", "support_command"]

--- a/settings.py
+++ b/settings.py
@@ -30,6 +30,8 @@ class _AppSettings(BaseModel):
     LOG_LEVEL: str = Field(default="INFO")
     LOG_JSON: bool = Field(default=True)
     MAX_IN_LOG_BODY: int = Field(default=2048, ge=256, le=65536)
+    SUPPORT_USERNAME: str = Field(default="BestAi_Support")
+    SUPPORT_USER_ID: int = Field(default=7223448532)
 
     HTTP_TIMEOUT_CONNECT: float = Field(default=10.0, ge=0.1, le=300.0)
     HTTP_TIMEOUT_READ: float = Field(default=60.0, ge=1.0, le=600.0)
@@ -158,6 +160,12 @@ class _AppSettings(BaseModel):
                 )
         return self
 
+    @field_validator("SUPPORT_USERNAME", mode="before")
+    def _normalize_support_username(cls, value: object) -> str:
+        text = str(value or "BestAi_Support").strip()
+        text = text.lstrip("@")
+        return text or "BestAi_Support"
+
 
 def _load_settings() -> _AppSettings:
     values: dict[str, str] = {}
@@ -198,6 +206,8 @@ TMP_CLEANUP_HOURS = int(_APP_SETTINGS.TMP_CLEANUP_HOURS)
 REDIS_PREFIX = (os.getenv("REDIS_PREFIX") or "suno:prod").strip() or "suno:prod"
 SUNO_LOG_KEY = f"{REDIS_PREFIX}:suno:logs"
 UPLOAD_FALLBACK_ENABLED = bool(_APP_SETTINGS.UPLOAD_FALLBACK_ENABLED)
+SUPPORT_USERNAME = _APP_SETTINGS.SUPPORT_USERNAME
+SUPPORT_USER_ID = int(_APP_SETTINGS.SUPPORT_USER_ID)
 
 
 def _strip_optional(value: Optional[str]) -> Optional[str]:

--- a/tests/test_handler_registration.py
+++ b/tests/test_handler_registration.py
@@ -18,6 +18,7 @@ from bot import (  # noqa: E402
     MENU_BTN_CHAT,
     MENU_BTN_IMAGE,
     MENU_BTN_PM,
+    MENU_BTN_SUPPORT,
     MENU_BTN_SUNO,
     MENU_BTN_VIDEO,
     REPLY_BUTTON_ROUTES,
@@ -26,6 +27,7 @@ from bot import (  # noqa: E402
     handle_image_entry,
     handle_music_entry,
     handle_video_entry,
+    help_command_entry,
     prompt_master_command,
     register_handlers,
 )
@@ -72,4 +74,5 @@ def test_reply_button_routes_match_expected() -> None:
         MENU_BTN_PM: prompt_master_command,
         MENU_BTN_CHAT: handle_chat_entry,
         MENU_BTN_BALANCE: handle_balance_entry,
+        MENU_BTN_SUPPORT: help_command_entry,
     }

--- a/tests/test_help_handler.py
+++ b/tests/test_help_handler.py
@@ -1,0 +1,126 @@
+import asyncio
+import logging
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+from telegram import InlineKeyboardMarkup
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from handlers import help_command as help_handler  # noqa: E402
+from handlers.help_handler import help_command, support_command  # noqa: E402
+from settings import SUPPORT_USERNAME  # noqa: E402
+from texts import help_text  # noqa: E402
+from utils.telegram_safe import SafeSendResult  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging_handlers(monkeypatch):
+    # Ensure logger uses fresh handlers during tests to avoid interference.
+    logger = logging.getLogger("bot.commands.help")
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+    logger.propagate = True
+    yield
+
+
+def _build_update(language_code: str = "ru"):
+    chat = SimpleNamespace(id=123, type="private")
+    user = SimpleNamespace(id=555, language_code=language_code)
+    message = SimpleNamespace(message_id=42, chat=chat)
+    return SimpleNamespace(
+        effective_chat=chat,
+        effective_user=user,
+        effective_message=message,
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_help_command_ru_sends_localized_message(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="bot.commands.help")
+    captured = {}
+
+    async def fake_send(context, *, chat_id, text, reply_markup, **kwargs):
+        captured["chat_id"] = chat_id
+        captured["text"] = text
+        captured["markup"] = reply_markup
+        return SafeSendResult(ok=True, message_id=777)
+
+    monkeypatch.setattr("handlers.help_handler.safe_send_text", fake_send)
+
+    update = _build_update("ru")
+    context = SimpleNamespace()
+
+    _run(help_command(update, context))
+
+    expected_text, expected_button = help_text("ru", SUPPORT_USERNAME)
+    assert captured["chat_id"] == update.effective_chat.id
+    assert captured["text"] == expected_text
+    markup = captured["markup"]
+    assert isinstance(markup, InlineKeyboardMarkup)
+    button = markup.inline_keyboard[0][0]
+    assert button.text == expected_button
+    assert button.url == f"https://t.me/{SUPPORT_USERNAME}"
+
+    messages = [record.msg for record in caplog.records if record.name == "bot.commands.help"]
+    assert "command.dispatch" in messages
+    assert "send.ok" in messages
+    send_ok_records = [record for record in caplog.records if record.msg == "send.ok"]
+    assert send_ok_records
+    assert send_ok_records[0].meta.get("message_id") == 777  # type: ignore[union-attr]
+
+
+def test_help_command_en_uses_english_copy(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="bot.commands.help")
+    captured = {}
+
+    async def fake_send(context, *, chat_id, text, reply_markup, **kwargs):
+        captured["text"] = text
+        captured["markup"] = reply_markup
+        return SafeSendResult(ok=True, message_id=321)
+
+    monkeypatch.setattr("handlers.help_handler.safe_send_text", fake_send)
+
+    update = _build_update("en")
+    context = SimpleNamespace()
+
+    _run(help_command(update, context))
+
+    expected_text, expected_button = help_text("en", SUPPORT_USERNAME)
+    assert captured["text"] == expected_text
+    button = captured["markup"].inline_keyboard[0][0]
+    assert button.text == expected_button
+    assert button.url.endswith(SUPPORT_USERNAME)
+
+
+def test_support_alias_reuses_handler():
+    assert support_command is help_command
+    assert help_handler is help_command  # sanity: public shortcut matches
+
+
+def test_help_command_logs_failure(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="bot.commands.help")
+
+    async def fake_send(context, *, chat_id, text, reply_markup, **kwargs):
+        return SafeSendResult(ok=False, error=RuntimeError("boom"))
+
+    monkeypatch.setattr("handlers.help_handler.safe_send_text", fake_send)
+
+    update = _build_update("ru")
+    context = SimpleNamespace()
+
+    _run(help_command(update, context))
+
+    messages = [record.msg for record in caplog.records if record.name == "bot.commands.help"]
+    assert "send.fail" in messages
+    fail_records = [record for record in caplog.records if record.msg == "send.fail"]
+    assert fail_records
+    meta = fail_records[0].meta  # type: ignore[union-attr]
+    assert meta.get("error_type") == "RuntimeError"

--- a/texts.py
+++ b/texts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from suno.cover_source import MAX_AUDIO_MB
 
@@ -16,6 +16,29 @@ FAQ_SECTIONS = {
     "chat": "💬 *Обычный чат*\n• /chat включает режим, /reset очищает контекст.\n• Поддерживаются голосовые — бот расшифрует.",
     "pm": "🧠 *Prompt-Master*\n• Помогает быстро получить качественный промпт.\n• Кнопки категорий в самом Prompt-Master.",
     "common": "ℹ️ *Общие вопросы*\n• Куда приходят клипы/изображения: прямо в чат.\n• Если бот «молчит»: проверьте баланс и повторите запрос.",
+}
+
+HELP_I18N = {
+    "ru": {
+        "title": "🆘 Поддержка",
+        "body": (
+            "Напишите нам, если что-то не работает, есть идея или нужен совет.\n"
+            "Ответим как можно скорее.\n\n"
+            "• Чат поддержки: @{support_username}\n"
+            "• Язык: автоматически — по языку профиля Telegram"
+        ),
+        "button": "Написать в поддержку",
+    },
+    "en": {
+        "title": "🆘 Support",
+        "body": (
+            "Message us if something breaks, you have an idea, or need guidance.\n"
+            "We’ll reply as soon as possible.\n\n"
+            "• Support chat: @{support_username}\n"
+            "• Language: auto — from your Telegram profile"
+        ),
+        "button": "Message Support",
+    },
 }
 
 SUNO_RU = {
@@ -67,6 +90,19 @@ def t(key: str, /, **kwargs: Any) -> str:
         except Exception:
             return value
     return value
+
+
+def help_text(language_code: Optional[str], support_username: str) -> tuple[str, str]:
+    """Return localized help message text and button label."""
+
+    locale = "ru"
+    if isinstance(language_code, str) and language_code:
+        lowered = language_code.lower()
+        if lowered.startswith("en"):
+            locale = "en"
+    data = HELP_I18N.get(locale, HELP_I18N["ru"])
+    body = data["body"].format(support_username=support_username)
+    return f"{data['title']}\n\n{body}", data["button"]
 
 
 SUNO_MODE_PROMPT = t("suno.prompt.mode_select")

--- a/utils/logging_extra.py
+++ b/utils/logging_extra.py
@@ -1,0 +1,58 @@
+"""Helpers for structured logging with Telegram updates."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+try:  # pragma: no cover - telegram is optional for type checking
+    from telegram import Chat, Message, Update, User
+except Exception:  # pragma: no cover - fallback for runtime without telegram
+    Chat = Message = Update = User = object  # type: ignore[assignment]
+
+
+def _get_user_meta(user: Optional[User]) -> dict[str, Any]:  # type: ignore[type-arg]
+    if user is None or getattr(user, "id", None) is None:
+        return {}
+    meta: dict[str, Any] = {"user_id": getattr(user, "id", None)}
+    language_code = getattr(user, "language_code", None)
+    if isinstance(language_code, str) and language_code:
+        meta["user_lang"] = language_code
+    return meta
+
+
+def _get_chat_meta(chat: Optional[Chat]) -> dict[str, Any]:  # type: ignore[type-arg]
+    if chat is None or getattr(chat, "id", None) is None:
+        return {}
+    meta: dict[str, Any] = {"chat_id": getattr(chat, "id", None)}
+    chat_type = getattr(chat, "type", None)
+    if isinstance(chat_type, str) and chat_type:
+        meta["chat_type"] = chat_type
+    return meta
+
+
+def _get_message_meta(message: Optional[Message]) -> dict[str, Any]:  # type: ignore[type-arg]
+    if message is None or getattr(message, "message_id", None) is None:
+        return {}
+    meta: dict[str, Any] = {"message_id": getattr(message, "message_id", None)}
+    return meta
+
+
+def _build_update_extra(update: Optional[Update]) -> dict[str, Any]:  # type: ignore[type-arg]
+    if update is None:
+        return {}
+    meta: dict[str, Any] = {}
+    meta.update(_get_user_meta(getattr(update, "effective_user", None)))
+    meta.update(_get_chat_meta(getattr(update, "effective_chat", None)))
+    meta.update(_get_message_meta(getattr(update, "effective_message", None)))
+    return meta
+
+
+def build_log_extra(update: Optional[Update] = None, **kwargs: Any) -> dict[str, Any]:  # type: ignore[type-arg]
+    meta = _build_update_extra(update)
+    for key, value in kwargs.items():
+        if value is None:
+            continue
+        meta[str(key)] = value
+    return {"meta": meta}
+
+
+__all__ = ["build_log_extra", "_build_update_extra"]

--- a/utils/telegram_utils.py
+++ b/utils/telegram_utils.py
@@ -109,6 +109,16 @@ _register_label(
     prefix=True,
     command="balance.show",
 )
+_register_label(
+    "🆘 ПОДДЕРЖКА",
+    "🆘 Поддержка",
+    "Поддержка",
+    "🆘 Support",
+    "Support",
+    "Help",
+    prefix=True,
+    command="help.open",
+)
 _register_label("💬 Обычный чат", "💬", prefix=True)
 _register_label("🏠 В меню", "⬅️ В меню")
 _register_label("ℹ️ FAQ", "ℹ️ Общие вопросы", "⚡ Токены и возвраты")


### PR DESCRIPTION
## Summary
- add a dedicated /help handler with telemetry logging and localized support text
- expose support contact via environment variables and wire the menu + label routing
- document the new configuration and cover the handler with unit tests

## Testing
- pytest tests/test_help_handler.py tests/test_handler_registration.py

------
https://chatgpt.com/codex/tasks/task_e_68de9b87ec9483229224c4ca90a3e997