### PR TITLE
Fix inline main menu callbacks

### DIFF
--- a/keyboards.py
+++ b/keyboards.py
@@ -19,21 +19,33 @@ EMOJI = {
     "pay": "💎",
 }
 
+CB_PROFILE = "mnu:profile"
+CB_KB = "mnu:kb"
+CB_PHOTO = "mnu:photo"
+CB_MUSIC = "mnu:music"
+CB_VIDEO = "mnu:video"
+CB_CHAT = "mnu:chat"
+
+
+def main_menu_kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton(text="👥 Профиль", callback_data=CB_PROFILE)],
+            [InlineKeyboardButton(text="📚 База знаний", callback_data=CB_KB)],
+            [
+                InlineKeyboardButton(text="📸 Режим фото", callback_data=CB_PHOTO),
+                InlineKeyboardButton(text="🎧 Режим музыки", callback_data=CB_MUSIC),
+            ],
+            [
+                InlineKeyboardButton(text="📹 Режим видео", callback_data=CB_VIDEO),
+                InlineKeyboardButton(text="🧠 Диалог с ИИ", callback_data=CB_CHAT),
+            ],
+        ]
+    )
+
 
 def kb_home_menu() -> InlineKeyboardMarkup:
-    rows = [
-        [InlineKeyboardButton(text="👥 Профиль", callback_data="home:profile")],
-        [InlineKeyboardButton(text="📚 База знаний", callback_data="home:kb")],
-        [
-            InlineKeyboardButton(text="📸 Режим фото", callback_data="home:photo"),
-            InlineKeyboardButton(text="🎧 Режим музыки", callback_data="home:music"),
-        ],
-        [
-            InlineKeyboardButton(text="📹 Режим видео", callback_data="home:video"),
-            InlineKeyboardButton(text="🧠 Диалог с ИИ", callback_data="home:chat"),
-        ],
-    ]
-    return InlineKeyboardMarkup(rows)
+    return main_menu_kb()
 
 
 def reply_kb_home() -> ReplyKeyboardMarkup:

--- a/telegram_utils.py
+++ b/telegram_utils.py
@@ -31,7 +31,7 @@ from telegram.constants import ParseMode
 from telegram.error import BadRequest, Forbidden, NetworkError, RetryAfter, TelegramError, TimedOut
 
 from metrics import telegram_send_total
-from keyboards import CB_VIDEO_MENU, kb_home_menu
+from keyboards import CB_VIDEO_MENU, main_menu_kb
 
 log = logging.getLogger("telegram.utils")
 
@@ -191,7 +191,7 @@ def build_hub_text(user_balance: int) -> str:
 
 def build_hub_keyboard() -> InlineKeyboardMarkup:
     """Return a compact 2x3 inline keyboard for the emoji hub."""
-    return kb_home_menu()
+    return main_menu_kb()
 
 
 def _extract_status(exc: BaseException) -> Optional[int]:

--- a/tests/test_hub_menu.py
+++ b/tests/test_hub_menu.py
@@ -26,12 +26,12 @@ def test_build_hub_keyboard_layout():
         "🧠 Диалог с ИИ",
     ]
     assert callbacks == [
-        "home:profile",
-        "home:kb",
-        "home:photo",
-        "home:music",
-        "home:video",
-        "home:chat",
+        "mnu:profile",
+        "mnu:kb",
+        "mnu:photo",
+        "mnu:music",
+        "mnu:video",
+        "mnu:chat",
     ]
 
 

--- a/tests/test_keyboards_unified.py
+++ b/tests/test_keyboards_unified.py
@@ -2,9 +2,11 @@ import os
 import sys
 from pathlib import Path
 
-from keyboards import kb_home_menu, menu_pay_unified
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+from keyboards import kb_home_menu, menu_pay_unified
 
 os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
 os.environ.setdefault("LEDGER_BACKEND", "memory")
@@ -29,12 +31,12 @@ def test_kb_home_menu_layout():
         "🧠 Диалог с ИИ",
     ]
     assert callbacks == [
-        "home:profile",
-        "home:kb",
-        "home:photo",
-        "home:music",
-        "home:video",
-        "home:chat",
+        "mnu:profile",
+        "mnu:kb",
+        "mnu:photo",
+        "mnu:music",
+        "mnu:video",
+        "mnu:chat",
     ]
 
 


### PR DESCRIPTION
## Summary
- introduce short `mnu:` callback constants and a reusable inline main menu keyboard
- route the new callbacks through the hub router with logging and avoid auto-opening the reply keyboard
- update helpers and tests to reflect the new callback identifiers

## Testing
- pytest tests/test_keyboards_unified.py tests/test_hub_menu.py

------
https://chatgpt.com/codex/tasks/task_e_68e255ee5afc8322b99a99adbeeb3150