### PR TITLE
Fix duplicate video menu flow and Prompt-Master routing

### DIFF
--- a/keyboards.py
+++ b/keyboards.py
@@ -3,6 +3,18 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 CB_FAQ_PREFIX = "faq:"
 CB_PM_PREFIX = "pm:"
 
+CB_PM_BACK = f"{CB_PM_PREFIX}back"
+CB_PM_MENU = f"{CB_PM_PREFIX}menu"
+CB_PM_SWITCH = f"{CB_PM_PREFIX}switch"
+CB_PM_COPY_PREFIX = f"{CB_PM_PREFIX}copy:"
+CB_PM_INSERT_PREFIX = f"{CB_PM_PREFIX}insert:"
+
+CB_VIDEO_MENU = "video_menu"
+CB_VIDEO_MODE_FAST = "mode:veo_text_fast"
+CB_VIDEO_MODE_QUALITY = "mode:veo_text_quality"
+CB_VIDEO_MODE_PHOTO = "mode:veo_photo"
+CB_VIDEO_BACK = "video:back"
+
 
 _PM_LABELS = {
     "veo": {"ru": "🎬 Видеопромпт (VEO)", "en": "🎬 Video prompt (VEO)"},
@@ -34,7 +46,7 @@ def prompt_master_keyboard(lang: str = "ru") -> InlineKeyboardMarkup:
         [InlineKeyboardButton(_label("animate", lang), callback_data=f"{CB_PM_PREFIX}animate")],
         [InlineKeyboardButton(_label("banana", lang), callback_data=f"{CB_PM_PREFIX}banana")],
         [InlineKeyboardButton(_label("suno", lang), callback_data=f"{CB_PM_PREFIX}suno")],
-        [InlineKeyboardButton(_label("back", lang), callback_data=f"{CB_PM_PREFIX}back")],
+        [InlineKeyboardButton(_label("back", lang), callback_data=CB_PM_BACK)],
     ]
     return InlineKeyboardMarkup(rows)
 
@@ -43,8 +55,8 @@ def prompt_master_mode_keyboard(lang: str = "ru") -> InlineKeyboardMarkup:
     back = _label("back", lang)
     switch = "🔁 Сменить движок" if lang == "ru" else "🔁 Switch engine"
     rows = [
-        [InlineKeyboardButton(back, callback_data=f"{CB_PM_PREFIX}back")],
-        [InlineKeyboardButton(switch, callback_data=f"{CB_PM_PREFIX}switch")],
+        [InlineKeyboardButton(back, callback_data=CB_PM_BACK)],
+        [InlineKeyboardButton(switch, callback_data=CB_PM_SWITCH)],
     ]
     return InlineKeyboardMarkup(rows)
 
@@ -61,12 +73,12 @@ def prompt_master_result_keyboard(engine: str, lang: str = "ru") -> InlineKeyboa
     switch = "🔁 Сменить движок" if lang == "ru" else "🔁 Switch engine"
     rows = [
         [
-            InlineKeyboardButton(copy_text, callback_data=f"{CB_PM_PREFIX}copy:{engine}"),
-            InlineKeyboardButton(insert_text, callback_data=f"{CB_PM_PREFIX}insert:{engine}"),
+            InlineKeyboardButton(copy_text, callback_data=f"{CB_PM_COPY_PREFIX}{engine}"),
+            InlineKeyboardButton(insert_text, callback_data=f"{CB_PM_INSERT_PREFIX}{engine}"),
         ],
         [
-            InlineKeyboardButton(back, callback_data=f"{CB_PM_PREFIX}back"),
-            InlineKeyboardButton(switch, callback_data=f"{CB_PM_PREFIX}switch"),
+            InlineKeyboardButton(back, callback_data=CB_PM_BACK),
+            InlineKeyboardButton(switch, callback_data=CB_PM_SWITCH),
         ],
     ]
     return InlineKeyboardMarkup(rows)

--- a/telegram_utils.py
+++ b/telegram_utils.py
@@ -24,6 +24,7 @@ from telegram.constants import ParseMode
 from telegram.error import BadRequest, Forbidden, NetworkError, RetryAfter, TelegramError, TimedOut
 
 from metrics import telegram_send_total
+from keyboards import CB_VIDEO_MENU
 
 log = logging.getLogger("telegram.utils")
 
@@ -179,7 +180,7 @@ def build_hub_keyboard() -> InlineKeyboardMarkup:
 
     rows = [
         [
-            InlineKeyboardButton("🎬", callback_data="hub:video"),
+            InlineKeyboardButton("🎬", callback_data=CB_VIDEO_MENU),
             InlineKeyboardButton("🎨", callback_data="hub:image"),
             InlineKeyboardButton("🎵", callback_data="hub:music"),
         ],

--- a/tests/test_hub_menu.py
+++ b/tests/test_hub_menu.py
@@ -5,6 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from keyboards import CB_VIDEO_MENU
 from telegram_utils import build_hub_keyboard, build_hub_text
 
 
@@ -16,7 +17,7 @@ def test_build_hub_keyboard_layout():
     assert all(len(row) == 3 for row in rows)
 
     expected = [
-        ("🎬", "hub:video"),
+        ("🎬", CB_VIDEO_MENU),
         ("🎨", "hub:image"),
         ("🎵", "hub:music"),
         ("🧠", "hub:prompt"),

--- a/tests/test_menu_command.py
+++ b/tests/test_menu_command.py
@@ -54,20 +54,20 @@ def test_video_menu_keyboard_options():
     assert rows[0][0].text == (
         f"🎬 Генерация видео (Veo Fast) — 💎 {bot_module.TOKEN_COSTS['veo_fast']}"
     )
-    assert rows[0][0].callback_data == "mode:veo_text_fast"
+    assert rows[0][0].callback_data == bot_module.CB_VIDEO_MODE_FAST
 
     assert rows[1][0].text == (
         f"🎬 Генерация видео (Veo Quality) — 💎 {bot_module.TOKEN_COSTS['veo_quality']}"
     )
-    assert rows[1][0].callback_data == "mode:veo_text_quality"
+    assert rows[1][0].callback_data == bot_module.CB_VIDEO_MODE_QUALITY
 
     assert rows[2][0].text == (
         f"🖼️ Оживить изображение (Veo) — 💎 {bot_module.TOKEN_COSTS['veo_photo']}"
     )
-    assert rows[2][0].callback_data == "mode:veo_photo"
+    assert rows[2][0].callback_data == bot_module.CB_VIDEO_MODE_PHOTO
 
     assert rows[3][0].text == "⬅️ Назад"
-    assert rows[3][0].callback_data == "back"
+    assert rows[3][0].callback_data == bot_module.CB_VIDEO_BACK
 
 
 def test_menu_command_always_sends_welcome_block(monkeypatch):
@@ -104,3 +104,8 @@ def test_menu_command_always_sends_welcome_block(monkeypatch):
     assert bot.deleted
     deleted_ids = {payload.get("message_id") for payload in bot.deleted}
     assert first_hub_id in deleted_ids
+
+
+def test_callback_handler_patterns_unique():
+    patterns = [pattern if pattern is not None else "<default>" for pattern, _ in bot_module.CALLBACK_HANDLER_SPECS]
+    assert len(patterns) == len(set(patterns))

--- a/utils/telegram_utils.py
+++ b/utils/telegram_utils.py
@@ -101,7 +101,7 @@ _register_label(
     command="mj.card",
 )
 _register_label("🎵 Генерация музыки", "🎵 Музыка", "🎵 Музыка (Suno)", "🎵 Track (Suno)", "🎵 Suno", prefix=True)
-_register_label("🧠 Prompt-Master", "🧠", prefix=True)
+_register_label("🧠 Prompt-Master", "🧠", prefix=True, command="pm.open")
 _register_label(
     "💎 Баланс",
     "Баланс",


### PR DESCRIPTION
## Summary
- add shared callback constants for video and Prompt-Master actions to avoid typos and duplicate handler registration
- restructure the video entry flow with a single menu renderer and a dedicated callback handler so /video and menu buttons no longer duplicate cards
- make Prompt-Master callbacks log once, stop leaking into chat fallback, and map the button label directly to the PM command
- update and expand tests covering video menu callbacks, Prompt-Master routing, and handler registration uniqueness

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68def331623c83229f3ed7e7dc8ddd78