### PR TITLE
Fix Midjourney document delivery and refresh gallery UI

### DIFF
--- a/keyboards.py
+++ b/keyboards.py
@@ -130,21 +130,42 @@ def suno_start_disabled_keyboard() -> InlineKeyboardMarkup:
 
 
 def mj_upscale_root_keyboard(grid_id: str) -> InlineKeyboardMarkup:
-    button = InlineKeyboardButton(
-        "Улучшить качество",
-        callback_data=f"mj.upscale.menu:{grid_id}",
-    )
-    return InlineKeyboardMarkup([[button]])
+    buttons = [
+        [
+            InlineKeyboardButton(
+                "✨ Улучшить качество",
+                callback_data=f"mj.upscale.menu:{grid_id}",
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "🔁 Сгенерировать ещё",
+                callback_data=f"mj.gallery.again:{grid_id}",
+            )
+        ],
+        [InlineKeyboardButton("🏠 Назад в меню", callback_data="mj.gallery.back")],
+    ]
+    return InlineKeyboardMarkup(buttons)
 
 
 def mj_upscale_select_keyboard(grid_id: str, *, count: int) -> InlineKeyboardMarkup:
     rows: list[list[InlineKeyboardButton]] = []
     safe_count = max(int(count), 0)
     for idx in range(1, safe_count + 1):
+        if idx == 1:
+            title = "Первая фотография"
+        elif idx == 2:
+            title = "Вторая фотография"
+        elif idx == 3:
+            title = "Третья фотография"
+        elif idx == 4:
+            title = "Четвёртая фотография"
+        else:
+            title = f"{idx}-я фотография"
         rows.append(
             [
                 InlineKeyboardButton(
-                    f"{idx}-я фотка",
+                    title,
                     callback_data=f"mj.upscale:{grid_id}:{idx}",
                 )
             ]

--- a/tests/test_handlers_image.py
+++ b/tests/test_handlers_image.py
@@ -115,6 +115,11 @@ def test_mj_documents_sent_without_compression(monkeypatch, bot_module):
     monkeypatch.setattr(ctx.bot, "send_document", fake_send_document)
     monkeypatch.setattr(ctx.bot, "send_message", fake_send_message)
     monkeypatch.setattr(bot_module, "_save_mj_grid_snapshot", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        bot_module,
+        "_download_mj_image_bytes",
+        lambda url, index: (b"x" * 2048, f"midjourney_{index:02d}.png", "image/png", url),
+    )
 
     delivered = asyncio.run(
         bot_module._deliver_mj_grid_documents(

--- a/tests/test_mj_document_naming.py
+++ b/tests/test_mj_document_naming.py
@@ -1,0 +1,61 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def bot_module(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "test-token")
+    monkeypatch.setenv("SUNO_API_BASE", "https://example.com")
+    monkeypatch.setenv("SUNO_API_TOKEN", "dummy-token")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    module = importlib.import_module("bot")
+    module = importlib.reload(module)
+    module.mj_log.disabled = True
+    return module
+
+
+def test_mj_document_naming(monkeypatch, bot_module):
+    responses = {
+        "https://cdn.example/a.png": [
+            (b"a" * 2048, "image/png"),
+        ],
+        "https://cdn.example/b.jpeg": [
+            (b"b" * 2048, "image/jpeg"),
+        ],
+        "https://cdn.example/c": [
+            (b"c" * 2048, "image/jpeg"),
+        ],
+        "https://cdn.example/d.jpeg": [
+            (b"", "image/jpeg"),
+            (b"d" * 4096, "image/jpeg"),
+        ],
+    }
+    counters = {key: 0 for key in responses}
+
+    def fake_get(url, timeout=None, headers=None):
+        base = url.split("?", 1)[0]
+        content, content_type = responses[base][counters[base]]
+        counters[base] = min(counters[base] + 1, len(responses[base]) - 1)
+        return SimpleNamespace(status_code=200, content=content, headers={"Content-Type": content_type})
+
+    monkeypatch.setattr(bot_module.requests, "get", fake_get)
+
+    data1 = bot_module._download_mj_image_bytes("https://cdn.example/a.png", 1)
+    data2 = bot_module._download_mj_image_bytes("https://cdn.example/b.jpeg", 2)
+    data3 = bot_module._download_mj_image_bytes("https://cdn.example/c", 3)
+    data4 = bot_module._download_mj_image_bytes("https://cdn.example/d.jpeg", 4)
+
+    assert data1[1].endswith(".png")
+    assert data2[1].endswith(".jpeg")
+    assert data3[1].endswith(".jpeg")
+    assert data3[2] == "image/jpeg"
+    assert len(data4[0]) > 1024

--- a/tests/test_mj_document_not_empty.py
+++ b/tests/test_mj_document_not_empty.py
@@ -1,0 +1,80 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def bot_module(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "test-token")
+    monkeypatch.setenv("SUNO_API_BASE", "https://example.com")
+    monkeypatch.setenv("SUNO_API_TOKEN", "dummy-token")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    module = importlib.import_module("bot")
+    module = importlib.reload(module)
+    module.mj_log.disabled = True
+    return module
+
+
+def test_mj_document_not_empty(monkeypatch, bot_module):
+    base_urls = [
+        "https://cdn.example/mj/1.jpeg",
+        "https://cdn.example/mj/2.jpeg",
+        "https://cdn.example/mj/3.jpeg",
+        "https://cdn.example/mj/4.jpeg",
+    ]
+
+    call_counts = {url: 0 for url in base_urls}
+
+    def fake_download(url: str, index: int):
+        call_counts[url] += 1
+        return b"x" * (2048 + index), f"midjourney_{index:02d}.jpeg", "image/jpeg", url
+
+    monkeypatch.setattr(bot_module, "_download_mj_image_bytes", fake_download)
+
+    sent_docs = []
+    sent_messages = []
+    gallery_store = []
+
+    async def fake_send_document(chat_id, document, **kwargs):
+        sent_docs.append(document)
+        return SimpleNamespace(message_id=len(sent_docs) + 10)
+
+    async def fake_send_message(chat_id, text, reply_markup=None):
+        sent_messages.append((text, reply_markup))
+        return SimpleNamespace(message_id=999)
+
+    monkeypatch.setattr(bot_module, "set_mj_gallery", lambda *args: gallery_store.append(args))
+
+    bot = SimpleNamespace(send_document=fake_send_document, send_message=fake_send_message)
+    ctx = SimpleNamespace(bot=bot, user_data={})
+
+    state = bot_module.state(ctx)
+    state["mj_locale"] = "ru"
+
+    result = asyncio.run(
+        bot_module._deliver_mj_grid_documents(
+            ctx,
+            chat_id=123,
+            user_id=456,
+            grid_id="grid123",
+            urls=base_urls,
+            prompt="test",
+        )
+    )
+
+    assert sum(call_counts.values()) == 4
+    assert len(sent_docs) == 4
+    for idx, doc in enumerate(sent_docs, start=1):
+        assert doc.filename == f"midjourney_{idx:02d}.jpeg"
+        assert len(doc.input_file_content) > 1024
+    assert sent_messages[0][0] == "Галерея сгенерирована."
+    assert gallery_store, "gallery metadata should be persisted"

--- a/tests/test_mj_ui_buttons.py
+++ b/tests/test_mj_ui_buttons.py
@@ -1,0 +1,86 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def bot_module(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "test-token")
+    monkeypatch.setenv("SUNO_API_BASE", "https://example.com")
+    monkeypatch.setenv("SUNO_API_TOKEN", "dummy-token")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    module = importlib.import_module("bot")
+    module = importlib.reload(module)
+    module.mj_log.disabled = True
+    return module
+
+
+def test_mj_ui_buttons(monkeypatch, bot_module):
+    root_keyboard = bot_module.mj_upscale_root_keyboard("grid")
+    texts = [[button.text for button in row] for row in root_keyboard.inline_keyboard]
+    assert texts == [
+        ["✨ Улучшить качество"],
+        ["🔁 Сгенерировать ещё"],
+        ["🏠 Назад в меню"],
+    ]
+
+    select_keyboard = bot_module.mj_upscale_select_keyboard("grid", count=4)
+    select_texts = [row[0].text for row in select_keyboard.inline_keyboard[:-1]]
+    assert select_texts == [
+        "Первая фотография",
+        "Вторая фотография",
+        "Третья фотография",
+        "Четвёртая фотография",
+    ]
+
+    monkeypatch.setattr(
+        bot_module,
+        "_download_mj_image_bytes",
+        lambda url, index: (b"x" * 2048, f"midjourney_{index:02d}.jpeg", "image/jpeg", url),
+    )
+    monkeypatch.setattr(bot_module, "set_mj_gallery", lambda *args: None)
+
+    async def fake_send_document(chat_id, document, **kwargs):
+        return SimpleNamespace(message_id=index_counter.pop(0))
+
+    sent_messages = []
+
+    async def fake_send_message(chat_id, text, reply_markup=None):
+        sent_messages.append((text, reply_markup))
+        return SimpleNamespace(message_id=500)
+
+    index_counter = [11, 12, 13, 14]
+    bot = SimpleNamespace(send_document=fake_send_document, send_message=fake_send_message)
+    ctx = SimpleNamespace(bot=bot, user_data={})
+
+    state = bot_module.state(ctx)
+    state["mj_locale"] = "ru"
+
+    asyncio.run(
+        bot_module._deliver_mj_grid_documents(
+            ctx,
+            chat_id=1,
+            user_id=2,
+            grid_id="grid",
+            urls=[f"https://cdn/{i}.jpeg" for i in range(4)],
+            prompt="p",
+        )
+    )
+
+    assert sent_messages
+    text, markup = sent_messages[0]
+    assert text == "Галерея сгенерирована."
+    assert markup is not None
+    markup_texts = [[button.text for button in row] for row in markup.inline_keyboard]
+    assert markup_texts[0][0] == "✨ Улучшить качество"
+    assert markup_texts[1][0] == "🔁 Сгенерировать ещё"
+    assert markup_texts[2][0] == "🏠 Назад в меню"

--- a/tests/test_mj_upscale_callback.py
+++ b/tests/test_mj_upscale_callback.py
@@ -1,0 +1,94 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def bot_module(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "test-token")
+    monkeypatch.setenv("SUNO_API_BASE", "https://example.com")
+    monkeypatch.setenv("SUNO_API_TOKEN", "dummy-token")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    module = importlib.import_module("bot")
+    module = importlib.reload(module)
+    module.mj_log.disabled = True
+    return module
+
+
+def _make_update(data: str):
+    async def answer(text: Optional[str] = None, show_alert: bool = False):
+        return None
+
+    query = SimpleNamespace(
+        data=data,
+        message=SimpleNamespace(chat=SimpleNamespace(id=100), message_id=0),
+        answer=answer,
+        from_user=SimpleNamespace(id=200, language_code="ru"),
+    )
+    return SimpleNamespace(
+        callback_query=query,
+        effective_chat=SimpleNamespace(id=100),
+        effective_user=SimpleNamespace(id=200, language_code="ru"),
+    )
+
+
+def test_mj_upscale_callback(monkeypatch, bot_module):
+    grid = {"task_id": "grid", "result_urls": ["a", "b", "c", "d"]}
+    monkeypatch.setattr(bot_module, "_load_mj_grid_snapshot", lambda *_: grid)
+    monkeypatch.setattr(bot_module, "acquire_ttl_lock", lambda *args, **kwargs: True)
+    monkeypatch.setattr(bot_module, "release_ttl_lock", lambda *args, **kwargs: None)
+
+    gallery_calls = []
+
+    def fake_gallery(chat_id, message_id):
+        gallery_calls.append((chat_id, message_id))
+        return [
+            {"source_url": "a", "file_name": "midjourney_01.jpeg", "bytes_len": 2048, "mime": "image/jpeg", "sent_message_id": 11},
+            {"source_url": "b", "file_name": "midjourney_02.jpeg", "bytes_len": 2048, "mime": "image/jpeg", "sent_message_id": 12},
+            {"source_url": "c", "file_name": "midjourney_03.jpeg", "bytes_len": 2048, "mime": "image/jpeg", "sent_message_id": 13},
+            {"source_url": "d", "file_name": "midjourney_04.jpeg", "bytes_len": 2048, "mime": "image/jpeg", "sent_message_id": 14},
+        ]
+
+    monkeypatch.setattr(bot_module, "get_mj_gallery", fake_gallery)
+
+    launch_calls = []
+
+    async def fake_launch(chat_id, ctx, *, user_id, grid, image_index, locale, source, **kwargs):
+        launch_calls.append(
+            {
+                "chat_id": chat_id,
+                "user_id": user_id,
+                "grid": grid,
+                "index": image_index,
+                "locale": locale,
+                "source": source,
+            }
+        )
+        return True
+
+    monkeypatch.setattr(bot_module, "_launch_mj_upscale", fake_launch)
+
+    async def fake_send_message(*args, **kwargs):  # pragma: no cover - should not trigger
+        raise AssertionError("send_message should not be used")
+
+    ctx = SimpleNamespace(
+        bot=SimpleNamespace(send_message=fake_send_message),
+        user_data={},
+    )
+
+    asyncio.run(bot_module.handle_mj_upscale_choice(_make_update("mj.upscale:grid:2"), ctx))
+
+    assert gallery_calls == [(100, 0)]
+    assert launch_calls
+    assert launch_calls[0]["index"] == 1
+    assert launch_calls[0]["grid"] is grid


### PR DESCRIPTION
## Summary
- download Midjourney grid assets with byte-size validation, retry logic, and sanitized filenames, while persisting gallery metadata for callbacks
- stream documents to Telegram with the new gallery metadata, surfacing an expanded inline menu that supports quality improvements, regeneration, and returning to the main menu
- align keyboards, upscale handlers, and redis helpers with the new gallery state and cover the behaviour with focused Midjourney delivery and UI tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfc39f21f08322a20a3d8343d7ef1d