### PR TITLE
Ensure Suno honors user-provided lyrics

### DIFF
--- a/suno/schemas.py
+++ b/suno/schemas.py
@@ -60,6 +60,7 @@ class SunoTrack(BaseModel):
     duration: float | None = None
     source_audio_url: str | None = None
     source_image_url: str | None = None
+    prompt: str | None = None
 
 
 class SunoTask(BaseModel):
@@ -148,6 +149,8 @@ def _build_track(raw: Any, index: int) -> SunoTrack | None:
     title = _first(raw, "title", "name")
     source_audio_url = _first(raw, "sourceAudioUrl", "audio_url", "audioUrl", "url", "fileUrl", "mp3Url")
     source_image_url = _first(raw, "sourceImageUrl", "image_url", "imageUrl", "coverUrl", "imgUrl")
+    prompt_value = _first(raw, "prompt", "lyrics", "lyric", "text")
+    prompt_text = str(prompt_value) if prompt_value not in (None, "") else None
     audio_url = _first(raw, "audio_url", "audioUrl", "url", "fileUrl", "mp3Url") or source_audio_url
     image_url = _first(raw, "image_url", "imageUrl", "coverUrl", "imgUrl") or source_image_url
     tags_value = _first(raw, "tags", "tag", "style", "styles")
@@ -177,6 +180,7 @@ def _build_track(raw: Any, index: int) -> SunoTrack | None:
         duration=duration,
         source_audio_url=str(source_audio_url) if source_audio_url else None,
         source_image_url=str(source_image_url) if source_image_url else None,
+        prompt=prompt_text,
     )
 
 

--- a/tests/test_suno_kie_service.py
+++ b/tests/test_suno_kie_service.py
@@ -60,7 +60,7 @@ def test_enqueue_music_builds_instrumental_payload():
     assert payload["userId"] == "878622103"
     assert payload["callBackUrl"] == "https://bot.example.com/suno-callback"
     assert "callBackSecret" not in payload
-    assert payload["customMode"] is False
+    assert payload["customMode"] is True
     assert payload["prompt_len"] == 16
     assert payload["instrumental"] is True
     assert payload["has_lyrics"] is False
@@ -92,15 +92,18 @@ def test_enqueue_music_builds_vocal_payload():
             instrumental=False,
             has_lyrics=True,
             lyrics="hello world",
+            style="pop ballad",
         )
 
     payload = captured.get("json")
     assert isinstance(payload, dict)
     assert payload["model"] == "V5"
-    assert payload["customMode"] is False
+    assert payload["customMode"] is True
     assert payload["has_lyrics"] is True
     assert payload["instrumental"] is False
+    assert payload["prompt"] == "hello world"
     assert payload["lyrics"] == "hello world"
+    assert payload["style"] == "pop ballad"
     assert payload["tags"] == ["pop", "ballad"]
     assert task_id == "task-2"
 

--- a/tests/test_suno_lyrics_source_toggle.py
+++ b/tests/test_suno_lyrics_source_toggle.py
@@ -82,7 +82,8 @@ def test_toggle_to_user_requests_lyrics(monkeypatch, bot_module):
     assert not state_dict["suno_lyrics_confirmed"]
     assert refresh_calls
     assert wait_calls and wait_calls[0]["kind"] == bot_module.WaitKind.SUNO_LYRICS
-    assert notify_calls and "8000" in notify_calls[0]["text"]
+    expected_limit = str(bot_module._SUNO_LYRICS_MAXLEN)
+    assert notify_calls and expected_limit in notify_calls[0]["text"]
 
 
 def test_toggle_back_to_ai_clears_wait(monkeypatch, bot_module):

--- a/tests/test_vocal_user_lyrics_passed_in_payload.py
+++ b/tests/test_vocal_user_lyrics_passed_in_payload.py
@@ -31,9 +31,11 @@ def test_vocal_user_lyrics_passed_in_payload() -> None:
 
     assert payload.get("lyrics") == "Line one\nLine two"
     assert payload.get("lyrics_source") == LyricsSource.USER.value
+    assert payload.get("prompt") == "Line one\nLine two"
 
     set_lyrics_source(state, LyricsSource.AI)
     payload_ai = build_generation_payload(state, model="V5", lang="ru")
 
     assert "lyrics" not in payload_ai or payload_ai.get("lyrics") in (None, "")
     assert payload_ai.get("lyrics_source") == LyricsSource.AI.value
+    assert payload_ai.get("prompt") == "Alt pop"


### PR DESCRIPTION
## Summary
- enforce model-specific lyric length limits and provide clearer guidance when user text is too long
- send style, lyrics source, and normalized lyrics to the Suno API so custom vocal and instrumental modes use the correct routing
- capture prompts returned in callbacks, verify they match user lyrics, and extend tests to cover the new behaviors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfcd0713408322801ebcade656e234