### PR TITLE
Ensure /menu shows the welcome block every time and adjust menu layout

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3763,7 +3763,6 @@ def main_menu_kb() -> ReplyKeyboardMarkup:
         [KeyboardButton(MENU_BTN_PM)],
         [KeyboardButton(MENU_BTN_CHAT)],
         [KeyboardButton(MENU_BTN_BALANCE)],
-        [KeyboardButton(MENU_BTN_SUPPORT)],
     ]
     return ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
 
@@ -3801,31 +3800,12 @@ async def show_emoji_hub_for_chat(
 
     log.info("hub.show | user_id=%s balance=%s", resolved_uid, balance)
 
-    hub_msg_id = ctx.user_data.get("hub_msg_id")
+    hub_msg_id_val = ctx.user_data.get("hub_msg_id")
+    hub_msg_id = hub_msg_id_val if isinstance(hub_msg_id_val, int) else None
     if replace and hub_msg_id:
-        try:
-            await ctx.bot.edit_message_text(
-                chat_id=chat_id,
-                message_id=hub_msg_id,
-                text=text,
-                reply_markup=keyboard,
-                parse_mode=ParseMode.MARKDOWN,
-                disable_web_page_preview=True,
-            )
-            ctx.user_data["hub_msg_id"] = hub_msg_id
-            return hub_msg_id
-        except BadRequest as exc:
-            if "message is not modified" in str(exc).lower():
-                ctx.user_data["hub_msg_id"] = hub_msg_id
-                return hub_msg_id
-            log.warning("hub.edit_failed | user_id=%s err=%s", resolved_uid, exc)
-            ctx.user_data["hub_msg_id"] = None
-        except TelegramError as exc:
-            log.warning("hub.edit_failed | user_id=%s err=%s", resolved_uid, exc)
-            ctx.user_data["hub_msg_id"] = None
-        except Exception as exc:  # pragma: no cover - unexpected errors
-            log.warning("hub.edit_failed | user_id=%s err=%s", resolved_uid, exc)
-            ctx.user_data["hub_msg_id"] = None
+        with suppress(Exception):
+            await ctx.bot.delete_message(chat_id=chat_id, message_id=hub_msg_id)
+        ctx.user_data["hub_msg_id"] = None
 
     try:
         message = await tg_safe_send(

--- a/tests/test_help_handler.py
+++ b/tests/test_help_handler.py
@@ -67,6 +67,7 @@ def test_help_command_ru_sends_localized_message(monkeypatch, caplog):
     assert isinstance(markup, InlineKeyboardMarkup)
     button = markup.inline_keyboard[0][0]
     assert button.text == expected_button
+    assert button.text == "Написать в поддержку"
     assert button.url == f"https://t.me/{SUPPORT_USERNAME}"
 
     messages = [record.msg for record in caplog.records if record.name == "bot.commands.help"]

--- a/tests/test_menu_command.py
+++ b/tests/test_menu_command.py
@@ -1,0 +1,83 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+from telegram import ReplyKeyboardMarkup
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+from tests.suno_test_utils import FakeBot, bot_module
+
+
+def _build_update(chat_id: int = 123, user_id: int = 555):
+    message = SimpleNamespace(message_id=42, chat_id=chat_id)
+    chat = SimpleNamespace(id=chat_id)
+    user = SimpleNamespace(id=user_id)
+    return SimpleNamespace(
+        callback_query=None,
+        effective_chat=chat,
+        effective_user=user,
+        effective_message=message,
+        message=message,
+    )
+
+
+def test_main_menu_keyboard_layout():
+    markup = bot_module.main_menu_kb()
+    assert isinstance(markup, ReplyKeyboardMarkup)
+
+    rows = markup.keyboard
+    labels = [[button.text for button in row] for row in rows]
+
+    assert labels == [
+        [bot_module.MENU_BTN_VIDEO],
+        [bot_module.MENU_BTN_IMAGE],
+        [bot_module.MENU_BTN_SUNO],
+        [bot_module.MENU_BTN_PM],
+        [bot_module.MENU_BTN_CHAT],
+        [bot_module.MENU_BTN_BALANCE],
+    ]
+    flattened = [text for row in labels for text in row]
+    assert bot_module.MENU_BTN_SUPPORT not in flattened
+
+
+def test_menu_command_always_sends_welcome_block(monkeypatch):
+    bot = FakeBot()
+    ctx = SimpleNamespace(bot=bot, user_data={})
+
+    async def fake_ensure(update):
+        return None
+
+    monkeypatch.setattr(bot_module, "ensure_user_record", fake_ensure)
+    monkeypatch.setattr(bot_module, "set_mode", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(bot_module, "clear_wait", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(bot_module, "_safe_get_balance", lambda _uid: 123)
+
+    update = _build_update()
+
+    asyncio.run(bot_module.handle_menu(update, ctx))
+    first_hub_id = ctx.user_data.get("hub_msg_id")
+
+    assert isinstance(first_hub_id, int)
+    assert bot.sent
+    assert bot.sent[0]["text"].startswith("👋 Добро пожаловать!")
+
+    asyncio.run(bot_module.handle_menu(update, ctx))
+    second_hub_id = ctx.user_data.get("hub_msg_id")
+
+    assert isinstance(second_hub_id, int)
+    assert second_hub_id != first_hub_id
+
+    welcome_texts = [entry["text"] for entry in bot.sent]
+    assert len(welcome_texts) == 2
+    assert all(text.startswith("👋 Добро пожаловать!") for text in welcome_texts)
+
+    assert bot.deleted
+    deleted_ids = {payload.get("message_id") for payload in bot.deleted}
+    assert first_hub_id in deleted_ids


### PR DESCRIPTION
## Summary
- remove the support entry from the reply keyboard and keep the video/image buttons in caps
- make the emoji hub welcome message re-send on every /menu invocation by deleting the previous hub card
- extend the test suite with coverage for the menu keyboard, repeated /menu calls, and the help support button caption

## Testing
- pytest tests/test_menu_command.py tests/test_help_handler.py

------
https://chatgpt.com/codex/tasks/task_e_68deb4b1cc1c8322aa16aaa74940271b