### PR TITLE
feat: support Banana documents and dedupe video menu

### DIFF
--- a/tests/test_banana_document_input.py
+++ b/tests/test_banana_document_input.py
@@ -1,0 +1,236 @@
+import asyncio
+import importlib
+import sys
+from io import BytesIO
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _make_image_bytes(fmt: str = "PNG") -> bytes:
+    image = Image.new("RGB", (4, 4), color=(200, 10, 10))
+    buffer = BytesIO()
+    image.save(buffer, format=fmt)
+    return buffer.getvalue()
+
+
+class _FakeFile:
+    def __init__(self, file_path: str, data: bytes) -> None:
+        self.file_path = file_path
+        self._data = data
+
+    async def download_as_bytearray(self) -> bytearray:
+        return bytearray(self._data)
+
+
+class _FakeBot:
+    def __init__(self, files: dict[str, tuple[str, bytes]]) -> None:
+        self._files = files
+        self.get_file_calls: list[str] = []
+        self.send_messages: list[dict[str, object]] = []
+        self.photo_calls: list[dict[str, object]] = []
+        self.document_calls: list[dict[str, object]] = []
+
+    async def get_file(self, file_id: str) -> _FakeFile:  # type: ignore[override]
+        self.get_file_calls.append(file_id)
+        path, data = self._files[file_id]
+        return _FakeFile(path, data)
+
+    async def send_message(self, chat_id: int, text: str, **kwargs: object):  # type: ignore[override]
+        payload = {"chat_id": chat_id, "text": text, **kwargs}
+        self.send_messages.append(payload)
+        return SimpleNamespace(message_id=len(self.send_messages))
+
+    async def send_photo(self, **kwargs: object):  # type: ignore[override]
+        self.photo_calls.append(kwargs)
+        return SimpleNamespace(message_id=len(self.photo_calls))
+
+    async def send_document(self, **kwargs: object):  # type: ignore[override]
+        self.document_calls.append(kwargs)
+        return SimpleNamespace(message_id=len(self.document_calls))
+
+
+class _DummyMessage:
+    def __init__(self, document=None, photo=None, caption: str | None = None) -> None:
+        self.document = document
+        self.photo = photo or []
+        self.caption = caption
+        self.replies: list[str] = []
+        self.reply_kwargs: list[dict[str, object]] = []
+
+    async def reply_text(self, text: str, **kwargs: object) -> None:  # type: ignore[override]
+        self.replies.append(text)
+        self.reply_kwargs.append(kwargs)
+
+
+class _DummyDocument:
+    def __init__(self, file_id: str, *, mime: str, name: str, size: int) -> None:
+        self.file_id = file_id
+        self.mime_type = mime
+        self.file_name = name
+        self.file_size = size
+
+
+class _DummyPhoto:
+    def __init__(self, file_id: str, *, width: int = 64, height: int = 64) -> None:
+        self.file_id = file_id
+        self.file_unique_id = f"u-{file_id}"
+        self.width = width
+        self.height = height
+
+
+@pytest.fixture
+def bot_module(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "test-token")
+    monkeypatch.setenv("SUNO_API_BASE", "https://example.com")
+    monkeypatch.setenv("SUNO_API_TOKEN", "dummy-token")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    module = importlib.import_module("bot")
+    return importlib.reload(module)
+
+
+def _build_update(message, chat_id: int = 1, user_id: int = 10):
+    return SimpleNamespace(
+        effective_message=message,
+        message=message,
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+    )
+
+
+def test_document_png_added_to_banana(monkeypatch, bot_module):
+    files = {"doc-1": ("file/documents/test.png", _make_image_bytes("PNG"))}
+    bot = _FakeBot(files)
+    ctx = SimpleNamespace(bot=bot, user_data={}, application=None)
+    state = bot_module.state(ctx)
+    state["mode"] = "banana"
+
+    document = _DummyDocument("doc-1", mime="image/png", name="test.png", size=len(files["doc-1"][1]))
+    message = _DummyMessage(document=document)
+
+    monkeypatch.setattr(bot_module, "show_banana_card", lambda *args, **kwargs: asyncio.sleep(0))
+
+    asyncio.run(bot_module.on_document(_build_update(message), ctx))
+
+    images = bot_module.state(ctx)["banana_images"]
+    assert len(images) == 1
+    entry = images[0]
+    assert entry["source"] == "document"
+    assert entry["mime"] == "image/png"
+    assert entry["url"].startswith("https://api.telegram.org/file/bottest-token/")
+    assert message.replies == ["📸 Фото принято (1/4)."]
+
+
+def test_document_non_image_rejected(bot_module):
+    files = {"doc-2": ("file/docs/sample.pdf", b"%PDF-1.4")}
+    bot = _FakeBot(files)
+    ctx = SimpleNamespace(bot=bot, user_data={}, application=None)
+    state = bot_module.state(ctx)
+    state["mode"] = "banana"
+
+    document = _DummyDocument("doc-2", mime="application/pdf", name="doc.pdf", size=2048)
+    message = _DummyMessage(document=document)
+
+    asyncio.run(bot_module.on_document(_build_update(message), ctx))
+
+    assert message.replies == ["Нужно прислать изображение (PNG/JPG/WEBP) как файл-документ."]
+    assert not bot_module.state(ctx)["banana_images"]
+    assert not bot.get_file_calls
+
+
+def test_document_too_large(bot_module):
+    files = {"doc-3": ("file/documents/huge.png", _make_image_bytes("PNG"))}
+    bot = _FakeBot(files)
+    ctx = SimpleNamespace(bot=bot, user_data={}, application=None)
+    state = bot_module.state(ctx)
+    state["mode"] = "banana"
+
+    document = _DummyDocument(
+        "doc-3",
+        mime="image/png",
+        name="huge.png",
+        size=(20 * 1024 * 1024) + 1,
+    )
+    message = _DummyMessage(document=document)
+
+    asyncio.run(bot_module.on_document(_build_update(message), ctx))
+
+    assert message.replies == ["Файл слишком большой (лимит 20 MB)."]
+    assert not bot.get_file_calls
+
+
+def test_mixed_photo_and_document_trigger_generation(monkeypatch, tmp_path, bot_module):
+    png_bytes = _make_image_bytes("PNG")
+    jpeg_bytes = _make_image_bytes("JPEG")
+    files = {
+        "photo-1": ("photos/test.jpg", jpeg_bytes),
+        "doc-4": ("documents/photo.png", png_bytes),
+    }
+    bot = _FakeBot(files)
+    ctx = SimpleNamespace(bot=bot, user_data={}, application=None)
+    state = bot_module.state(ctx)
+    state["mode"] = "banana"
+
+    monkeypatch.setattr(bot_module, "show_banana_card", lambda *args, **kwargs: asyncio.sleep(0))
+
+    photo_message = _DummyMessage(photo=[_DummyPhoto("photo-1")])
+    asyncio.run(bot_module.on_photo(_build_update(photo_message), ctx))
+
+    document = _DummyDocument("doc-4", mime="image/png", name="doc.png", size=len(png_bytes))
+    doc_message = _DummyMessage(document=document)
+    asyncio.run(bot_module.on_document(_build_update(doc_message), ctx))
+
+    images = bot_module.state(ctx)["banana_images"]
+    assert len(images) == 2
+    assert images[0]["source"] == "photo"
+    assert images[1]["source"] == "document"
+
+    created_urls: list[list[str]] = []
+
+    def _fake_create(prompt, image_urls, *args, **kwargs):
+        created_urls.append(list(image_urls))
+        return "task-xyz"
+
+    monkeypatch.setattr(bot_module, "create_banana_task", _fake_create)
+    monkeypatch.setattr(
+        bot_module,
+        "wait_for_banana_result",
+        lambda *args, **kwargs: ["https://cdn.example.com/result.png"],
+    )
+    monkeypatch.setattr(
+        bot_module,
+        "_download_binary",
+        lambda url: (png_bytes, "image/png"),
+    )
+
+    def _save_bytes(data, suffix=".png"):
+        target = tmp_path / f"banana{suffix}"
+        target.write_bytes(data)
+        return target
+
+    monkeypatch.setattr(bot_module, "save_bytes_to_temp", _save_bytes)
+
+    asyncio.run(
+        bot_module._banana_run_and_send(  # type: ignore[attr-defined]
+            chat_id=1,
+            ctx=ctx,
+            src_images=list(images),
+            prompt="clean background",
+            price=5,
+            user_id=101,
+        )
+    )
+
+    assert len(created_urls) == 1
+    assert len(created_urls[0]) == 2
+    assert created_urls[0][0].startswith("https://api.telegram.org/file/bottest-token/")
+    assert created_urls[0][1].startswith("https://api.telegram.org/file/bottest-token/")
+

--- a/tests/test_text_router.py
+++ b/tests/test_text_router.py
@@ -412,6 +412,9 @@ def test_video_button_opens_mode_selector() -> None:
     original_clear_wait = bot_module.clear_wait
     original_input_clear = bot_module.input_state.clear
     original_video_menu_kb = bot_module.video_menu_kb
+    original_lock = bot_module.acquire_ttl_lock
+    original_cache_get = bot_module.cache_get
+    original_cache_set = bot_module.cache_set
 
     try:
         bot_module.ensure_user_record = fake_ensure  # type: ignore[assignment]
@@ -419,6 +422,9 @@ def test_video_button_opens_mode_selector() -> None:
         bot_module.clear_wait = fake_clear_wait  # type: ignore[assignment]
         bot_module.input_state.clear = fake_input_clear  # type: ignore[assignment]
         bot_module.video_menu_kb = fake_video_menu_kb  # type: ignore[assignment]
+        bot_module.acquire_ttl_lock = lambda *args, **kwargs: True  # type: ignore[assignment]
+        bot_module.cache_get = lambda name: None  # type: ignore[assignment]
+        bot_module.cache_set = lambda name, value, ttl: None  # type: ignore[assignment]
 
         for sample in ("🎬 Генерация видео", "ГЕНЕРАЦИЯ ВИДЕО"):
             message = DummyMessage(chat_id=303, text=sample)
@@ -437,6 +443,9 @@ def test_video_button_opens_mode_selector() -> None:
         bot_module.clear_wait = original_clear_wait  # type: ignore[assignment]
         bot_module.input_state.clear = original_input_clear  # type: ignore[assignment]
         bot_module.video_menu_kb = original_video_menu_kb  # type: ignore[assignment]
+        bot_module.acquire_ttl_lock = original_lock  # type: ignore[assignment]
+        bot_module.cache_get = original_cache_get  # type: ignore[assignment]
+        bot_module.cache_set = original_cache_set  # type: ignore[assignment]
 
     assert replies == [
         "🎬 Выберите тип генерации видео:",

--- a/tests/test_video_menu_dedup.py
+++ b/tests/test_video_menu_dedup.py
@@ -1,0 +1,149 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def bot_module(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "dummy-token")
+    monkeypatch.setenv("SUNO_API_BASE", "https://example.com")
+    monkeypatch.setenv("SUNO_API_TOKEN", "token")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    module = importlib.import_module("bot")
+    return importlib.reload(module)
+
+
+def _make_ctx(bot=None):
+    return SimpleNamespace(bot=bot, user_data={}, application=None)
+
+
+def test_show_video_menu_uses_lock(monkeypatch, bot_module):
+    calls: list[tuple[int | None, object | None]] = []
+    lock_calls: list[str] = []
+    cache: dict[str, str] = {}
+
+    def fake_lock(name: str, ttl: int) -> bool:
+        lock_calls.append(name)
+        return len(lock_calls) == 1
+
+    monkeypatch.setattr(bot_module, "acquire_ttl_lock", fake_lock)
+    monkeypatch.setattr(bot_module, "cache_get", lambda name: cache.get(name))
+    monkeypatch.setattr(bot_module, "cache_set", lambda name, value, ttl: cache.update({name: value}))
+
+    async def fake_send(ctx, *, chat_id=None, message=None):  # type: ignore[override]
+        calls.append((chat_id, message))
+        return 111
+
+    monkeypatch.setattr(bot_module, "_send_video_menu_message", fake_send)
+
+    ctx = _make_ctx()
+    asyncio.run(bot_module.show_video_menu(ctx, chat_id=42))
+    asyncio.run(bot_module.show_video_menu(ctx, chat_id=42))
+    asyncio.run(bot_module.show_video_menu(ctx, chat_id=42))
+
+    assert calls == [(42, None)]
+    assert cache == {"video_menu:last_menu_msg_id:42": "111"}
+    assert lock_calls == ["lock:video_menu:42", "lock:video_menu:42", "lock:video_menu:42"]
+
+
+def test_callback_deduplicated(monkeypatch, bot_module):
+    send_calls: list[tuple[int | None, object | None]] = []
+    answers: list[int] = []
+    lock_state = {"count": 0}
+
+    def fake_lock(name: str, ttl: int) -> bool:
+        lock_state["count"] += 1
+        return lock_state["count"] == 1
+
+    monkeypatch.setattr(bot_module, "acquire_ttl_lock", fake_lock)
+    monkeypatch.setattr(bot_module, "cache_get", lambda name: None)
+    monkeypatch.setattr(bot_module, "cache_set", lambda name, value, ttl: None)
+
+    async def fake_send(ctx, *, chat_id=None, message=None):  # type: ignore[override]
+        send_calls.append((chat_id, message))
+        return 321
+
+    monkeypatch.setattr(bot_module, "_send_video_menu_message", fake_send)
+
+    class _Query:
+        def __init__(self):
+            self.data = bot_module.CB_VIDEO_MENU
+            self.message = SimpleNamespace(chat=SimpleNamespace(id=9))
+            self.from_user = SimpleNamespace(id=1)
+
+        async def answer(self):  # type: ignore[override]
+            answers.append(1)
+
+    ctx = _make_ctx()
+
+    update = SimpleNamespace(
+        callback_query=_Query(),
+        effective_chat=SimpleNamespace(id=9),
+        effective_user=SimpleNamespace(id=1),
+    )
+    asyncio.run(bot_module.video_menu_callback(update, ctx))
+
+    update.callback_query = _Query()
+    asyncio.run(bot_module.video_menu_callback(update, ctx))
+
+    assert len(send_calls) == 1
+    assert answers == [1, 1]
+
+
+def test_command_and_callback_share_lock(monkeypatch, bot_module):
+    send_calls: list[tuple[int | None, object | None]] = []
+    cache: dict[str, str] = {}
+    lock_sequence = iter([True, False])
+
+    def fake_lock(name: str, ttl: int) -> bool:
+        return next(lock_sequence, False)
+
+    monkeypatch.setattr(bot_module, "acquire_ttl_lock", fake_lock)
+    monkeypatch.setattr(bot_module, "cache_get", lambda name: cache.get(name))
+    monkeypatch.setattr(bot_module, "cache_set", lambda name, value, ttl: cache.update({name: value}))
+
+    async def fake_send(ctx, *, chat_id=None, message=None):  # type: ignore[override]
+        send_calls.append((chat_id, message))
+        return 555
+
+    monkeypatch.setattr(bot_module, "_send_video_menu_message", fake_send)
+
+    ctx = _make_ctx()
+    message = SimpleNamespace(chat_id=7, reply_text=lambda *args, **kwargs: asyncio.sleep(0))
+    update_command = SimpleNamespace(
+        effective_chat=SimpleNamespace(id=7),
+        effective_user=SimpleNamespace(id=2),
+        effective_message=message,
+    )
+
+    asyncio.run(bot_module.video_command(update_command, ctx))
+
+    class _Query:
+        def __init__(self):
+            self.data = bot_module.CB_VIDEO_MENU
+            self.message = SimpleNamespace(chat=SimpleNamespace(id=7))
+            self.from_user = SimpleNamespace(id=2)
+
+        async def answer(self):  # type: ignore[override]
+            return None
+
+    update_callback = SimpleNamespace(
+        callback_query=_Query(),
+        effective_chat=SimpleNamespace(id=7),
+        effective_user=SimpleNamespace(id=2),
+    )
+    asyncio.run(bot_module.video_menu_callback(update_callback, ctx))
+
+    assert len(send_calls) == 1
+    assert cache == {"video_menu:last_menu_msg_id:7": "555"}
+


### PR DESCRIPTION
## Summary
- accept Banana reference images uploaded as Telegram documents alongside photos and validate their metadata
- add unified video menu rendering with short-term locks and cache to avoid duplicate sends
- provide reusable cache helpers and regression tests for Banana document handling and video menu deduplication

## Testing
- pytest tests/test_banana_document_input.py tests/test_video_menu_dedup.py tests/test_text_router.py

------
https://chatgpt.com/codex/tasks/task_e_68df04a52b048322838b04624d4f11f7