### PR TITLE
Fix handler registration and MJ upscale flow

### DIFF
--- a/redis_utils.py
+++ b/redis_utils.py
@@ -140,12 +140,22 @@ def _mj_lock_key(user_id: int, task_id: str, index: int) -> str:
     return _MJ_LOCK_KEY_TMPL.format(f"{int(user_id)}:{task_id}:{int(index)}")
 
 
-def set_last_mj_grid(user_id: int, task_id: str, result_urls: List[str]) -> None:
+def set_last_mj_grid(
+    user_id: int,
+    task_id: str,
+    result_urls: List[str],
+    *,
+    prompt: Optional[str] = None,
+) -> None:
     doc = {
         "task_id": str(task_id),
         "result_urls": [str(url) for url in result_urls if isinstance(url, str)],
         "created_at": _now_iso(),
     }
+    if isinstance(prompt, str):
+        prompt_clean = prompt.strip()
+        if prompt_clean:
+            doc["prompt"] = prompt_clean
     payload = json.dumps(doc, ensure_ascii=False)
     key = _mj_last_key(user_id)
     if _r:
@@ -183,7 +193,12 @@ def get_last_mj_grid(user_id: int) -> Optional[Dict[str, Any]]:
     normalized_urls = [str(url) for url in urls if isinstance(url, str)]
     if not normalized_urls:
         return None
-    return {"task_id": task_id, "result_urls": normalized_urls}
+    prompt = data.get("prompt")
+    prompt_value = prompt.strip() if isinstance(prompt, str) else None
+    result: Dict[str, Any] = {"task_id": task_id, "result_urls": normalized_urls}
+    if prompt_value:
+        result["prompt"] = prompt_value
+    return result
 
 
 def clear_last_mj_grid(user_id: int) -> None:


### PR DESCRIPTION
## Summary
- avoid duplicate handler registration by storing a flag in Application.bot_data
- persist Midjourney prompts and inject a fallback prompt when launching upscales so the API always receives non-empty text
- adjust MJ upscale tests to cover prompt propagation and document delivery

## Testing
- PYTHONPATH=. pytest tests/test_mj_upscale.py

------
https://chatgpt.com/codex/tasks/task_e_68df0d1ed0008322bac3b3026dfc8676