### PR TITLE
Implement large tile home menu and remove quick actions

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -192,7 +192,6 @@ from keyboards import (
     suno_start_disabled_keyboard,
     kb_ai_dialog_modes,
     kb_profile_topup_entry,
-    menu_bottom_unified,
     menu_pay_unified,
 )
 from texts import (
@@ -206,7 +205,6 @@ from texts import (
     TXT_KB_AI_DIALOG,
     TXT_KB_PROFILE,
     TXT_KNOWLEDGE_INTRO,
-    TXT_MENU_TITLE,
     TXT_PROFILE_TITLE,
     TXT_TOPUP_CHOOSE,
     TXT_PAY_CRYPTO_OPEN_LINK,
@@ -2438,7 +2436,6 @@ async def chat_command(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         )
     except Exception as exc:
         log.warning("chat.command_hint_failed | chat=%s err=%s", chat.id, exc)
-    await _show_bottom_menu(chat.id, ctx)
 
 
 async def chat_reset_command(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
@@ -4736,9 +4733,6 @@ WELCOME = (
 )
 
 
-MAIN_MENU_TEXT = f"*{TXT_MENU_TITLE}*\nВыберите, что хотите сделать:"
-
-
 MENU_BTN_VIDEO = "🎬 Генерация видео"
 MENU_BTN_IMAGE = "🎨 Генерация изображений"
 MENU_BTN_SUNO = "🎵 Генерация музыки"
@@ -4749,7 +4743,6 @@ MENU_BTN_SUPPORT = "🆘 ПОДДЕРЖКА"
 BALANCE_CARD_STATE_KEY = "last_ui_msg_id_balance"
 LEDGER_PAGE_SIZE = 10
 
-BOTTOM_MENU_TEXT = "👇 Быстрые действия"
 BOTTOM_MENU_STATE_KEY = "last_ui_msg_id_bottom"
 
 VIDEO_MENU_TEXT = "🎬 Выберите тип генерации видео:"
@@ -5011,34 +5004,6 @@ async def safe_edit_or_send_menu(
     return None
 
 
-async def _show_bottom_menu(
-    chat_id: int,
-    ctx: ContextTypes.DEFAULT_TYPE,
-    *,
-    state_dict: Optional[Dict[str, Any]] = None,
-    text: str = BOTTOM_MENU_TEXT,
-) -> Optional[int]:
-    state_obj = state_dict if isinstance(state_dict, dict) else state(ctx)
-    try:
-        return await safe_edit_or_send_menu(
-            ctx,
-            chat_id=chat_id,
-            text=text,
-            reply_markup=menu_bottom_unified(),
-            state_key=BOTTOM_MENU_STATE_KEY,
-            state_dict=state_obj,
-            parse_mode=ParseMode.HTML,
-            disable_web_page_preview=True,
-            log_label="ui.bottom_menu",
-        )
-    except Exception as exc:  # pragma: no cover - network issues
-        log.debug(
-            "ui.bottom_menu.error",
-            extra={"chat_id": chat_id, "error": str(exc)},
-        )
-        return None
-
-
 async def refresh_suno_card(
     ctx: ContextTypes.DEFAULT_TYPE,
     chat_id: int,
@@ -5056,7 +5021,6 @@ async def refresh_suno_card(
         state_key=state_key,
         force_new=force_new,
     )
-    await _show_bottom_menu(chat_id, ctx, state_dict=state_dict)
     return result
 
 
@@ -5263,6 +5227,12 @@ async def show_main_menu(chat_id: int, ctx: ContextTypes.DEFAULT_TYPE) -> Option
 
 
 _HUB_ACTION_ALIASES: Dict[str, str] = {
+    "home:profile": "balance",
+    "home:kb": "knowledge",
+    "home:photo": "image",
+    "home:music": "music",
+    "home:video": "video",
+    "home:chat": "ai_modes",
     CB_MAIN_PROFILE: "balance",
     CB_PROFILE_BACK: "balance",
     CB_MAIN_BACK: "root",
@@ -5456,7 +5426,6 @@ async def hub_router(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
             )
         except Exception as exc:  # pragma: no cover - network issues
             log.warning("hub.chat_send_failed | chat=%s err=%s", chat_id, exc)
-        await _show_bottom_menu(chat_id, ctx, state_dict=s)
         return
 
     if action == "balance":
@@ -6382,7 +6351,6 @@ async def _update_mj_card(chat_id: int, ctx: ContextTypes.DEFAULT_TYPE, text: st
         s["_last_text_mj"] = text
     elif force:
         s["_last_text_mj"] = None
-    await _show_bottom_menu(chat_id, ctx, state_dict=s)
 
 async def show_mj_format_card(
     chat_id: int,
@@ -7789,7 +7757,6 @@ async def suno_entry(
     save_suno_state(ctx, suno_state_obj)
     s["suno_state"] = suno_state_obj.to_dict()
     await _music_show_main_menu(chat_id, ctx, s)
-    await _show_bottom_menu(chat_id, ctx, state_dict=s)
 
 
 async def _suno_notify(
@@ -12642,14 +12609,6 @@ async def handle_menu(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         clear_wait(user_id)
     await show_emoji_hub_for_chat(chat_id, ctx, user_id=user_id, replace=True)
 
-    menu_message = await safe_send(update, ctx, MAIN_MENU_TEXT, reply_markup=main_menu_kb())
-    if isinstance(menu_message, Message):
-        try:
-            s["last_ui_msg_id_menu"] = menu_message.message_id
-        except Exception:
-            pass
-
-
 async def start(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     await ensure_user_record(update)
     uid = update.effective_user.id if update.effective_user else None
@@ -13562,7 +13521,6 @@ async def show_banana_card(
         s["_last_text_banana"] = text
     else:
         s["_last_text_banana"] = None
-    await _show_bottom_menu(chat_id, ctx, state_dict=s)
 
 async def banana_entry(chat_id: int, ctx: ContextTypes.DEFAULT_TYPE, *, force_new: bool = True) -> None:
     s = state(ctx)
@@ -13677,7 +13635,6 @@ async def show_veo_card(
         s["_last_text_veo"] = text
     else:
         s["_last_text_veo"] = None
-    await _show_bottom_menu(chat_id, ctx, state_dict=s)
 
 async def veo_entry(chat_id: int, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     s = state(ctx)

--- a/handlers/prompt_master_handler.py
+++ b/handlers/prompt_master_handler.py
@@ -21,7 +21,6 @@ from keyboards import (
     CB_PM_MENU,
     CB_PM_PREFIX,
     CB_PM_SWITCH,
-    menu_bottom_unified,
     prompt_master_keyboard,
     prompt_master_mode_keyboard,
     prompt_master_result_keyboard,
@@ -48,8 +47,6 @@ PM_ROOT_TEXT = {
     "ru": "🧠 <b>Prompt-Master</b>\nВыберите движок, под который нужно подготовить промпт.",
     "en": "🧠 <b>Prompt-Master</b>\nPick the engine you want a perfect prompt for.",
 }
-
-PM_BOTTOM_MENU_TEXT = "👇 Быстрые действия"
 
 PM_ENGINE_HINTS = {
     "veo": {
@@ -169,50 +166,6 @@ def _store_prompt(chat_id: int, engine: str, payload: PMResult) -> None:
     _LAST_PROMPTS[(chat_id, engine)] = payload
 
 
-async def _ensure_bottom_menu(
-    context: ContextTypes.DEFAULT_TYPE,
-    chat_id: Optional[int],
-) -> None:
-    if chat_id is None:
-        return
-    user_data = getattr(context, "user_data", None)
-    if not isinstance(user_data, dict):
-        return
-    shared_state = user_data.get("state")
-    if not isinstance(shared_state, dict):
-        shared_state = {}
-        user_data["state"] = shared_state
-    message_id = shared_state.get("last_ui_msg_id_bottom")
-    markup = menu_bottom_unified()
-    text = PM_BOTTOM_MENU_TEXT
-    if isinstance(message_id, int):
-        try:
-            await context.bot.edit_message_text(
-                chat_id=chat_id,
-                message_id=message_id,
-                text=text,
-                reply_markup=markup,
-                disable_web_page_preview=True,
-            )
-            return
-        except BadRequest:
-            shared_state["last_ui_msg_id_bottom"] = None
-        except Exception:
-            logger.debug("prompt_master.bottom_menu_edit_failed", exc_info=True)
-            shared_state["last_ui_msg_id_bottom"] = None
-    try:
-        message = await context.bot.send_message(
-            chat_id=chat_id,
-            text=text,
-            reply_markup=markup,
-            disable_web_page_preview=True,
-        )
-    except Exception:
-        logger.debug("prompt_master.bottom_menu_send_failed", exc_info=True)
-        return
-    shared_state["last_ui_msg_id_bottom"] = getattr(message, "message_id", None)
-
-
 def get_pm_prompt(chat_id: int, engine: str) -> Optional[PMResult]:
     return _LAST_PROMPTS.get((chat_id, engine))
 
@@ -280,7 +233,6 @@ async def _upsert_card(
                 disable_web_page_preview=True,
                 reply_markup=keyboard,
             )
-            await _ensure_bottom_menu(context, chat_id)
             return
         except BadRequest:
             state["card_msg_id"] = None
@@ -290,7 +242,6 @@ async def _upsert_card(
     message = await safe_send(context.bot, chat_id, safe_text, reply_markup=keyboard)
     if message:
         state["card_msg_id"] = message.message_id
-    await _ensure_bottom_menu(context, chat_id)
 
 
 async def _edit_with_fallback(
@@ -313,7 +264,7 @@ async def _edit_with_fallback(
             reply_markup=reply_markup,
         )
         if state is not None:
-            await _ensure_bottom_menu(context, chat_id)
+            state["card_msg_id"] = message_id
         return
     except BadRequest as exc:
         message = str(exc).lower()
@@ -330,8 +281,7 @@ async def _edit_with_fallback(
             disable_web_page_preview=True,
         )
         if state is not None:
-            await _ensure_bottom_menu(context, chat_id)
-
+            state["card_msg_id"] = message_id
 
 async def _safe_delete(message) -> None:
     if message is None:
@@ -365,14 +315,13 @@ async def _handle_render_failure(
                 reply_markup=keyboard,
             )
             if state is not None:
-                await _ensure_bottom_menu(context, status_message.chat_id)
+                state["card_msg_id"] = status_message.message_id
         except Exception:
             logger.exception("pm.card.fail", extra={"engine": engine})
     elif chat_id is not None:
         await send_html_with_fallback(context.bot, chat_id, safe_error, reply_markup=keyboard)
         if state is not None:
-            await _ensure_bottom_menu(context, chat_id)
-
+            state["card_msg_id"] = None
 
 async def _notify_failure(
     context: ContextTypes.DEFAULT_TYPE,
@@ -749,7 +698,6 @@ async def prompt_master_text_handler(update: Update, context: ContextTypes.DEFAU
                     await _safe_delete(message)
             else:
                 logger.error("pm.card.fail", extra={"engine": engine})
-            await _ensure_bottom_menu(context, chat_id)
     finally:
         if chat_id is not None:
             await delete_wait_sticker(context, chat_id=chat_id)
@@ -772,7 +720,6 @@ async def prompt_master_reset(update: Update, context: ContextTypes.DEFAULT_TYPE
             f"{text}\n\n{PM_ROOT_TEXT.get(lang, PM_ROOT_TEXT['en'])}",
             reply_markup=keyboard,
         )
-        await _ensure_bottom_menu(context, chat_id)
 
 
 prompt_master_handle_text = prompt_master_text_handler

--- a/keyboards.py
+++ b/keyboards.py
@@ -15,6 +15,22 @@ EMOJI = {
 }
 
 
+def kb_home_menu() -> InlineKeyboardMarkup:
+    rows = [
+        [InlineKeyboardButton(text="👥 Профиль", callback_data="home:profile")],
+        [InlineKeyboardButton(text="📚 База знаний", callback_data="home:kb")],
+        [
+            InlineKeyboardButton(text="📸 Режим фото", callback_data="home:photo"),
+            InlineKeyboardButton(text="🎧 Режим музыки", callback_data="home:music"),
+        ],
+        [
+            InlineKeyboardButton(text="📹 Режим видео", callback_data="home:video"),
+            InlineKeyboardButton(text="🧠 Диалог с ИИ", callback_data="home:chat"),
+        ],
+    ]
+    return InlineKeyboardMarkup(rows)
+
+
 def _row(*buttons: InlineKeyboardButton) -> list[list[InlineKeyboardButton]]:
     return [list(buttons)]
 

--- a/telegram_utils.py
+++ b/telegram_utils.py
@@ -31,7 +31,7 @@ from telegram.constants import ParseMode
 from telegram.error import BadRequest, Forbidden, NetworkError, RetryAfter, TelegramError, TimedOut
 
 from metrics import telegram_send_total
-from keyboards import CB_VIDEO_MENU, kb_main_menu_profile_first
+from keyboards import CB_VIDEO_MENU, kb_home_menu
 
 log = logging.getLogger("telegram.utils")
 
@@ -176,25 +176,22 @@ def sanitize_html(text: str) -> str:
 def build_hub_text(user_balance: int) -> str:
     """Render the main hub text with the current balance."""
 
-    from texts import TXT_MENU_TITLE
-
     try:
         balance_value = int(user_balance)
     except (TypeError, ValueError):
         balance_value = 0
 
     return (
-        "👋 Добро пожаловать!\n\n"
-        f"{TXT_MENU_TITLE}\n"
-        f"💎 Ваш баланс: {balance_value}\n"
-        f"📈 Больше идей и примеров — [канал с промптами]({_HUB_PROMPTS_URL})\n\n"
+        "👋 Добро пожаловать!\n"
+        f"💎 Ваш баланс: {balance_value}💎\n"
+        f"🧾 Больше идей и примеров — [канал с промптами]({_HUB_PROMPTS_URL})\n\n"
         "Выберите, что хотите сделать:"
     )
 
 
 def build_hub_keyboard() -> InlineKeyboardMarkup:
     """Return a compact 2x3 inline keyboard for the emoji hub."""
-    return kb_main_menu_profile_first()
+    return kb_home_menu()
 
 
 def _extract_status(exc: BaseException) -> Optional[int]:

--- a/tests/test_hub_menu.py
+++ b/tests/test_hub_menu.py
@@ -5,24 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from keyboards import (
-    CB_MAIN_AI_DIALOG,
-    CB_MAIN_KNOWLEDGE,
-    CB_MAIN_MUSIC,
-    CB_MAIN_PHOTO,
-    CB_MAIN_PROFILE,
-    CB_MAIN_VIDEO,
-)
 from telegram_utils import build_hub_keyboard, build_hub_text
-from texts import (
-    TXT_KB_AI_DIALOG,
-    TXT_KB_KNOWLEDGE,
-    TXT_KB_MUSIC,
-    TXT_KB_PHOTO,
-    TXT_KB_PROFILE,
-    TXT_KB_VIDEO,
-    TXT_MENU_TITLE,
-)
 
 
 def test_build_hub_keyboard_layout():
@@ -31,29 +14,36 @@ def test_build_hub_keyboard_layout():
 
     assert [len(row) for row in rows] == [1, 1, 2, 2]
 
-    expected = [
-        (TXT_KB_PROFILE, CB_MAIN_PROFILE),
-        (TXT_KB_KNOWLEDGE, CB_MAIN_KNOWLEDGE),
-        (TXT_KB_PHOTO, CB_MAIN_PHOTO),
-        (TXT_KB_MUSIC, CB_MAIN_MUSIC),
-        (TXT_KB_VIDEO, CB_MAIN_VIDEO),
-        (TXT_KB_AI_DIALOG, CB_MAIN_AI_DIALOG),
+    texts = [button.text for row in rows for button in row]
+    callbacks = [button.callback_data for row in rows for button in row]
+
+    assert texts == [
+        "👥 Профиль",
+        "📚 База знаний",
+        "📸 Режим фото",
+        "🎧 Режим музыки",
+        "📹 Режим видео",
+        "🧠 Диалог с ИИ",
     ]
-
-    actual = [(button.text, button.callback_data) for row in rows for button in row]
-
-    assert actual == expected
+    assert callbacks == [
+        "home:profile",
+        "home:kb",
+        "home:photo",
+        "home:music",
+        "home:video",
+        "home:chat",
+    ]
 
 
 def test_build_hub_text_contains_balance_and_link():
     text = build_hub_text(123)
 
     assert text.startswith("👋 Добро пожаловать!")
-    assert TXT_MENU_TITLE in text
-    assert "💎 Ваш баланс: 123" in text
+    assert "💎 Ваш баланс: 123💎" in text
+    assert "🧾 Больше идей и примеров — [канал с промптами](" in text
+    assert text.strip().endswith("Выберите, что хотите сделать:")
 
     link_marker = "[канал с промптами]("
-    assert link_marker in text
     start = text.index(link_marker) + len(link_marker)
     end = text.index(")", start)
     url = text[start:end]

--- a/tests/test_keyboards_unified.py
+++ b/tests/test_keyboards_unified.py
@@ -1,37 +1,40 @@
-import asyncio
 import os
 import sys
-import types
 from pathlib import Path
 
-import pytest
-
-from telegram import InlineKeyboardMarkup
+from keyboards import kb_home_menu, menu_pay_unified
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
 os.environ.setdefault("LEDGER_BACKEND", "memory")
 
-import bot
-from keyboards import menu_bottom_unified, menu_pay_unified
-from handlers import prompt_master_handler
 
-
-def test_menu_bottom_unified_layout():
-    markup = menu_bottom_unified()
+def test_kb_home_menu_layout():
+    markup = kb_home_menu()
     rows = markup.inline_keyboard
 
-    assert len(rows) == 6
+    assert len(rows) == 4
+    assert [len(row) for row in rows] == [1, 1, 2, 2]
 
     texts = [button.text for row in rows for button in row]
+    callbacks = [button.callback_data for row in rows for button in row]
+
     assert texts == [
-        "🎬 Генерация видео",
-        "🎨 Генерация изображений",
-        "🎵 Генерация музыки",
-        "🧠 Prompt-Master",
-        "💬 Обычный чат",
         "👥 Профиль",
+        "📚 База знаний",
+        "📸 Режим фото",
+        "🎧 Режим музыки",
+        "📹 Режим видео",
+        "🧠 Диалог с ИИ",
+    ]
+    assert callbacks == [
+        "home:profile",
+        "home:kb",
+        "home:photo",
+        "home:music",
+        "home:video",
+        "home:chat",
     ]
 
 
@@ -48,177 +51,3 @@ def test_menu_pay_unified_layout():
         "🔐 Crypto",
         "⬅️ Назад",
     ]
-
-
-class DummyBot:
-    async def send_message(self, *args, **kwargs):
-        return types.SimpleNamespace(message_id=99)
-
-    async def edit_message_text(self, *args, **kwargs):
-        return None
-
-    async def edit_message_reply_markup(self, *args, **kwargs):
-        return None
-
-    async def delete_message(self, *args, **kwargs):
-        return None
-
-
-class DummyCtx:
-    def __init__(self):
-        self.bot = DummyBot()
-        self.user_data = {"state": {}}
-
-
-class DummyChat:
-    def __init__(self, chat_id):
-        self.id = chat_id
-
-
-class DummyUpdate:
-    def __init__(self, chat_id, user_id):
-        self.effective_chat = DummyChat(chat_id)
-        self.effective_user = types.SimpleNamespace(id=user_id)
-
-
-@pytest.mark.parametrize(
-    "callable_name, setup_state",
-    [
-        ("show_veo_card", {"aspect": "16:9", "model": "veo3_fast", "last_prompt": None, "last_image_url": None}),
-        ("show_banana_card", {"banana_images": [], "last_prompt": None}),
-        ("show_mj_format_card", {"aspect": "16:9", "last_prompt": None}),
-    ],
-)
-def test_menu_bottom_called_for_cards(monkeypatch, callable_name, setup_state):
-    ctx = DummyCtx()
-    ctx.user_data["state"].update(setup_state)
-
-    calls = []
-
-    async def fake_safe_edit_or_send_menu(*args, **kwargs):
-        return 1
-
-    async def fake_upsert_card(*args, **kwargs):
-        return 1
-
-    def fake_menu_bottom_unified():
-        calls.append(True)
-        return InlineKeyboardMarkup([])
-
-    monkeypatch.setattr(bot, "safe_edit_or_send_menu", fake_safe_edit_or_send_menu)
-    monkeypatch.setattr(bot, "upsert_card", fake_upsert_card)
-    monkeypatch.setattr(bot, "menu_bottom_unified", fake_menu_bottom_unified)
-
-    def fake_state(context):
-        return context.user_data.setdefault("state", {})
-
-    monkeypatch.setattr(bot, "state", fake_state)
-
-    func = getattr(bot, callable_name)
-
-    async def _run() -> None:
-        await func(1, ctx, force_new=True)
-
-    asyncio.run(_run())
-
-    assert calls
-
-
-def test_menu_bottom_called_for_suno(monkeypatch):
-    ctx = DummyCtx()
-    ctx.user_data["state"].update({})
-
-    calls = []
-
-    async def fake_safe_edit_or_send_menu(*args, **kwargs):
-        return 1
-
-    async def fake_refresh_raw(*args, **kwargs):
-        return 1
-
-    def fake_menu_bottom_unified():
-        calls.append(True)
-        return InlineKeyboardMarkup([])
-
-    monkeypatch.setattr(bot, "safe_edit_or_send_menu", fake_safe_edit_or_send_menu)
-    monkeypatch.setattr(bot, "_refresh_suno_card_raw", fake_refresh_raw)
-    monkeypatch.setattr(bot, "menu_bottom_unified", fake_menu_bottom_unified)
-
-    def fake_state(context):
-        return context.user_data.setdefault("state", {})
-
-    monkeypatch.setattr(bot, "state", fake_state)
-
-    async def _run() -> None:
-        await bot.refresh_suno_card(ctx, 1, ctx.user_data["state"], price=10)
-
-    asyncio.run(_run())
-
-    assert calls
-
-
-def test_menu_bottom_called_for_chat(monkeypatch):
-    ctx = DummyCtx()
-    ctx.user_data.setdefault("state", {})
-
-    calls = []
-
-    async def fake_safe_edit_or_send_menu(*args, **kwargs):
-        return 1
-
-    def fake_menu_bottom_unified():
-        calls.append(True)
-        return InlineKeyboardMarkup([])
-
-    async def fake_safe_send_text(*args, **kwargs):
-        return None
-
-    async def fake_ensure_user_record(update):
-        return None
-
-    def fake_state(context):
-        return context.user_data.setdefault("state", {})
-
-    monkeypatch.setattr(bot, "safe_edit_or_send_menu", fake_safe_edit_or_send_menu)
-    monkeypatch.setattr(bot, "menu_bottom_unified", fake_menu_bottom_unified)
-    monkeypatch.setattr(bot, "safe_send_text", fake_safe_send_text)
-    monkeypatch.setattr(bot, "ensure_user_record", fake_ensure_user_record)
-    monkeypatch.setattr(bot, "set_mode", lambda *args, **kwargs: None)
-    monkeypatch.setattr(bot, "_mode_set", lambda *args, **kwargs: None)
-    monkeypatch.setattr(bot, "state", fake_state)
-
-    update = DummyUpdate(chat_id=1, user_id=2)
-
-    async def _run() -> None:
-        await bot.chat_command(update, ctx)
-
-    asyncio.run(_run())
-
-    assert calls
-
-
-def test_prompt_master_bottom_menu(monkeypatch):
-    calls = []
-
-    def fake_menu_bottom_unified():
-        calls.append(True)
-        return InlineKeyboardMarkup([])
-
-    async def fake_safe_send(*args, **kwargs):
-        return types.SimpleNamespace(message_id=42)
-
-    ctx = DummyCtx()
-    update = DummyUpdate(chat_id=1, user_id=2)
-    state = prompt_master_handler._ensure_state(ctx)
-
-    monkeypatch.setattr(prompt_master_handler, "menu_bottom_unified", fake_menu_bottom_unified)
-    monkeypatch.setattr(prompt_master_handler, "safe_send", fake_safe_send)
-    monkeypatch.setattr(ctx.bot, "send_message", fake_safe_send)
-    monkeypatch.setattr(ctx.bot, "edit_message_text", fake_safe_send)
-
-    async def _run() -> None:
-        await prompt_master_handler._upsert_card(update, ctx, engine="veo", state=state, lang="ru")
-
-    asyncio.run(_run())
-
-    assert calls

--- a/tests/test_prompt_master_ptb.py
+++ b/tests/test_prompt_master_ptb.py
@@ -187,8 +187,6 @@ def test_prompt_master_callback_selects_engine_and_creates_card() -> None:
     assert kwargs["reply_markup"].inline_keyboard == prompt_master_mode_keyboard("ru").inline_keyboard
     assert "<br/>" not in card_html
     assert state["card_msg_id"]
-    bottom_menu = [entry for entry in bot.sent if entry[1] == "👇 Быстрые действия"]
-    assert bottom_menu, "bottom menu should be rendered"
 
 
 def test_prompt_master_text_handler_generates_prompt_and_updates_status() -> None:
@@ -198,7 +196,8 @@ def test_prompt_master_text_handler_generates_prompt_and_updates_status() -> Non
     message = SimpleNamespace(text="futuristic portrait", chat=SimpleNamespace(id=333, type=ChatType.PRIVATE))
     update = SimpleNamespace(message=message, effective_chat=message.chat)
     asyncio.run(prompt_master_text_handler(update, ctx))
-    assert len(bot.sent) >= 3
+    assert len(bot.sent) >= 2
+    assert all(entry[1] != "👇 Быстрые действия" for entry in bot.sent)
     card_entry = next(
         (entry for entry in bot.sent if "<pre><code>" in entry[1]),
         None,
@@ -220,8 +219,6 @@ def test_prompt_master_text_handler_generates_prompt_and_updates_status() -> Non
     assert status_text.startswith("🧠")
     assert status_kwargs["reply_markup"].inline_keyboard == prompt_master_mode_keyboard("en").inline_keyboard
     assert status_kwargs.get("parse_mode") == "HTML"
-    bottom_menu = [entry for entry in bot.sent if entry[1] == "👇 Быстрые действия"]
-    assert bottom_menu, "bottom menu should be rendered"
     # Final edit should include result keyboard
     assert bot.edited, "status message must be edited"
     final_entry = next((entry for entry in bot.edited if "Ready prompt" in entry[2]), None)
@@ -248,7 +245,8 @@ def test_prompt_master_status_message_for_veo() -> None:
     message = SimpleNamespace(text="Два героя спорят у окна во время грозы.", chat=SimpleNamespace(id=555, type=ChatType.PRIVATE))
     update = SimpleNamespace(message=message, effective_chat=message.chat)
     asyncio.run(prompt_master_text_handler(update, ctx))
-    assert len(bot.sent) >= 3
+    assert len(bot.sent) >= 2
+    assert all(entry[1] != "👇 Быстрые действия" for entry in bot.sent)
     status_entry = next(
         (entry for entry in bot.sent if entry[1].startswith("⚙️ Начинаю собирать промпт для VEO")),
         None,


### PR DESCRIPTION
## Summary
- add a dedicated `kb_home_menu` keyboard and update the hub text and keyboard factory to use the new six-tile layout
- drop the quick actions footer across the bot, rewire home callbacks to the existing handlers, and adjust Prompt-Master state handling accordingly
- refresh automated tests to cover the new menu layout and ensure no quick actions are rendered

## Testing
- pytest tests/test_hub_menu.py tests/test_keyboards_unified.py tests/test_prompt_master_ptb.py

------
https://chatgpt.com/codex/tasks/task_e_68e1dc6f3afc8322a876e27443da205b