### PR TITLE
Implement Midjourney album delivery with localization

### DIFF
--- a/suno/service.py
+++ b/suno/service.py
@@ -1845,18 +1845,16 @@ class SunoService:
                     extra=audio_extra,
                     file_name=file_name,
                 )
-                document_sent = False
-                if not audio_sent:
-                    document_sent = send_file(
-                        "sendDocument",
-                        "document",
-                        chat_id,
-                        prepared_path,
-                        caption=caption,
-                        reply_to=reply_to,
-                        extra=None,
-                        file_name=file_name,
-                    )
+                document_sent = send_file(
+                    "sendDocument",
+                    "document",
+                    chat_id,
+                    prepared_path,
+                    caption=caption,
+                    reply_to=reply_to,
+                    extra=None,
+                    file_name=file_name,
+                )
                 if audio_sent or document_sent:
                     return True, None
                 last_reason = "upload_failed"
@@ -1925,18 +1923,16 @@ class SunoService:
                 extra=extra,
                 file_name=file_name,
             )
-            document_sent = False
-            if not audio_sent:
-                document_sent = send_file(
-                    "sendDocument",
-                    "document",
-                    chat_id,
-                    local_path,
-                    caption=caption,
-                    reply_to=reply_to,
-                    extra=None,
-                    file_name=file_name,
-                )
+            document_sent = send_file(
+                "sendDocument",
+                "document",
+                chat_id,
+                local_path,
+                caption=caption,
+                reply_to=reply_to,
+                extra=None,
+                file_name=file_name,
+            )
         finally:
             schedule_unlink(local_path)
         if audio_sent or document_sent:

--- a/tests/test_mj_media_group.py
+++ b/tests/test_mj_media_group.py
@@ -1,0 +1,269 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def bot_module(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "test-token")
+    monkeypatch.setenv("SUNO_API_BASE", "https://example.com")
+    monkeypatch.setenv("SUNO_API_TOKEN", "dummy-token")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    module = importlib.import_module("bot")
+    return importlib.reload(module)
+
+
+def _build_items(count: int) -> list[tuple[bytes, str]]:
+    return [(f"data-{i}".encode(), f"{i:02d}.png") for i in range(count)]
+
+
+def test_album_sends_four_photos(bot_module):
+    class _Bot:
+        def __init__(self):
+            self.media_calls = []
+            self.photo_calls = []
+
+        async def send_media_group(self, **kwargs):
+            self.media_calls.append(kwargs)
+            return [SimpleNamespace(message_id=i) for i in range(len(kwargs["media"]))]
+
+        async def send_photo(self, **kwargs):
+            self.photo_calls.append(kwargs)
+            return SimpleNamespace(message_id=len(self.photo_calls))
+
+    bot = _Bot()
+    items = _build_items(4)
+    delivered = asyncio.run(
+        bot_module._deliver_mj_media(  # type: ignore[attr-defined]
+            bot,
+            chat_id=1,
+            user_id=2,
+            caption="Caption",
+            items=items,
+            send_as_album=True,
+            task_id="album-1",
+        )
+    )
+
+    assert delivered is True
+    assert len(bot.media_calls) == 1
+    payload = bot.media_calls[0]
+    assert len(payload["media"]) == 4
+    assert payload["media"][0].caption == "Caption"
+    assert all(item.caption is None for item in payload["media"][1:])
+    assert not bot.photo_calls
+
+
+def test_single_photo_uses_send_photo(bot_module):
+    class _Bot:
+        def __init__(self):
+            self.media_calls = []
+            self.photo_calls = []
+
+        async def send_media_group(self, **kwargs):
+            self.media_calls.append(kwargs)
+            return []
+
+        async def send_photo(self, **kwargs):
+            self.photo_calls.append(kwargs)
+            return SimpleNamespace(message_id=1)
+
+    bot = _Bot()
+    delivered = asyncio.run(
+        bot_module._deliver_mj_media(  # type: ignore[attr-defined]
+            bot,
+            chat_id=5,
+            user_id=6,
+            caption="Only",
+            items=_build_items(1),
+            send_as_album=True,
+            task_id="single-1",
+        )
+    )
+
+    assert delivered is True
+    assert not bot.media_calls
+    assert len(bot.photo_calls) == 1
+    assert bot.photo_calls[0]["caption"] == "Only"
+
+
+def test_more_than_ten_chunked(bot_module):
+    class _Bot:
+        def __init__(self):
+            self.media_calls = []
+            self.photo_calls = []
+
+        async def send_media_group(self, **kwargs):
+            self.media_calls.append(kwargs)
+            return [SimpleNamespace(message_id=i) for i in range(len(kwargs["media"]))]
+
+        async def send_photo(self, **kwargs):
+            self.photo_calls.append(kwargs)
+            return SimpleNamespace(message_id=len(self.photo_calls))
+
+    bot = _Bot()
+    delivered = asyncio.run(
+        bot_module._deliver_mj_media(  # type: ignore[attr-defined]
+            bot,
+            chat_id=9,
+            user_id=10,
+            caption="Chunk",
+            items=_build_items(13),
+            send_as_album=True,
+            task_id="chunk-1",
+        )
+    )
+
+    assert delivered is True
+    assert len(bot.media_calls) == 2
+    chunk_lengths = [len(call["media"]) for call in bot.media_calls]
+    assert chunk_lengths == [10, 3]
+    assert not bot.photo_calls
+
+
+def test_album_error_fallbacks_to_single(bot_module, monkeypatch):
+    class _Bot:
+        def __init__(self):
+            self.media_calls = []
+            self.photo_calls = []
+
+        async def send_media_group(self, **kwargs):
+            self.media_calls.append(kwargs)
+            raise RuntimeError("fail")
+
+        async def send_photo(self, **kwargs):
+            self.photo_calls.append(kwargs)
+            return SimpleNamespace(message_id=len(self.photo_calls))
+
+    records = []
+
+    class _MJLog:
+        def info(self, msg, *, extra=None):  # type: ignore[override]
+            records.append(("info", msg, extra))
+
+        def warning(self, msg, *, extra=None):  # type: ignore[override]
+            records.append(("warning", msg, extra))
+
+    monkeypatch.setattr(bot_module, "mj_log", _MJLog())
+
+    bot = _Bot()
+    delivered = asyncio.run(
+        bot_module._deliver_mj_media(  # type: ignore[attr-defined]
+            bot,
+            chat_id=11,
+            user_id=12,
+            caption="Fallback",
+            items=_build_items(4),
+            send_as_album=True,
+            task_id="fail-1",
+        )
+    )
+
+    assert delivered is True
+    assert len(bot.media_calls) == 1
+    assert len(bot.photo_calls) == 4
+    assert any(name == "warning" and msg == "mj.album.fallback_single" for name, msg, _ in records)
+
+
+def test_caption_is_trimmed(bot_module):
+    class _Bot:
+        def __init__(self):
+            self.media_calls = []
+            self.photo_calls = []
+
+        async def send_media_group(self, **kwargs):
+            self.media_calls.append(kwargs)
+            return [SimpleNamespace(message_id=i) for i in range(len(kwargs["media"]))]
+
+        async def send_photo(self, **kwargs):
+            self.photo_calls.append(kwargs)
+            return SimpleNamespace(message_id=len(self.photo_calls))
+
+    bot = _Bot()
+    long_caption = "A" * 1100
+    asyncio.run(
+        bot_module._deliver_mj_media(  # type: ignore[attr-defined]
+            bot,
+            chat_id=21,
+            user_id=22,
+            caption=long_caption,
+            items=_build_items(2),
+            send_as_album=True,
+            task_id="trim-1",
+        )
+    )
+
+    assert len(bot.media_calls) == 1
+    caption = bot.media_calls[0]["media"][0].caption
+    assert isinstance(caption, str)
+    assert len(caption) == 1024
+    assert caption.endswith("…")
+    assert all(item.caption is None for item in bot.media_calls[0]["media"][1:])
+
+
+def test_follow_up_message_after_album(monkeypatch, bot_module):
+    class _Bot:
+        def __init__(self):
+            self.messages = []
+
+        async def send_message(self, chat_id, text, reply_markup=None, **kwargs):
+            self.messages.append({
+                "chat_id": chat_id,
+                "text": text,
+                "reply_markup": reply_markup,
+                "kwargs": kwargs,
+            })
+            return SimpleNamespace(message_id=len(self.messages))
+
+    bot = _Bot()
+
+    def _fake_status(task_id):
+        return True, 1, {}
+
+    monkeypatch.setattr(bot_module, "mj_status", _fake_status)
+    monkeypatch.setattr(bot_module, "_extract_mj_image_urls", lambda payload: ["u1", "u2"])
+    monkeypatch.setattr(
+        bot_module,
+        "_download_mj_image_bytes",
+        lambda url, index: (b"data", f"img{index}.png"),
+    )
+
+    deliver_calls = []
+
+    async def _fake_deliver(*args, **kwargs):
+        deliver_calls.append(kwargs)
+        return True
+
+    monkeypatch.setattr(bot_module, "_deliver_mj_media", _fake_deliver)
+
+    ctx = SimpleNamespace(bot=bot, user_data={"state": {"mj_locale": "ru"}})
+
+    asyncio.run(
+        bot_module.poll_mj_and_send_photos(  # type: ignore[attr-defined]
+            chat_id=33,
+            task_id="tid-1",
+            ctx=ctx,
+            prompt="prompt",
+            aspect="16:9",
+            user_id=44,
+            price=5,
+        )
+    )
+
+    assert deliver_calls
+    assert bot.messages
+    last_message = bot.messages[-1]
+    assert last_message["text"] == "Галерея сгенерирована."
+    markup = last_message["reply_markup"]
+    assert markup is not None
+    buttons = [[button.text for button in row] for row in markup.inline_keyboard]
+    assert buttons == [["Повторить"], ["Назад в меню"]]

--- a/utils/telegram_utils.py
+++ b/utils/telegram_utils.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import re
 import unicodedata
 from time import time
-from typing import Any, Optional, Set
+from typing import Any, Optional, Sequence, Set
 
+from telegram import InputMediaPhoto
+from telegram.constants import ParseMode
 from telegram.error import BadRequest
 
 
@@ -167,6 +169,26 @@ _register_label("🧠", prefix=True)
 _register_label("🧩 Banana")
 _register_label("🎵 Suno (текст песни)")
 
+
+def build_photo_album_media(
+    media_sources: Sequence[Any],
+    *,
+    caption: Optional[str] = None,
+    parse_mode: Optional[ParseMode] = None,
+) -> list[InputMediaPhoto]:
+    album: list[InputMediaPhoto] = []
+    for index, media in enumerate(media_sources):
+        if index == 0:
+            kwargs: dict[str, Any] = {"media": media}
+            if caption is not None:
+                kwargs["caption"] = caption
+                if parse_mode is not None:
+                    kwargs["parse_mode"] = parse_mode
+            album.append(InputMediaPhoto(**kwargs))
+        else:
+            album.append(InputMediaPhoto(media=media))
+    return album
+
 MENU_LABELS = tuple(sorted(_MENU_LABELS))
 
 _LABEL_PATTERN_PARTS: list[str] = []
@@ -294,5 +316,6 @@ __all__ = [
     "is_button_label",
     "should_capture_to_prompt",
     "safe_edit",
+    "build_photo_album_media",
 ]
 


### PR DESCRIPTION
## Summary
- add Midjourney album delivery helpers that chunk, trim captions, and provide localized follow-up messaging
- ensure Midjourney polling downloads images, logs failures, and sends localized gallery status with buttons
- expand Telegram utilities, Suno delivery, and tests to cover album, fallback, caption trimming, and follow-up flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dee47d139c8322b277a8297ca03aee