### PR TITLE
Align reply keyboard navigation with home menu

### DIFF
--- a/keyboards.py
+++ b/keyboards.py
@@ -1,6 +1,11 @@
 from typing import Optional
 
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    KeyboardButton,
+    ReplyKeyboardMarkup,
+)
 
 
 EMOJI = {
@@ -29,6 +34,25 @@ def kb_home_menu() -> InlineKeyboardMarkup:
         ],
     ]
     return InlineKeyboardMarkup(rows)
+
+
+def reply_kb_home() -> ReplyKeyboardMarkup:
+    return ReplyKeyboardMarkup(
+        keyboard=[
+            [KeyboardButton(text="👥 Профиль")],
+            [KeyboardButton(text="📚 База знаний")],
+            [
+                KeyboardButton(text="📸 Режим фото"),
+                KeyboardButton(text="🎧 Режим музыки"),
+            ],
+            [
+                KeyboardButton(text="📹 Режим видео"),
+                KeyboardButton(text="🧠 Диалог с ИИ"),
+            ],
+        ],
+        resize_keyboard=True,
+        is_persistent=True,
+    )
 
 
 def _row(*buttons: InlineKeyboardButton) -> list[list[InlineKeyboardButton]]:

--- a/tests/test_menu_command.py
+++ b/tests/test_menu_command.py
@@ -36,15 +36,11 @@ def test_main_menu_keyboard_layout():
     labels = [[button.text for button in row] for row in rows]
 
     assert labels == [
-        [bot_module.MENU_BTN_VIDEO],
-        [bot_module.MENU_BTN_IMAGE],
-        [bot_module.MENU_BTN_SUNO],
-        [bot_module.MENU_BTN_PM],
-        [bot_module.MENU_BTN_CHAT],
-        [bot_module.MENU_BTN_BALANCE],
+        ["👥 Профиль"],
+        ["📚 База знаний"],
+        ["📸 Режим фото", "🎧 Режим музыки"],
+        ["📹 Режим видео", "🧠 Диалог с ИИ"],
     ]
-    flattened = [text for row in labels for text in row]
-    assert bot_module.MENU_BTN_SUPPORT not in flattened
 
 
 def test_video_menu_keyboard_options():


### PR DESCRIPTION
## Summary
- add a persistent reply keyboard that mirrors the home inline menu entries
- centralize home navigation handling for callbacks, commands, and text aliases while preserving legacy labels
- refresh command registrations and tests to cover the updated menu flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1e289aaec8322b6aa082e5352697e