### PR TITLE
Fix video menu locking and Midjourney document delivery

### DIFF
--- a/keyboards.py
+++ b/keyboards.py
@@ -127,3 +127,29 @@ def suno_start_keyboard() -> InlineKeyboardMarkup:
 def suno_start_disabled_keyboard() -> InlineKeyboardMarkup:
     rows = [[InlineKeyboardButton("⏳ Идёт генерация…")]]
     return InlineKeyboardMarkup(rows)
+
+
+def mj_upscale_root_keyboard(grid_id: str) -> InlineKeyboardMarkup:
+    button = InlineKeyboardButton(
+        "Улучшить качество",
+        callback_data=f"mj.upscale.menu:{grid_id}",
+    )
+    return InlineKeyboardMarkup([[button]])
+
+
+def mj_upscale_select_keyboard(grid_id: str, *, count: int) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    safe_count = max(int(count), 0)
+    for idx in range(1, safe_count + 1):
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    f"{idx}-я фотка",
+                    callback_data=f"mj.upscale:{grid_id}:{idx}",
+                )
+            ]
+        )
+    rows.append(
+        [InlineKeyboardButton("⬅️ Назад", callback_data=f"mj.upscale.menu:{grid_id}")]
+    )
+    return InlineKeyboardMarkup(rows)

--- a/redis_utils.py
+++ b/redis_utils.py
@@ -268,6 +268,17 @@ def acquire_ttl_lock(name: str, ttl: int) -> bool:
     return _memory_set_if_absent(key, "1", ttl)
 
 
+def release_ttl_lock(name: str) -> None:
+    key = f"{_PFX}:{name}"
+    if _r:
+        try:
+            _r.delete(key)
+            return
+        except Exception as exc:
+            _logger.warning("lock.release.error | key=%s err=%s", key, exc)
+    _memory_delete(key)
+
+
 def save_task_meta(
     task_id: str,
     chat_id: int,

--- a/utils/telegram_safe.py
+++ b/utils/telegram_safe.py
@@ -65,6 +65,7 @@ async def safe_edit_message(
     *,
     parse_mode: ParseMode = ParseMode.HTML,
     disable_web_page_preview: bool = True,
+    log_on_noop: Optional[str] = None,
 ) -> bool:
     """Safely edit a Telegram message without triggering noisy errors."""
 
@@ -77,8 +78,9 @@ async def safe_edit_message(
     new_hashes = _hash_payload(text_payload, reply_markup)
 
     if _MessageHashes.get(key) == new_hashes:
+        log_label = log_on_noop or "card_edit_noop"
         _logger.info(
-            "card_edit_noop",
+            log_label,
             extra={"chat_id": chat_id, "message_id": message_id},
         )
         return False
@@ -97,8 +99,9 @@ async def safe_edit_message(
     except BadRequest as exc:
         lowered = str(exc).lower()
         if "message is not modified" in lowered:
+            log_label = log_on_noop or "card_edit_ignored_same_content"
             _logger.info(
-                "card_edit_ignored_same_content",
+                log_label,
                 extra={"chat_id": chat_id, "message_id": message_id},
             )
             _store_hashes(key, new_hashes)


### PR DESCRIPTION
## Summary
- unify video menu entry handling with redis-backed deduplication and safe message editing
- deliver Midjourney grids as numbered documents, cache grid snapshots, and expose upscale menu callbacks
- add inline keyboards, safe-edit logging enhancements, redis helpers, and refresh the Midjourney/video test suite

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfae19c7888322a2ee2544226f07af