### PR TITLE
Improve menu locking for video and Prompt-Master flows

### DIFF
--- a/tests/test_mj_document_delivery.py
+++ b/tests/test_mj_document_delivery.py
@@ -73,9 +73,9 @@ def test_grid_delivery_sends_documents_and_menu(monkeypatch, bot_module):
     assert delivered is True
     assert len(doc_calls) == 3
     assert [call["document"].filename for call in doc_calls] == [
-        "midjourney_01.jpeg",
-        "midjourney_02.png",
-        "midjourney_03.jpeg",
+        "mj_01.jpg",
+        "mj_02.png",
+        "mj_03.jpg",
     ]
     assert [call["document"].input_file_content.decode() for call in doc_calls] == urls
     assert menu_calls and menu_calls[0]["markup"].inline_keyboard[0][0].callback_data.startswith("mj.upscale.menu:")


### PR DESCRIPTION
## Summary
- replace the video menu caching logic with Redis-based locking and message reuse helpers
- add similar idempotent card handling for Prompt-Master and clear menu state when navigating away
- rename Midjourney document filenames to mj_XX.* and extend tests for the new locking helpers

## Testing
- pytest tests/test_video_menu_dedup.py
- pytest tests/test_mj_document_delivery.py
- pytest tests/test_prompt_master_ptb.py

------
https://chatgpt.com/codex/tasks/task_e_68dfbc42e9948322a874d1cd7c5f09a5