### PR TITLE
Fix Sora2 integration for the updated KIE API

### DIFF
--- a/tests/test_sora2_payloads.py
+++ b/tests/test_sora2_payloads.py
@@ -134,21 +134,19 @@ def test_sora2_payload_text_to_video(monkeypatch, bot_module, ctx):
 
     assert payloads, "payload not built"
     payload = payloads[0]
-    assert payload["task_type"] == "text2video"
-    assert payload["model"] == "sora2-text-to-video"
-    assert payload["input"]["aspect_ratio"] == "4:5"
+    assert "task_type" not in payload
+    assert payload["model"] == "sora-2-text-to-video"
+    assert payload["input"]["aspect_ratio"] == "portrait"
     assert payload["input"]["prompt"] == "Epic scene"
-    assert "quality" not in payload["input"]
+    assert payload["input"]["quality"] == "standard"
     assert "image_urls" not in payload["input"]
-    assert payload["resolution"] == bot_module.SORA2_DEFAULT_TTV_RESOLUTION
-    assert payload["duration"] == bot_module.SORA2_DEFAULT_TTV_DURATION
-    assert payload["audio"] is True
     extra = saved_meta.get("extra", {})
     assert extra.get("image_urls") == []
     assert extra.get("submit_raw") == {"taskId": "ttv-1"}
     assert extra.get("duration") == bot_module.SORA2_DEFAULT_TTV_DURATION
     assert extra.get("resolution") == bot_module.SORA2_DEFAULT_TTV_RESOLUTION
     assert extra.get("audio") is True
+    assert extra.get("quality") == "standard"
     bot_module.ACTIVE_TASKS.clear()
 
 
@@ -198,14 +196,14 @@ def test_sora2_payload_image_to_video(monkeypatch, bot_module, ctx):
     assert upload_calls == [["https://img.one/a.png", "https://img.two/b.png"]]
     assert payloads, "payload not built"
     payload = payloads[0]
-    assert payload["task_type"] == "image2video"
-    assert payload["model"] == "sora2-image-to-video"
-    assert payload["input"]["aspect_ratio"] == "16:9"
+    assert "task_type" not in payload
+    assert payload["model"] == "sora-2-image-to-video"
+    assert payload["input"]["aspect_ratio"] == "landscape"
     assert payload["input"].get("prompt", "") == ""
-    assert "quality" not in payload["input"]
+    assert payload["input"]["quality"] == "standard"
     assert payload["input"]["image_urls"] == ["https://uploads.example/0", "https://uploads.example/1"]
-    assert payload["resolution"] == bot_module.SORA2_DEFAULT_ITV_RESOLUTION
-    assert payload["duration"] == bot_module.SORA2_DEFAULT_ITV_DURATION
+    assert "resolution" not in payload
+    assert "duration" not in payload
     assert "audio" not in payload
     extra = saved_meta.get("extra", {})
     assert extra.get("image_urls") == payload["input"]["image_urls"]
@@ -213,5 +211,6 @@ def test_sora2_payload_image_to_video(monkeypatch, bot_module, ctx):
     assert extra.get("duration") == bot_module.SORA2_DEFAULT_ITV_DURATION
     assert extra.get("resolution") == bot_module.SORA2_DEFAULT_ITV_RESOLUTION
     assert extra.get("audio") is None
+    assert extra.get("quality") == "standard"
     bot_module.ACTIVE_TASKS.clear()
 

--- a/tests/test_sora2_start_button.py
+++ b/tests/test_sora2_start_button.py
@@ -154,15 +154,15 @@ def test_sora2_start_button(monkeypatch, bot_module):
 
     assert payloads, "payload was not sent"
     payload = payloads[0]
-    assert payload["task_type"] == "text2video"
-    assert payload["model"] == "sora2-text-to-video"
-    assert payload["input"]["aspect_ratio"] == "9:16"
+    assert "task_type" not in payload
+    assert payload["model"] == "sora-2-text-to-video"
+    assert payload["input"]["aspect_ratio"] == "portrait"
     assert payload["input"]["prompt"] == "Make a movie"
-    assert "quality" not in payload["input"]
+    assert payload["input"]["quality"] == "standard"
     assert "image_urls" not in payload["input"]
-    assert payload["resolution"] == bot_module.SORA2_DEFAULT_TTV_RESOLUTION
-    assert payload["duration"] == bot_module.SORA2_DEFAULT_TTV_DURATION
-    assert payload["audio"] is True
+    assert "resolution" not in payload
+    assert "duration" not in payload
+    assert "audio" not in payload
     assert payload["callBackUrl"].endswith("/sora2-callback")
 
     assert ctx.bot.sent_stickers == [(555, bot_module.SORA2_WAIT_STICKER_ID)]
@@ -180,6 +180,7 @@ def test_sora2_start_button(monkeypatch, bot_module):
     assert extra.get("duration") == bot_module.SORA2_DEFAULT_TTV_DURATION
     assert extra.get("resolution") == bot_module.SORA2_DEFAULT_TTV_RESOLUTION
     assert extra.get("audio") is True
+    assert extra.get("quality") == "standard"
 
     bot_module.ACTIVE_TASKS.clear()
 

--- a/tests/test_sora2_timeout.py
+++ b/tests/test_sora2_timeout.py
@@ -52,12 +52,12 @@ def test_sora2_client_uses_configured_timeout(monkeypatch):
 
         def post(self, url, headers=None, json=None):
             if "createTask" in url:
-                return DummyResponse({"taskId": "abc"})
+                return DummyResponse({"code": 200, "data": {"taskId": "abc"}})
             return DummyResponse({"status": "success", "result": {}})
 
     monkeypatch.setattr(httpx, "Client", DummyClient)
 
-    result = sora2_client.create_task({"task_type": "text2video", "input": {"prompt": "hi"}})
+    result = sora2_client.create_task({"model": "sora-2-text-to-video", "input": {"prompt": "hi"}})
     assert result.task_id == "abc"
 
     timeout = captured["timeout"]


### PR DESCRIPTION
## Summary
- align the Sora2 HTTP client with the new createTask payload schema and recordInfo status endpoint
- update bot-side payload construction, polling backoff, and error handling to match the revised Sora 2 contract
- refresh the Sora2 unit tests to cover the new payload format and behaviours

## Testing
- pytest tests/test_sora2_payloads.py tests/test_sora2_start_button.py tests/test_sora2_timeout.py tests/test_sora2_no_taskid_refund.py tests/test_sora2_success_finalize.py tests/test_sora2_callback_replace.py

------
https://chatgpt.com/codex/tasks/task_e_68e04f32e318832298f9db5b7191f431