### PR TITLE
Add robust Sora2 polling and delivery flow

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -81,6 +81,10 @@ class _AppSettings(BaseModel):
     SORA2_GEN_PATH: str = Field(default="https://api.kie.ai/api/v1/jobs/createTask")
     SORA2_STATUS_PATH: str = Field(default="https://api.kie.ai/api/v1/jobs/queryTask")
     SORA2_WAIT_STICKER_ID: str = Field(default="5375464961822695044")
+    SORA2_TIMEOUT_CONNECT: int = Field(default=20, ge=1, le=120)
+    SORA2_TIMEOUT_READ: int = Field(default=30, ge=1, le=300)
+    SORA2_TIMEOUT_WRITE: int = Field(default=30, ge=1, le=300)
+    SORA2_TIMEOUT_POOL: int = Field(default=10, ge=1, le=120)
 
     YOOKASSA_SHOP_ID: Optional[str] = Field(default=None)
     YOOKASSA_SECRET_KEY: Optional[str] = Field(default=None)
@@ -297,10 +301,10 @@ SORA2 = {
     "CALLBACK_URL": f"{PUBLIC_BASE_URL}/sora2-callback" if PUBLIC_BASE_URL else None,
     "API_KEY": SORA2_API_KEY,
 }
-SORA2_TIMEOUT_CONNECT = int(os.getenv("SORA2_TIMEOUT_CONNECT", 20))
-SORA2_TIMEOUT_READ = int(os.getenv("SORA2_TIMEOUT_READ", 30))
-SORA2_TIMEOUT_WRITE = int(os.getenv("SORA2_TIMEOUT_WRITE", 30))
-SORA2_TIMEOUT_POOL = int(os.getenv("SORA2_TIMEOUT_POOL", 10))
+SORA2_TIMEOUT_CONNECT = int(_APP_SETTINGS.SORA2_TIMEOUT_CONNECT)
+SORA2_TIMEOUT_READ = int(_APP_SETTINGS.SORA2_TIMEOUT_READ)
+SORA2_TIMEOUT_WRITE = int(_APP_SETTINGS.SORA2_TIMEOUT_WRITE)
+SORA2_TIMEOUT_POOL = int(_APP_SETTINGS.SORA2_TIMEOUT_POOL)
 
 BANANA_SEND_AS_DOCUMENT = bool(_APP_SETTINGS.BANANA_SEND_AS_DOCUMENT)
 MJ_SEND_AS_ALBUM = bool(_APP_SETTINGS.MJ_SEND_AS_ALBUM)

--- a/tests/test_sora2_callback_replace.py
+++ b/tests/test_sora2_callback_replace.py
@@ -124,6 +124,8 @@ def test_sora2_callback_replaces_sticker(monkeypatch, bot_module, tmp_path):
         "price": 0,
         "service": "SORA2_TTV",
         "mode": "sora2_ttv",
+        "duration": bot_module.SORA2_DEFAULT_TTV_DURATION,
+        "resolution": bot_module.SORA2_DEFAULT_TTV_RESOLUTION,
     }
 
     asyncio.run(
@@ -142,7 +144,11 @@ def test_sora2_callback_replaces_sticker(monkeypatch, bot_module, tmp_path):
     assert bot.send_document_calls, "document was not sent"
     doc_call = bot.send_document_calls[0]
     assert doc_call["chat_id"] == chat_id
-    assert "Готово" in (doc_call["caption"] or "")
+    expected_caption = (
+        f"Sora 2 • Text-to-Video • {bot_module.SORA2_DEFAULT_TTV_DURATION}s "
+        f"• {bot_module.SORA2_DEFAULT_TTV_RESOLUTION.replace('x', '×')}"
+    )
+    assert doc_call["caption"] == expected_caption
     buttons = doc_call["reply_markup"].inline_keyboard
     assert any(btn.text == "🔁 Сгенерировать ещё" for row in buttons for btn in row)
     assert not bot.send_video_calls
@@ -180,6 +186,8 @@ def test_sora2_callback_fallback_to_send(monkeypatch, bot_module, tmp_path):
         "price": 0,
         "service": "SORA2_TTV",
         "mode": "sora2_ttv",
+        "duration": bot_module.SORA2_DEFAULT_TTV_DURATION,
+        "resolution": bot_module.SORA2_DEFAULT_TTV_RESOLUTION,
     }
 
     asyncio.run(

--- a/tests/test_sora2_payloads.py
+++ b/tests/test_sora2_payloads.py
@@ -134,13 +134,21 @@ def test_sora2_payload_text_to_video(monkeypatch, bot_module, ctx):
 
     assert payloads, "payload not built"
     payload = payloads[0]
+    assert payload["task_type"] == "text2video"
     assert payload["model"] == "sora2-text-to-video"
     assert payload["input"]["aspect_ratio"] == "4:5"
     assert payload["input"]["prompt"] == "Epic scene"
-    assert payload["input"]["quality"] == "standard"
+    assert "quality" not in payload["input"]
     assert "image_urls" not in payload["input"]
-    assert saved_meta.get("extra", {}).get("image_urls") == []
-    assert saved_meta.get("extra", {}).get("submit_raw") == {"taskId": "ttv-1"}
+    assert payload["resolution"] == bot_module.SORA2_DEFAULT_TTV_RESOLUTION
+    assert payload["duration"] == bot_module.SORA2_DEFAULT_TTV_DURATION
+    assert payload["audio"] is True
+    extra = saved_meta.get("extra", {})
+    assert extra.get("image_urls") == []
+    assert extra.get("submit_raw") == {"taskId": "ttv-1"}
+    assert extra.get("duration") == bot_module.SORA2_DEFAULT_TTV_DURATION
+    assert extra.get("resolution") == bot_module.SORA2_DEFAULT_TTV_RESOLUTION
+    assert extra.get("audio") is True
     bot_module.ACTIVE_TASKS.clear()
 
 
@@ -190,12 +198,20 @@ def test_sora2_payload_image_to_video(monkeypatch, bot_module, ctx):
     assert upload_calls == [["https://img.one/a.png", "https://img.two/b.png"]]
     assert payloads, "payload not built"
     payload = payloads[0]
+    assert payload["task_type"] == "image2video"
     assert payload["model"] == "sora2-image-to-video"
     assert payload["input"]["aspect_ratio"] == "16:9"
     assert payload["input"].get("prompt", "") == ""
-    assert payload["input"]["quality"] == "standard"
+    assert "quality" not in payload["input"]
     assert payload["input"]["image_urls"] == ["https://uploads.example/0", "https://uploads.example/1"]
-    assert saved_meta.get("extra", {}).get("image_urls") == payload["input"]["image_urls"]
-    assert saved_meta.get("extra", {}).get("submit_raw") == {"taskId": "itv-42"}
+    assert payload["resolution"] == bot_module.SORA2_DEFAULT_ITV_RESOLUTION
+    assert payload["duration"] == bot_module.SORA2_DEFAULT_ITV_DURATION
+    assert "audio" not in payload
+    extra = saved_meta.get("extra", {})
+    assert extra.get("image_urls") == payload["input"]["image_urls"]
+    assert extra.get("submit_raw") == {"taskId": "itv-42"}
+    assert extra.get("duration") == bot_module.SORA2_DEFAULT_ITV_DURATION
+    assert extra.get("resolution") == bot_module.SORA2_DEFAULT_ITV_RESOLUTION
+    assert extra.get("audio") is None
     bot_module.ACTIVE_TASKS.clear()
 

--- a/tests/test_sora2_start_button.py
+++ b/tests/test_sora2_start_button.py
@@ -154,13 +154,16 @@ def test_sora2_start_button(monkeypatch, bot_module):
 
     assert payloads, "payload was not sent"
     payload = payloads[0]
+    assert payload["task_type"] == "text2video"
     assert payload["model"] == "sora2-text-to-video"
     assert payload["input"]["aspect_ratio"] == "9:16"
     assert payload["input"]["prompt"] == "Make a movie"
-    assert payload["input"]["quality"] == "standard"
+    assert "quality" not in payload["input"]
     assert "image_urls" not in payload["input"]
+    assert payload["resolution"] == bot_module.SORA2_DEFAULT_TTV_RESOLUTION
+    assert payload["duration"] == bot_module.SORA2_DEFAULT_TTV_DURATION
+    assert payload["audio"] is True
     assert payload["callBackUrl"].endswith("/sora2-callback")
-    assert "aspect_ratio" not in payload
 
     assert ctx.bot.sent_stickers == [(555, bot_module.SORA2_WAIT_STICKER_ID)]
     assert ensure_calls
@@ -172,7 +175,11 @@ def test_sora2_start_button(monkeypatch, bot_module):
     assert saved_meta.get("extra", {}).get("wait_message_id") == state.get("sora2_wait_msg_id")
     assert saved_meta.get("extra", {}).get("aspect_ratio") == "9:16"
     assert saved_meta.get("extra", {}).get("image_urls") == []
-    assert saved_meta.get("extra", {}).get("submit_raw") == {"taskId": "task-123"}
+    extra = saved_meta.get("extra", {})
+    assert extra.get("submit_raw") == {"taskId": "task-123"}
+    assert extra.get("duration") == bot_module.SORA2_DEFAULT_TTV_DURATION
+    assert extra.get("resolution") == bot_module.SORA2_DEFAULT_TTV_RESOLUTION
+    assert extra.get("audio") is True
 
     bot_module.ACTIVE_TASKS.clear()
 

--- a/tests/test_sora2_success_finalize.py
+++ b/tests/test_sora2_success_finalize.py
@@ -69,6 +69,8 @@ def test_sora2_success_releases_lock(tmp_path, monkeypatch, bot_module):
         "mode": "sora2_ttv",
         "wait_message_id": 333,
         "chat_id": 999,
+        "duration": bot_module.SORA2_DEFAULT_TTV_DURATION,
+        "resolution": bot_module.SORA2_DEFAULT_TTV_RESOLUTION,
     }
 
     result_payload = {"video_url": "https://example.com/result.mp4"}
@@ -89,5 +91,9 @@ def test_sora2_success_releases_lock(tmp_path, monkeypatch, bot_module):
     assert ctx.bot.sent_docs
     sent_doc = ctx.bot.sent_docs[0]
     assert sent_doc["chat_id"] == 999
-    assert "Готово" in sent_doc["caption"]
+    expected_caption = (
+        f"Sora 2 • Text-to-Video • {bot_module.SORA2_DEFAULT_TTV_DURATION}s "
+        f"• {bot_module.SORA2_DEFAULT_TTV_RESOLUTION.replace('x', '×')}"
+    )
+    assert sent_doc["caption"] == expected_caption
     assert bot_module.ACTIVE_TASKS.get(999) is None


### PR DESCRIPTION
## Summary
- update the Sora 2 start flow to apply default duration/resolution, persist extra metadata, and caption results via a safe edit/send helper
- expand the Sora 2 HTTP client with centralized timeouts, retry logic, and stricter payload handling, with matching configuration support
- refresh Sora 2 unit tests to cover the new payloads, captions, and timeout wiring

## Testing
- `pytest tests/test_sora2_start_button.py tests/test_sora2_payloads.py tests/test_sora2_timeout.py tests/test_sora2_success_finalize.py tests/test_sora2_callback_replace.py`
- `pytest tests/test_sora2_no_taskid_refund.py`


------
https://chatgpt.com/codex/tasks/task_e_68e03d62bb788322a7fdb15fcf76c566