### PR TITLE
Add YooKassa payments and balance guards

### DIFF
--- a/balance.py
+++ b/balance.py
@@ -1,0 +1,67 @@
+"""Helpers for balance checks and top-up prompts."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.constants import ParseMode
+from telegram.ext import ContextTypes
+
+from redis_utils import get_balance
+from texts import common_text
+
+log = logging.getLogger(__name__)
+
+
+def insufficient_balance_keyboard() -> InlineKeyboardMarkup:
+    """Return inline keyboard with shortcuts to the top-up menu."""
+
+    return InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton(common_text("topup.inline.open"), callback_data="topup:open")],
+            [InlineKeyboardButton(common_text("topup.inline.back"), callback_data="back")],
+        ]
+    )
+
+
+async def ensure_tokens(
+    ctx: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    user_id: int,
+    need: int,
+    *,
+    reply_to: Optional[int] = None,
+) -> bool:
+    """Ensure the user has at least ``need`` tokens; prompt to top up otherwise."""
+
+    try:
+        have = int(get_balance(user_id))
+    except Exception as exc:  # pragma: no cover - network/redis failure
+        log.exception("ensure_tokens.get_balance_failed", extra={"user_id": user_id, "need": need})
+        have = 0
+
+    if have >= need:
+        return True
+
+    text = common_text("balance.insufficient", need=need, have=have)
+    keyboard = insufficient_balance_keyboard()
+
+    try:
+        await ctx.bot.send_message(
+            chat_id=chat_id,
+            text=text,
+            reply_markup=keyboard,
+            reply_to_message_id=reply_to,
+            parse_mode=ParseMode.MARKDOWN,
+        )
+    except Exception as exc:  # pragma: no cover - defensive logging
+        log.warning(
+            "ensure_tokens.notify_failed",
+            extra={"user_id": user_id, "chat_id": chat_id, "need": need, "err": str(exc)},
+        )
+    return False
+
+
+__all__ = ["ensure_tokens", "insufficient_balance_keyboard"]

--- a/payments/__init__.py
+++ b/payments/__init__.py
@@ -1,0 +1,5 @@
+"""Payment-related helpers."""
+
+from .yookassa import YOOKASSA_PACKS, create_payment, get_pack, list_packs
+
+__all__ = ["YOOKASSA_PACKS", "create_payment", "get_pack", "list_packs"]

--- a/payments/yookassa.py
+++ b/payments/yookassa.py
@@ -1,0 +1,245 @@
+"""Integration helpers for YooKassa payments."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Dict, Iterable, List, Optional
+
+import requests
+
+from settings import (
+    HTTP_TIMEOUT_CONNECT,
+    HTTP_TIMEOUT_READ,
+    YOOKASSA_CURRENCY,
+    YOOKASSA_RETURN_URL,
+    YOOKASSA_SECRET_KEY,
+    YOOKASSA_SHOP_ID,
+)
+from texts import common_text
+
+from .yookassa_storage import PendingPayment, save_pending_payment
+
+log = logging.getLogger("payments.yookassa")
+
+_API_BASE = os.getenv("YOOKASSA_API_BASE", "https://api.yookassa.ru").rstrip("/")
+_PAYMENTS_PATH = "/v3/payments"
+_RETRY_DELAYS = (0.0, 1.0, 3.0)
+
+
+@dataclass(frozen=True)
+class YookassaPack:
+    pack_id: str
+    label_key: str
+    amount: Decimal
+    tokens: int
+
+    @property
+    def button_label(self) -> str:
+        return common_text(self.label_key)
+
+
+@dataclass
+class YookassaPayment:
+    payment_id: str
+    confirmation_url: str
+    amount: str
+    currency: str
+    user_id: int
+    pack_id: str
+    tokens_to_add: int
+    idempotence_key: str
+    created_at: float
+
+
+class YookassaError(RuntimeError):
+    """Base exception for YooKassa operations."""
+
+
+YOOKASSA_PACKS: Dict[str, YookassaPack] = {
+    "pack_1": YookassaPack("pack_1", "topup.yookassa.pack_1", Decimal("199.00"), 120),
+    "pack_2": YookassaPack("pack_2", "topup.yookassa.pack_2", Decimal("399.00"), 360),
+    "pack_3": YookassaPack("pack_3", "topup.yookassa.pack_3", Decimal("899.00"), 900),
+}
+
+# Maintain deterministic order for menu rendering.
+YOOKASSA_PACKS_ORDER: List[YookassaPack] = [YOOKASSA_PACKS[key] for key in sorted(YOOKASSA_PACKS)]
+
+
+def list_packs() -> Iterable[YookassaPack]:
+    return list(YOOKASSA_PACKS_ORDER)
+
+
+def get_pack(pack_id: str) -> Optional[YookassaPack]:
+    return YOOKASSA_PACKS.get(pack_id)
+
+
+def _authorization_header(shop_id: str, secret_key: str) -> str:
+    token = base64.b64encode(f"{shop_id}:{secret_key}".encode("utf-8")).decode("ascii")
+    return f"Basic {token}"
+
+
+def _make_session() -> requests.Session:
+    session = requests.Session()
+    adapter = requests.adapters.HTTPAdapter(pool_connections=10, pool_maxsize=10)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+_SESSION = _make_session()
+
+
+def _request_timeout() -> tuple[float, float]:
+    connect = max(0.5, float(HTTP_TIMEOUT_CONNECT))
+    read = max(1.0, float(HTTP_TIMEOUT_READ))
+    return connect, read
+
+
+def _format_amount(amount: Decimal) -> str:
+    normalized = amount.quantize(Decimal("0.01"))
+    return f"{normalized:.2f}"
+
+
+def _validate_configuration() -> None:
+    if not (YOOKASSA_SHOP_ID and YOOKASSA_SECRET_KEY and YOOKASSA_RETURN_URL):
+        raise YookassaError("YooKassa configuration is incomplete")
+
+
+def create_payment(user_id: int, pack_id: str) -> YookassaPayment:
+    """Create a YooKassa payment for ``user_id`` and ``pack_id``."""
+
+    _validate_configuration()
+
+    pack = get_pack(pack_id)
+    if not pack:
+        raise YookassaError(f"Unknown YooKassa pack: {pack_id}")
+
+    idempotence_key = f"yk:{user_id}:{pack_id}:{uuid.uuid4()}"
+    payload = {
+        "amount": {"value": _format_amount(pack.amount), "currency": YOOKASSA_CURRENCY or "RUB"},
+        "capture": True,
+        "confirmation": {"type": "redirect", "return_url": YOOKASSA_RETURN_URL},
+        "description": f"Best AI Bot: {pack_id} for user {user_id}",
+        "metadata": {"user_id": user_id, "pack_id": pack_id, "tokens": pack.tokens},
+    }
+
+    headers = {
+        "Content-Type": "application/json",
+        "Idempotence-Key": idempotence_key,
+        "Authorization": _authorization_header(YOOKASSA_SHOP_ID, YOOKASSA_SECRET_KEY),
+    }
+
+    connect, read = _request_timeout()
+    url = f"{_API_BASE}{_PAYMENTS_PATH}"
+
+    for attempt, delay in enumerate(_RETRY_DELAYS, start=1):
+        if delay:
+            time.sleep(delay)
+        try:
+            response = _SESSION.post(
+                url,
+                data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                headers=headers,
+                timeout=(connect, read),
+            )
+        except requests.RequestException as exc:
+            log.warning(
+                "topup.yookassa.create.network",
+                extra={"meta": {"user_id": user_id, "pack_id": pack_id, "attempt": attempt, "err": str(exc)}},
+            )
+            if attempt == len(_RETRY_DELAYS):
+                raise YookassaError("Не удалось создать платёж в YooKassa") from exc
+            continue
+
+        if response.status_code >= 500 and attempt < len(_RETRY_DELAYS):
+            log.warning(
+                "topup.yookassa.create.retry",
+                extra={"meta": {"user_id": user_id, "pack_id": pack_id, "status": response.status_code}},
+            )
+            continue
+
+        if response.status_code >= 400:
+            log.error(
+                "topup.yookassa.create.failed",
+                extra={"meta": {"user_id": user_id, "pack_id": pack_id, "status": response.status_code, "body": response.text[:400]}},
+            )
+            raise YookassaError(f"YooKassa responded with status {response.status_code}")
+
+        try:
+            payload_json = response.json()
+        except ValueError as exc:  # pragma: no cover - invalid JSON
+            log.error(
+                "topup.yookassa.create.invalid_json",
+                extra={"meta": {"user_id": user_id, "pack_id": pack_id, "status": response.status_code}},
+            )
+            raise YookassaError("YooKassa returned invalid JSON") from exc
+
+        payment_id = payload_json.get("id")
+        confirmation = payload_json.get("confirmation") or {}
+        confirmation_url = confirmation.get("confirmation_url") or confirmation.get("url")
+
+        if not payment_id or not confirmation_url:
+            log.error(
+                "topup.yookassa.create.malformed",
+                extra={"meta": {"user_id": user_id, "pack_id": pack_id, "body": payload_json}},
+            )
+            raise YookassaError("YooKassa response missing payment details")
+
+        payment = YookassaPayment(
+            payment_id=str(payment_id),
+            confirmation_url=str(confirmation_url),
+            amount=_format_amount(pack.amount),
+            currency=YOOKASSA_CURRENCY or "RUB",
+            user_id=user_id,
+            pack_id=pack.pack_id,
+            tokens_to_add=pack.tokens,
+            idempotence_key=idempotence_key,
+            created_at=time.time(),
+        )
+
+        log.info(
+            "topup.yookassa.create", extra={"meta": {"user_id": user_id, "pack_id": pack.pack_id, "payment_id": payment.payment_id}}
+        )
+
+        save_pending_payment(
+            PendingPayment(
+                payment_id=payment.payment_id,
+                user_id=user_id,
+                pack_id=pack.pack_id,
+                amount=payment.amount,
+                currency=payment.currency,
+                tokens_to_add=pack.tokens,
+                idempotence_key=idempotence_key,
+            )
+        )
+
+        return payment
+
+    raise YookassaError("Не удалось создать платёж в YooKassa")
+
+
+def pack_button_label(pack_id: str) -> str:
+    pack = get_pack(pack_id)
+    if not pack:
+        return pack_id
+    return pack.button_label
+
+
+__all__ = [
+    "YookassaPack",
+    "YookassaPayment",
+    "YOOKASSA_PACKS",
+    "YOOKASSA_PACKS_ORDER",
+    "create_payment",
+    "get_pack",
+    "list_packs",
+    "pack_button_label",
+    "YookassaError",
+]

--- a/payments/yookassa_callback.py
+++ b/payments/yookassa_callback.py
@@ -1,0 +1,120 @@
+"""Webhook processing for YooKassa payments."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import requests
+
+from ledger import LedgerStorage
+from texts import common_text
+
+from .yookassa_storage import (
+    acquire_payment_lock,
+    load_pending_payment,
+    release_payment_lock,
+    update_pending_status,
+)
+
+log = logging.getLogger("payments.yookassa.callback")
+
+_TELEGRAM_TOKEN = (os.getenv("TELEGRAM_TOKEN") or "").strip()
+_TELEGRAM_BASE_URL = (
+    f"https://api.telegram.org/bot{_TELEGRAM_TOKEN}" if _TELEGRAM_TOKEN else None
+)
+_TELEGRAM_SESSION = requests.Session()
+
+_SUCCESS_STICKER_ID = "5471952986970267163"
+
+_ledger_instance: Optional[LedgerStorage] = None
+
+
+def _ledger() -> LedgerStorage:
+    global _ledger_instance
+    if _ledger_instance is None:
+        backend = (os.getenv("LEDGER_BACKEND") or "postgres").lower()
+        dsn = os.getenv("DATABASE_URL") or os.getenv("POSTGRES_DSN")
+        _ledger_instance = LedgerStorage(dsn, backend=backend)
+    return _ledger_instance
+
+
+def _telegram_request(method: str, payload: Dict[str, Any]) -> None:
+    if not _TELEGRAM_BASE_URL:
+        log.warning("topup.telegram.missing_token")
+        return
+    url = f"{_TELEGRAM_BASE_URL}/{method}"
+    try:
+        response = _TELEGRAM_SESSION.post(url, json=payload, timeout=20)
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        log.warning("topup.telegram.network", extra={"meta": {"method": method, "err": str(exc)}})
+        return
+    if not response.ok:
+        log.warning(
+            "topup.telegram.failed",
+            extra={"meta": {"method": method, "status": response.status_code, "body": response.text[:200]}},
+        )
+
+
+def _notify_success(user_id: int, new_balance: int) -> None:
+    _telegram_request("sendSticker", {"chat_id": user_id, "sticker": _SUCCESS_STICKER_ID})
+    text = common_text("balance.success", new_balance=new_balance)
+    _telegram_request("sendMessage", {"chat_id": user_id, "text": text})
+
+
+def process_callback(payload: Dict[str, Any]) -> Dict[str, Any]:
+    event = payload.get("event")
+    object_data = payload.get("object") or {}
+    payment_id = str(object_data.get("id")) if object_data.get("id") else None
+
+    meta = {"event": event, "payment_id": payment_id}
+    log.info("topup.yookassa.callback", extra={"meta": meta})
+
+    if event != "payment.succeeded" or not payment_id:
+        return {"status": "ignored"}
+
+    if not acquire_payment_lock(payment_id):
+        log.info("topup.yookassa.locked", extra={"meta": meta})
+        return {"status": "locked"}
+
+    try:
+        pending = load_pending_payment(payment_id)
+        if not pending:
+            log.warning("topup.yookassa.unknown_payment", extra={"meta": meta})
+            return {"status": "missing"}
+
+        if pending.status == "SUCCESS":
+            log.info("topup.yookassa.duplicate", extra={"meta": meta})
+            return {"status": "duplicate"}
+
+        op_id = f"yk:{payment_id}"
+        ledger = _ledger()
+        result = ledger.credit(
+            pending.user_id,
+            pending.tokens_to_add,
+            "yookassa_topup",
+            op_id,
+            {"pack_id": pending.pack_id, "amount": pending.amount, "currency": pending.currency},
+        )
+        update_pending_status(payment_id, "SUCCESS")
+        balance = int(result.balance)
+
+        log.info(
+            "topup.success",
+            extra={"meta": {"payment_id": payment_id, "user_id": pending.user_id, "balance": balance}},
+        )
+
+        _notify_success(pending.user_id, balance)
+        return {"status": "success", "balance": balance}
+    except Exception as exc:
+        log.exception(
+            "topup.failed", extra={"meta": {"payment_id": payment_id, "error": str(exc)}}
+        )
+        update_pending_status(payment_id, "FAILED")
+        return {"status": "error", "error": str(exc)}
+    finally:
+        release_payment_lock(payment_id)
+
+
+__all__ = ["process_callback"]

--- a/payments/yookassa_storage.py
+++ b/payments/yookassa_storage.py
@@ -1,0 +1,156 @@
+"""Persistence helpers for YooKassa payments."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, Optional
+
+from redis_utils import rds
+from settings import REDIS_PREFIX
+
+log = logging.getLogger("payments.yookassa.storage")
+
+_PENDING_KEY_TMPL = f"{REDIS_PREFIX}:yk:pending:{{}}"
+_LOCK_KEY_TMPL = f"{REDIS_PREFIX}:yk:lock:{{}}"
+_PENDING_TTL = 24 * 60 * 60
+
+_memory_pending: Dict[str, tuple[float, Dict[str, Any]]] = {}
+_memory_locks: Dict[str, float] = {}
+_memory_lock = threading.Lock()
+
+
+@dataclass(slots=True)
+class PendingPayment:
+    payment_id: str
+    user_id: int
+    pack_id: str
+    amount: str
+    currency: str
+    tokens_to_add: int
+    status: str = "PENDING"
+    idempotence_key: Optional[str] = None
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+
+    def to_json(self) -> str:
+        payload = asdict(self)
+        return json.dumps(payload, ensure_ascii=False)
+
+    @classmethod
+    def from_json(cls, raw: str) -> "PendingPayment":
+        data = json.loads(raw)
+        return cls(
+            payment_id=str(data.get("payment_id")),
+            user_id=int(data.get("user_id")),
+            pack_id=str(data.get("pack_id")),
+            amount=str(data.get("amount")),
+            currency=str(data.get("currency")),
+            tokens_to_add=int(data.get("tokens_to_add")),
+            status=str(data.get("status", "PENDING")),
+            idempotence_key=data.get("idempotence_key"),
+            created_at=float(data.get("created_at", time.time())),
+            updated_at=float(data.get("updated_at", time.time())),
+        )
+
+    def with_status(self, status: str) -> "PendingPayment":
+        self.status = status
+        self.updated_at = time.time()
+        return self
+
+
+def _pending_key(payment_id: str) -> str:
+    return _PENDING_KEY_TMPL.format(payment_id)
+
+
+def _lock_key(payment_id: str) -> str:
+    return _LOCK_KEY_TMPL.format(payment_id)
+
+
+def save_pending_payment(payment: PendingPayment) -> None:
+    payload = payment.to_json()
+    key = _pending_key(payment.payment_id)
+    if rds is not None:
+        try:
+            rds.setex(key, _PENDING_TTL, payload)
+            return
+        except Exception as exc:  # pragma: no cover - Redis failure fallback
+            log.warning("yookassa.pending.redis_save_failed", extra={"meta": {"key": key, "err": str(exc)}})
+    with _memory_lock:
+        _memory_pending[key] = (time.time() + _PENDING_TTL, json.loads(payload))
+
+
+def load_pending_payment(payment_id: str) -> Optional[PendingPayment]:
+    key = _pending_key(payment_id)
+    if rds is not None:
+        try:
+            raw = rds.get(key)
+        except Exception as exc:  # pragma: no cover - Redis failure fallback
+            log.warning("yookassa.pending.redis_get_failed", extra={"meta": {"key": key, "err": str(exc)}})
+        else:
+            if raw:
+                try:
+                    return PendingPayment.from_json(raw.decode("utf-8"))
+                except Exception:  # pragma: no cover - invalid data
+                    log.exception("yookassa.pending.redis_payload_invalid", extra={"meta": {"key": key}})
+
+    with _memory_lock:
+        entry = _memory_pending.get(key)
+        if not entry:
+            return None
+        expires_at, payload = entry
+        if expires_at < time.time():
+            _memory_pending.pop(key, None)
+            return None
+        return PendingPayment.from_json(json.dumps(payload, ensure_ascii=False))
+
+
+def update_pending_status(payment_id: str, status: str) -> Optional[PendingPayment]:
+    record = load_pending_payment(payment_id)
+    if not record:
+        return None
+    record.with_status(status)
+    save_pending_payment(record)
+    return record
+
+
+def acquire_payment_lock(payment_id: str, ttl: int = 30) -> bool:
+    key = _lock_key(payment_id)
+    now = time.time()
+    if rds is not None:
+        try:
+            stored = rds.set(key, str(now), nx=True, ex=max(ttl, 1))
+            if stored:
+                return True
+        except Exception as exc:  # pragma: no cover - Redis failure fallback
+            log.warning("yookassa.lock.redis_error", extra={"meta": {"key": key, "err": str(exc)}})
+    with _memory_lock:
+        expires_at = _memory_locks.get(key)
+        if expires_at and expires_at > now:
+            return False
+        _memory_locks[key] = now + max(ttl, 1)
+    return True
+
+
+def release_payment_lock(payment_id: str) -> None:
+    key = _lock_key(payment_id)
+    if rds is not None:
+        try:
+            rds.delete(key)
+        except Exception as exc:  # pragma: no cover - Redis failure fallback
+            log.warning("yookassa.lock.redis_release_failed", extra={"meta": {"key": key, "err": str(exc)}})
+    with _memory_lock:
+        _memory_locks.pop(key, None)
+
+
+__all__ = [
+    "PendingPayment",
+    "save_pending_payment",
+    "load_pending_payment",
+    "update_pending_status",
+    "acquire_payment_lock",
+    "release_payment_lock",
+]

--- a/settings.py
+++ b/settings.py
@@ -75,6 +75,11 @@ class _AppSettings(BaseModel):
     UPLOAD_BASE64_PATH: str = Field(default="/api/v1/upload/base64")
     UPLOAD_FALLBACK_ENABLED: bool = Field(default=False)
 
+    YOOKASSA_SHOP_ID: Optional[str] = Field(default=None)
+    YOOKASSA_SECRET_KEY: Optional[str] = Field(default=None)
+    YOOKASSA_RETURN_URL: Optional[str] = Field(default=None)
+    YOOKASSA_CURRENCY: str = Field(default="RUB")
+
     @field_validator("LOG_LEVEL", mode="before")
     def _normalize_level(cls, value: object) -> str:
         if value is None:
@@ -91,6 +96,9 @@ class _AppSettings(BaseModel):
         "SUNO_API_TOKEN",
         "SUNO_CALLBACK_SECRET",
         "SUNO_CALLBACK_URL",
+        "YOOKASSA_SHOP_ID",
+        "YOOKASSA_SECRET_KEY",
+        "YOOKASSA_RETURN_URL",
         mode="before",
     )
     def _strip_optional(cls, value: object) -> Optional[str]:
@@ -232,6 +240,13 @@ SUNO_TIMEOUT_SEC = int(round(HTTP_TIMEOUT_TOTAL))
 SUNO_MAX_RETRIES = max(1, HTTP_RETRY_ATTEMPTS)
 SUNO_ENABLED = bool(_APP_SETTINGS.SUNO_ENABLED)
 
+YOOKASSA_SHOP_ID = _strip_optional(_APP_SETTINGS.YOOKASSA_SHOP_ID)
+YOOKASSA_SECRET_KEY = _strip_optional(_APP_SETTINGS.YOOKASSA_SECRET_KEY)
+YOOKASSA_RETURN_URL = _strip_optional(_APP_SETTINGS.YOOKASSA_RETURN_URL)
+YOOKASSA_CURRENCY = (
+    (_APP_SETTINGS.YOOKASSA_CURRENCY or "RUB").strip() or "RUB"
+)
+
 SUNO_GEN_PATH = _APP_SETTINGS.SUNO_GEN_PATH
 SUNO_TASK_STATUS_PATH = _APP_SETTINGS.SUNO_TASK_STATUS_PATH
 SUNO_WAV_PATH = _APP_SETTINGS.SUNO_WAV_PATH
@@ -360,6 +375,10 @@ __all__ = [
     "UPLOAD_STREAM_PATH",
     "UPLOAD_URL_PATH",
     "UPLOAD_BASE64_PATH",
+    "YOOKASSA_SHOP_ID",
+    "YOOKASSA_SECRET_KEY",
+    "YOOKASSA_RETURN_URL",
+    "YOOKASSA_CURRENCY",
     "BANANA_SEND_AS_DOCUMENT",
     "MJ_SEND_AS_ALBUM",
     "resolve_outbound_ip",

--- a/tests/test_suno_basic.py
+++ b/tests/test_suno_basic.py
@@ -96,10 +96,21 @@ def _reset_env(monkeypatch):
     monkeypatch.setenv("LOG_LEVEL", "INFO")
     monkeypatch.setenv("SUNO_ENABLED", "true")
     monkeypatch.setenv("SUNO_CALLBACK_URL", "https://callback.local/suno-callback")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.delenv("TELEGRAM_TOKEN", raising=False)
     monkeypatch.delenv("ADMIN_IDS", raising=False)
     monkeypatch.setattr(suno_web, "SUNO_ENABLED", True, raising=False)
     suno_web._memory_idempotency.clear()
+
+    bot = importlib.import_module("bot")
+    balance = importlib.import_module("balance")
+
+    async def _ensure_tokens_stub(*args, **kwargs):
+        return True
+
+    monkeypatch.setattr(bot, "ensure_tokens", _ensure_tokens_stub)
+    monkeypatch.setattr(balance, "ensure_tokens", _ensure_tokens_stub)
 
 
 def _client():

--- a/tests/test_suno_flow.py
+++ b/tests/test_suno_flow.py
@@ -7,6 +7,8 @@ from types import SimpleNamespace
 from pathlib import Path
 import sys
 
+import pytest
+
 from telegram import InlineKeyboardMarkup
 from telegram.error import BadRequest
 
@@ -44,6 +46,16 @@ from utils.suno_state import (
 import utils.api_client as api_client_utils
 
 bot_module = importlib.import_module("bot")
+balance_module = importlib.import_module("balance")
+
+
+@pytest.fixture(autouse=True)
+def _patch_ensure_tokens(monkeypatch):
+    async def _ensure_tokens_stub(*args, **kwargs):
+        return True
+
+    monkeypatch.setattr(bot_module, "ensure_tokens", _ensure_tokens_stub)
+    monkeypatch.setattr(balance_module, "ensure_tokens", _ensure_tokens_stub)
 
 
 class FakeBot:

--- a/tests/test_topup.py
+++ b/tests/test_topup.py
@@ -1,0 +1,151 @@
+import asyncio
+import importlib
+import inspect
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("LEDGER_BACKEND", "memory")
+
+import balance
+import bot
+
+
+def test_topup_menu_opens_once():
+    async def run() -> None:
+        ctx = SimpleNamespace(bot=AsyncMock())
+        query = Mock()
+        query.message = Mock(chat_id=123)
+        query.edit_message_text = AsyncMock()
+
+        await bot.show_topup_menu(ctx, 123, query=query, user_id=456)
+
+        query.edit_message_text.assert_called_once()
+        assert ctx.bot.send_message.await_count == 0
+
+    asyncio.run(run())
+
+
+def test_insufficient_tokens_shows_button(monkeypatch):
+    async def run() -> None:
+        monkeypatch.setattr(balance, "get_balance", lambda user_id: 0)
+        ctx = SimpleNamespace(bot=AsyncMock())
+
+        result = await balance.ensure_tokens(ctx, chat_id=111, user_id=222, need=5)
+
+        assert result is False
+        ctx.bot.send_message.assert_called_once()
+        kwargs = ctx.bot.send_message.call_args.kwargs
+        keyboard = kwargs["reply_markup"]
+        assert keyboard.inline_keyboard[0][0].callback_data == "topup:open"
+
+    asyncio.run(run())
+
+
+def test_stars_button_label():
+    keyboard = bot.topup_menu_keyboard()
+    assert keyboard.inline_keyboard[0][0].text.startswith("💎")
+    assert keyboard.inline_keyboard[1][0].text.startswith("💳")
+
+
+@pytest.fixture
+def yk_environment(monkeypatch):
+    monkeypatch.setenv("YOOKASSA_SHOP_ID", "shop")
+    monkeypatch.setenv("YOOKASSA_SECRET_KEY", "secret")
+    monkeypatch.setenv("YOOKASSA_RETURN_URL", "https://return")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("TELEGRAM_TOKEN", "dummy-token")
+
+    settings = importlib.import_module("settings")
+    importlib.reload(settings)
+
+    import payments.yookassa as yk
+    import payments.yookassa_storage as storage
+    import payments.yookassa_callback as callback
+
+    importlib.reload(yk)
+    importlib.reload(storage)
+    importlib.reload(callback)
+
+    sent = []
+
+    class DummyTGResponse:
+        status_code = 200
+        ok = True
+        text = ""
+
+    def fake_tg_post(url, json=None, timeout=None):
+        sent.append((url, json))
+        return DummyTGResponse()
+
+    monkeypatch.setattr(callback, "_TELEGRAM_SESSION", SimpleNamespace(post=fake_tg_post))
+    ledger_module = importlib.import_module("ledger")
+    ledger_instance = ledger_module.LedgerStorage(None, backend="memory")
+    callback._ledger_instance = ledger_instance
+
+    class DummyResponse:
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {"id": "pay-1", "confirmation": {"confirmation_url": "https://pay"}}
+
+        @property
+        def ok(self):
+            return True
+
+    monkeypatch.setattr(yk._SESSION, "post", lambda *args, **kwargs: DummyResponse())
+
+    return yk, storage, callback, sent, ledger_instance
+
+
+def test_yk_payment_flow_success(monkeypatch, yk_environment):
+    async def run() -> None:
+        yk, storage, callback, sent, _ = yk_environment
+
+        payment = yk.create_payment(1001, "pack_1")
+        assert payment.payment_id == "pay-1"
+
+        pending = storage.load_pending_payment("pay-1")
+        assert pending is not None
+
+        result = callback.process_callback({"event": "payment.succeeded", "object": {"id": "pay-1"}})
+        assert result["status"] == "success"
+
+        balance_value = callback._ledger_instance.get_balance(1001)
+        assert balance_value == pending.tokens_to_add
+
+        assert len(sent) == 2
+        assert sent[0][0].endswith("/sendSticker")
+        assert sent[1][0].endswith("/sendMessage")
+
+    asyncio.run(run())
+
+
+def test_yk_callback_idempotent(yk_environment):
+    yk, storage, callback, sent, _ = yk_environment
+
+    payment = yk.create_payment(2002, "pack_2")
+    callback.process_callback({"event": "payment.succeeded", "object": {"id": payment.payment_id}})
+    sent_length = len(sent)
+
+    duplicate = callback.process_callback({"event": "payment.succeeded", "object": {"id": payment.payment_id}})
+    assert duplicate["status"] == "duplicate"
+    assert len(sent) == sent_length
+
+
+def test_modes_guard():
+    source = inspect.getsource(bot)
+    assert "await ensure_tokens(ctx, chat_id, user_id, PRICE_SUNO)" in source
+    assert "if not await ensure_tokens(ctx, chat_id, user_id, price):" in source
+    assert "if not await ensure_tokens(ctx, chat_id, uid, PRICE_BANANA):" in source
+    assert "if not await ensure_tokens(ctx, chat_id, uid, price):" in source

--- a/texts.py
+++ b/texts.py
@@ -6,6 +6,30 @@ from suno.cover_source import MAX_AUDIO_MB
 
 FAQ_INTRO = "🧾 *FAQ*\nВыберите раздел:"
 
+COMMON_TEXTS_RU = {
+    "topup.menu.title": "Выберите способ пополнения:",
+    "topup.menu.stars": "💎 Оплатить звёздами",
+    "topup.menu.yookassa": "💳 Оплатить картой (ЮKassa)",
+    "topup.menu.back": "⬅️ Назад",
+    "topup.inline.open": "Пополнить баланс",
+    "topup.inline.back": "⬅️ Назад в меню",
+    "topup.yookassa.pack_1": "Пакет 1 (+X1💎)",
+    "topup.yookassa.pack_2": "Пакет 2 (+X2💎)",
+    "topup.yookassa.pack_3": "Пакет 3 (+X3💎)",
+    "topup.yookassa.title": "Выберите пакет пополнения:",
+    "topup.yookassa.pay": "Перейти к оплате",
+    "topup.yookassa.created": "Счёт создан. Перейдите к оплате:",
+    "topup.yookassa.retry": "Попробовать снова",
+    "topup.yookassa.error": "⚠️ Не удалось создать платёж. Попробуйте ещё раз.",
+    "topup.yookassa.processing": "⚠️ Обработка платежа уже идёт. Подождите пару секунд и обновите меню.",
+    "topup.stars.title": "💎 Пополнение через Telegram Stars",
+    "topup.stars.info": (
+        "Если звёзд не хватает — купите в официальном боте @PremiumBot."
+    ),
+    "balance.insufficient": "Недостаточно токенов: нужно {need}💎, на балансе {have}💎.",
+    "balance.success": "Оплата прошла успешно! Баланс: {new_balance}💎.",
+}
+
 FAQ_SECTIONS = {
     "veo": "🎬 *Видео (VEO)*\n• Fast — быстрее и дешевле.\n• Quality — дольше, но лучше детализация.\n• Формат: присылаете идею/ фото → карточка → «Сгенерировать».\n• Время: 2–10 мин.",
     "mj": "🎨 *Изображения (MJ)*\n• Стоимость: 10💎 за 1 изображение.\n• Один бесплатный перезапуск при сетевой ошибке.",
@@ -108,3 +132,13 @@ def help_text(language_code: Optional[str], support_username: str) -> tuple[str,
 SUNO_MODE_PROMPT = t("suno.prompt.mode_select")
 SUNO_START_READY_MESSAGE = t("suno.prompt.ready")
 SUNO_STARTING_MESSAGE = t("suno.prompt.starting")
+
+
+def common_text(key: str, /, **kwargs: Any) -> str:
+    value = COMMON_TEXTS_RU.get(key, key)
+    if kwargs:
+        try:
+            return value.format(**kwargs)
+        except Exception:
+            return value
+    return value


### PR DESCRIPTION
## Summary
- add a shared balance helper and call it before starting paid tasks
- implement YooKassa card payment creation, persistence, and webhook fulfillment
- extend the top-up menus, copy updates, and regression tests for balance flows

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dfd43660988322b05fda0a9d3e3230