### PR TITLE
Add Sora 2 integration and regressions for video generation flows

### DIFF
--- a/keyboards.py
+++ b/keyboards.py
@@ -13,6 +13,8 @@ CB_VIDEO_MENU = "video_menu"
 CB_VIDEO_MODE_FAST = "mode:veo_text_fast"
 CB_VIDEO_MODE_QUALITY = "mode:veo_text_quality"
 CB_VIDEO_MODE_PHOTO = "mode:veo_photo"
+CB_VIDEO_MODE_SORA_TEXT = "mode:sora2_ttv"
+CB_VIDEO_MODE_SORA_IMAGE = "mode:sora2_itv"
 CB_VIDEO_BACK = "video:back"
 
 

--- a/settings.py
+++ b/settings.py
@@ -47,6 +47,7 @@ class _AppSettings(BaseModel):
 
     KIE_BASE_URL: str = Field(default="https://api.kie.ai")
     KIE_API_KEY: Optional[str] = Field(default=None)
+    PUBLIC_BASE_URL: Optional[str] = Field(default=None)
 
     SUNO_ENABLED: bool = Field(default=False)
     SUNO_API_BASE: Optional[str] = Field(default="https://api.kie.ai")
@@ -75,6 +76,9 @@ class _AppSettings(BaseModel):
     UPLOAD_BASE64_PATH: str = Field(default="/api/v1/upload/base64")
     UPLOAD_FALLBACK_ENABLED: bool = Field(default=False)
 
+    SORA2_GEN_PATH: str = Field(default="https://api.kie.ai/api/v1/jobs/createTask")
+    SORA2_STATUS_PATH: str = Field(default="https://api.kie.ai/api/v1/jobs/getTask")
+
     YOOKASSA_SHOP_ID: Optional[str] = Field(default=None)
     YOOKASSA_SECRET_KEY: Optional[str] = Field(default=None)
     YOOKASSA_RETURN_URL: Optional[str] = Field(default=None)
@@ -92,6 +96,7 @@ class _AppSettings(BaseModel):
     @field_validator(
         "KIE_BASE_URL",
         "KIE_API_KEY",
+        "PUBLIC_BASE_URL",
         "SUNO_API_BASE",
         "SUNO_API_TOKEN",
         "SUNO_CALLBACK_SECRET",
@@ -230,6 +235,9 @@ def _strip_optional(value: Optional[str]) -> Optional[str]:
 
 KIE_BASE_URL = (_strip_optional(_APP_SETTINGS.KIE_BASE_URL) or "https://api.kie.ai").rstrip("/")
 KIE_API_KEY = _strip_optional(_APP_SETTINGS.KIE_API_KEY)
+PUBLIC_BASE_URL = _strip_optional(_APP_SETTINGS.PUBLIC_BASE_URL)
+if PUBLIC_BASE_URL:
+    PUBLIC_BASE_URL = PUBLIC_BASE_URL.rstrip("/")
 
 _suno_base_candidate = _APP_SETTINGS.SUNO_API_BASE or KIE_BASE_URL
 SUNO_API_BASE = (_strip_optional(_suno_base_candidate) or KIE_BASE_URL).rstrip("/")
@@ -271,6 +279,14 @@ UPLOAD_BASE64_PATH = _APP_SETTINGS.UPLOAD_BASE64_PATH
 SUNO_READY = bool(
     SUNO_ENABLED and SUNO_API_TOKEN and SUNO_CALLBACK_SECRET and SUNO_CALLBACK_URL
 )
+
+SORA2_GEN_PATH = _APP_SETTINGS.SORA2_GEN_PATH
+SORA2_STATUS_PATH = _APP_SETTINGS.SORA2_STATUS_PATH
+SORA2 = {
+    "GEN_PATH": SORA2_GEN_PATH,
+    "STATUS_PATH": SORA2_STATUS_PATH,
+    "CALLBACK_URL": f"{PUBLIC_BASE_URL}/sora2-callback" if PUBLIC_BASE_URL else None,
+}
 
 BANANA_SEND_AS_DOCUMENT = bool(_APP_SETTINGS.BANANA_SEND_AS_DOCUMENT)
 MJ_SEND_AS_ALBUM = bool(_APP_SETTINGS.MJ_SEND_AS_ALBUM)

--- a/sora2_client.py
+++ b/sora2_client.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import httpx
+
+from settings import KIE_API_KEY, SORA2
+
+
+def sora2_create_task(payload: dict) -> dict:
+    response = httpx.post(
+        SORA2["GEN_PATH"],
+        headers={
+            "Authorization": f"Bearer {KIE_API_KEY}",
+            "Content-Type": "application/json",
+        },
+        json=payload,
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def sora2_get_task(task_id: str) -> dict:
+    response = httpx.get(
+        SORA2["STATUS_PATH"],
+        headers={"Authorization": f"Bearer {KIE_API_KEY}"},
+        params={"taskId": task_id},
+        timeout=15,
+    )
+    response.raise_for_status()
+    return response.json()

--- a/tests/test_balance_block.py
+++ b/tests/test_balance_block.py
@@ -1,0 +1,43 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def balance_module(monkeypatch):
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    module = importlib.import_module("balance")
+    return importlib.reload(module)
+
+
+class DummyBot:
+    def __init__(self):
+        self.messages = []
+
+    async def send_message(self, **kwargs):  # pragma: no cover - async stub
+        self.messages.append(kwargs)
+        return SimpleNamespace()
+
+
+def test_balance_block_shows_topup(monkeypatch, balance_module):
+    monkeypatch.setattr(balance_module, "get_balance", lambda user_id: 0)
+
+    bot = DummyBot()
+    ctx = SimpleNamespace(bot=bot)
+
+    result = asyncio.run(balance_module.ensure_tokens(ctx, chat_id=11, user_id=22, need=100))
+    assert result is False
+    assert len(bot.messages) == 1
+
+    keyboard = bot.messages[0]["reply_markup"]
+    button_texts = [button.text for row in keyboard.inline_keyboard for button in row]
+    assert "💳 Пополнить баланс" in button_texts

--- a/tests/test_sora2_payloads.py
+++ b/tests/test_sora2_payloads.py
@@ -1,0 +1,44 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def bot_module(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "dummy-token")
+    monkeypatch.setenv("SUNO_API_BASE", "https://example.com")
+    monkeypatch.setenv("SUNO_API_TOKEN", "token")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://bot.example")
+    module = importlib.import_module("bot")
+    return importlib.reload(module)
+
+
+def test_sora2_text_to_video_payload(bot_module):
+    payload = bot_module._build_sora2_payload("sora2_ttv", "Hello world", [])
+
+    assert payload["model"] == "sora-2-text-to-video"
+    assert payload["callBackUrl"] == "https://bot.example/sora2-callback"
+    assert payload["input"]["prompt"] == "Hello world"
+    assert payload["input"]["duration"] == 10
+    assert payload["input"]["aspect_ratio"] == "16:9"
+    assert payload["input"]["quality"] == "standard"
+    assert payload["input"]["audio"] is True
+    assert "image_urls" not in payload["input"]
+
+
+def test_sora2_image_to_video_payload(bot_module):
+    image_urls = ["https://example.com/one.png", "https://example.com/two.png"]
+    payload = bot_module._build_sora2_payload("sora2_itv", "Prompt", image_urls)
+
+    assert payload["model"] == "sora-2-image-to-video"
+    assert payload["input"]["prompt"] == "Prompt"
+    assert payload["input"]["image_urls"] == image_urls

--- a/tests/test_user_lock_no_duplicates.py
+++ b/tests/test_user_lock_no_duplicates.py
@@ -1,0 +1,25 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def redis_module(monkeypatch):
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    module = importlib.import_module("redis_utils")
+    return importlib.reload(module)
+
+
+def test_user_lock_blocks_duplicates(redis_module):
+    assert redis_module.user_lock(123, "video_start") is True
+    assert redis_module.user_lock(123, "video_start") is False
+
+    redis_module.release_user_lock(123, "video_start")
+    assert redis_module.user_lock(123, "video_start") is True

--- a/tests/test_video_menu_single_card.py
+++ b/tests/test_video_menu_single_card.py
@@ -1,0 +1,41 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def bot_module(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "dummy-token")
+    monkeypatch.setenv("SUNO_API_BASE", "https://example.com")
+    monkeypatch.setenv("SUNO_API_TOKEN", "token")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://bot.example")
+    module = importlib.import_module("bot")
+    return importlib.reload(module)
+
+
+def test_video_menu_single_card(bot_module):
+    markup = bot_module.video_menu_kb()
+    rows = markup.inline_keyboard
+
+    # 5 generation options + 1 back button
+    assert len(rows) == 6
+
+    titles = [row[0].text for row in rows[:5]]
+    assert any("Veo Fast" in title for title in titles)
+    assert any("Veo Quality" in title for title in titles)
+    assert any("Оживить изображение (Veo)" in title for title in titles)
+    assert any("Sora 2 (Text-to-Video)" in title for title in titles)
+    assert any("Sora 2 (Image-to-Video)" in title for title in titles)
+
+    back_row = rows[-1]
+    assert len(back_row) == 1
+    assert back_row[0].callback_data == bot_module.CB_VIDEO_BACK

--- a/tests/test_wait_sticker_replace.py
+++ b/tests/test_wait_sticker_replace.py
@@ -1,0 +1,59 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def bot_module(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "dummy-token")
+    monkeypatch.setenv("SUNO_API_BASE", "https://example.com")
+    monkeypatch.setenv("SUNO_API_TOKEN", "token")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://bot.example")
+    module = importlib.import_module("bot")
+    return importlib.reload(module)
+
+
+class DummyBot:
+    def __init__(self):
+        self.sent_stickers = []
+        self.deleted_messages = []
+        self.sent_documents = []
+        self._next_id = 100
+
+    async def send_sticker(self, chat_id, sticker_id):  # pragma: no cover - async stub
+        self.sent_stickers.append((chat_id, sticker_id))
+        self._next_id += 1
+        return SimpleNamespace(message_id=self._next_id)
+
+    async def delete_message(self, chat_id, message_id):  # pragma: no cover - async stub
+        self.deleted_messages.append((chat_id, message_id))
+
+    async def send_document(self, chat_id, document):  # pragma: no cover - async stub
+        self.sent_documents.append((chat_id, getattr(document, "name", None)))
+
+
+def test_wait_sticker_replace(bot_module, tmp_path):
+    bot = DummyBot()
+    ctx = SimpleNamespace(bot=bot)
+
+    wait_id = asyncio.run(bot_module.show_wait_sticker(ctx, 123, "sticker"))
+    assert bot.sent_stickers == [(123, "sticker")]
+
+    file_path = tmp_path / "result.mp4"
+    file_path.write_bytes(b"data")
+
+    asyncio.run(bot_module.replace_wait_with_docs(ctx, 123, wait_id, [str(file_path)]))
+
+    assert bot.deleted_messages == [(123, wait_id)]
+    assert bot.sent_documents == [(123, str(file_path))]

--- a/texts.py
+++ b/texts.py
@@ -11,7 +11,7 @@ COMMON_TEXTS_RU = {
     "topup.menu.stars": "💎 Оплатить звёздами",
     "topup.menu.yookassa": "💳 Оплатить картой (ЮKassa)",
     "topup.menu.back": "⬅️ Назад",
-    "topup.inline.open": "Пополнить баланс",
+    "topup.inline.open": "💳 Пополнить баланс",
     "topup.inline.back": "⬅️ Назад в меню",
     "topup.yookassa.pack_1": "Пакет 1 (+X1💎)",
     "topup.yookassa.pack_2": "Пакет 2 (+X2💎)",

--- a/utils/input_state.py
+++ b/utils/input_state.py
@@ -5,7 +5,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, Mapping, Optional, Tuple
+from typing import Any, Dict, Mapping, Optional, Tuple, Literal
 
 import time
 
@@ -29,6 +29,7 @@ class WaitKind(str, Enum):
     SUNO_STYLE = "suno_style"
     SUNO_LYRICS = "suno_lyrics"
     MJ_PROMPT = "mj_prompt"
+    SORA2_PROMPT = "sora2_prompt"
 
 
 def classify_wait_input(text: Optional[str]) -> Tuple[bool, Optional[str]]:
@@ -227,6 +228,7 @@ def set_wait(
         "suno_style",
         "suno_lyrics",
         "banana_prompt",
+        "sora2_prompt",
     ],
     card_msg_id: Optional[int],
     *,


### PR DESCRIPTION
## Summary
- consolidate the video generation menu into a single card, add wait-sticker handling, lock guards, and a footer keyboard for results
- integrate the Sora 2 text- and image-to-video flows through KIE with webhook + polling support and supporting settings/client helpers
- add regression tests covering the video menu, user locks, wait sticker replacement, Sora 2 payload construction, and balance-block messaging

## Testing
- pytest tests/test_video_menu_single_card.py tests/test_user_lock_no_duplicates.py tests/test_wait_sticker_replace.py tests/test_sora2_payloads.py tests/test_balance_block.py

------
https://chatgpt.com/codex/tasks/task_e_68dfee0a1248832296410447f95aeaac