### PR TITLE
Fix AI dialog routing and SUNO start callback

### DIFF
--- a/keyboards.py
+++ b/keyboards.py
@@ -19,26 +19,37 @@ EMOJI = {
     "pay": "💎",
 }
 
-CB_PROFILE = "mnu:profile"
-CB_KB = "mnu:kb"
-CB_PHOTO = "mnu:photo"
-CB_MUSIC = "mnu:music"
-CB_VIDEO = "mnu:video"
-CB_CHAT = "mnu:chat"
+AI_MENU_CB = "ai:menu"
+AI_TO_SIMPLE_CB = "ai:chat"
+AI_TO_PROMPTMASTER_CB = "ai:pm"
+
+VIDEO_MENU_CB = "video:menu"
+IMAGE_MENU_CB = "image:menu"
+MUSIC_MENU_CB = "music:menu"
+PROFILE_MENU_CB = "profile:menu"
+KNOWLEDGE_MENU_CB = "kb:menu"
+
+# Backward compatible aliases (deprecated)
+CB_PROFILE = PROFILE_MENU_CB
+CB_KB = KNOWLEDGE_MENU_CB
+CB_PHOTO = IMAGE_MENU_CB
+CB_MUSIC = MUSIC_MENU_CB
+CB_VIDEO = VIDEO_MENU_CB
+CB_CHAT = AI_MENU_CB
 
 
 def main_menu_kb() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         [
-            [InlineKeyboardButton(text="👥 Профиль", callback_data=CB_PROFILE)],
-            [InlineKeyboardButton(text="📚 База знаний", callback_data=CB_KB)],
+            [InlineKeyboardButton(text="👥 Профиль", callback_data=PROFILE_MENU_CB)],
+            [InlineKeyboardButton(text="📚 База знаний", callback_data=KNOWLEDGE_MENU_CB)],
             [
-                InlineKeyboardButton(text="📸 Режим фото", callback_data=CB_PHOTO),
-                InlineKeyboardButton(text="🎧 Режим музыки", callback_data=CB_MUSIC),
+                InlineKeyboardButton(text="📸 Режим фото", callback_data=IMAGE_MENU_CB),
+                InlineKeyboardButton(text="🎧 Режим музыки", callback_data=MUSIC_MENU_CB),
             ],
             [
-                InlineKeyboardButton(text="📹 Режим видео", callback_data=CB_VIDEO),
-                InlineKeyboardButton(text="🧠 Диалог с ИИ", callback_data=CB_CHAT),
+                InlineKeyboardButton(text="📹 Режим видео", callback_data=VIDEO_MENU_CB),
+                InlineKeyboardButton(text="🧠 Диалог с ИИ", callback_data=AI_MENU_CB),
             ],
         ]
     )
@@ -274,7 +285,7 @@ def menu_pay_unified() -> InlineKeyboardMarkup:
 
 
 def suno_start_keyboard() -> InlineKeyboardMarkup:
-    rows = [[InlineKeyboardButton("▶️ Начать генерацию", callback_data="suno:start")]]
+    rows = [[InlineKeyboardButton("▶️ Начать генерацию", callback_data="music:suno:start")]]
     return InlineKeyboardMarkup(rows)
 
 
@@ -328,18 +339,18 @@ def mj_upscale_select_keyboard(grid_id: str, *, count: int) -> InlineKeyboardMar
         [InlineKeyboardButton("⬅️ Назад", callback_data=f"mj.upscale.menu:{grid_id}")]
     )
     return InlineKeyboardMarkup(rows)
-CB_MAIN_PROFILE = "main_profile"
-CB_MAIN_KNOWLEDGE = "main_knowledge"
-CB_MAIN_PHOTO = "main_photo"
-CB_MAIN_MUSIC = "main_music"
-CB_MAIN_VIDEO = "main_video"
-CB_MAIN_AI_DIALOG = "main_ai_dialog"
+CB_MAIN_PROFILE = PROFILE_MENU_CB
+CB_MAIN_KNOWLEDGE = KNOWLEDGE_MENU_CB
+CB_MAIN_PHOTO = IMAGE_MENU_CB
+CB_MAIN_MUSIC = MUSIC_MENU_CB
+CB_MAIN_VIDEO = VIDEO_MENU_CB
+CB_MAIN_AI_DIALOG = AI_MENU_CB
 CB_MAIN_BACK = "main_back"
 CB_PROFILE_TOPUP = "profile_topup"
 CB_PROFILE_BACK = "profile_back"
-CB_AI_MODES = "ai_modes"
-CB_CHAT_NORMAL = "chat_normal"
-CB_CHAT_PROMPTMASTER = "chat_promptmaster"
+CB_AI_MODES = AI_MENU_CB
+CB_CHAT_NORMAL = AI_TO_SIMPLE_CB
+CB_CHAT_PROMPTMASTER = AI_TO_PROMPTMASTER_CB
 CB_PAY_STARS = "pay_stars"
 CB_PAY_CARD = "pay_card"
 CB_PAY_CRYPTO = "pay_crypto"
@@ -397,9 +408,10 @@ def kb_ai_dialog_modes() -> InlineKeyboardMarkup:
     from texts import common_text
 
     rows = [
-        [InlineKeyboardButton(TXT_AI_DIALOG_NORMAL, callback_data=CB_CHAT_NORMAL)],
-        [InlineKeyboardButton(TXT_AI_DIALOG_PM, callback_data=CB_CHAT_PROMPTMASTER)],
-        [InlineKeyboardButton(common_text("topup.menu.back"), callback_data=CB_MAIN_BACK)],
+        [
+            InlineKeyboardButton(TXT_AI_DIALOG_NORMAL, callback_data=AI_TO_SIMPLE_CB),
+            InlineKeyboardButton(TXT_AI_DIALOG_PM, callback_data=AI_TO_PROMPTMASTER_CB),
+        ]
     ]
     return InlineKeyboardMarkup(rows)
 

--- a/tests/test_ai_dialog_modes_menu.py
+++ b/tests/test_ai_dialog_modes_menu.py
@@ -37,7 +37,7 @@ def test_ai_dialog_submenu_render(monkeypatch):
         return None
 
     query = SimpleNamespace(
-        data=bot_module.CB_MAIN_AI_DIALOG,
+        data=bot_module.AI_MENU_CB,
         message=message,
         answer=fake_answer,
     )
@@ -52,5 +52,5 @@ def test_ai_dialog_submenu_render(monkeypatch):
     assert captured["text"] == f"{TXT_KB_AI_DIALOG}\n{TXT_AI_DIALOG_CHOOSE}"
     markup = captured["markup"]
     rows = markup.inline_keyboard
-    assert rows[0][0].text == TXT_AI_DIALOG_NORMAL
-    assert rows[1][0].text == TXT_AI_DIALOG_PM
+    assert len(rows) == 1
+    assert [button.text for button in rows[0]] == [TXT_AI_DIALOG_NORMAL, TXT_AI_DIALOG_PM]

--- a/tests/test_hub_menu.py
+++ b/tests/test_hub_menu.py
@@ -26,12 +26,12 @@ def test_build_hub_keyboard_layout():
         "🧠 Диалог с ИИ",
     ]
     assert callbacks == [
-        "mnu:profile",
-        "mnu:kb",
-        "mnu:photo",
-        "mnu:music",
-        "mnu:video",
-        "mnu:chat",
+        "profile:menu",
+        "kb:menu",
+        "image:menu",
+        "music:menu",
+        "video:menu",
+        "ai:menu",
     ]
 
 

--- a/tests/test_keyboards_unified.py
+++ b/tests/test_keyboards_unified.py
@@ -31,12 +31,12 @@ def test_kb_home_menu_layout():
         "🧠 Диалог с ИИ",
     ]
     assert callbacks == [
-        "mnu:profile",
-        "mnu:kb",
-        "mnu:photo",
-        "mnu:music",
-        "mnu:video",
-        "mnu:chat",
+        "profile:menu",
+        "kb:menu",
+        "image:menu",
+        "music:menu",
+        "video:menu",
+        "ai:menu",
     ]
 
 

--- a/tests/test_start_calls_existing_handler.py
+++ b/tests/test_start_calls_existing_handler.py
@@ -24,7 +24,7 @@ class FakeMessage:
 
 class FakeCallback:
     def __init__(self, chat_id: int) -> None:
-        self.data = "suno:start"
+        self.data = "music:suno:start"
         self.message = FakeMessage(chat_id)
         self._answered: list[tuple[str | None, bool]] = []
 

--- a/tests/test_start_idempotent_under_race.py
+++ b/tests/test_start_idempotent_under_race.py
@@ -29,7 +29,7 @@ class FakeMessage:
 
 class FakeCallback:
     def __init__(self, chat_id: int) -> None:
-        self.data = "suno:start"
+        self.data = "music:suno:start"
         self.message = FakeMessage(chat_id)
         self._answers: list[tuple[str | None, bool]] = []
 

--- a/tests/test_start_redis_lock_blocks_duplicates.py
+++ b/tests/test_start_redis_lock_blocks_duplicates.py
@@ -29,7 +29,7 @@ class FakeMessage:
 
 class FakeCallback:
     def __init__(self, chat_id: int) -> None:
-        self.data = "suno:start"
+        self.data = "music:suno:start"
         self.message = FakeMessage(chat_id)
         self._answers: list[tuple[str | None, bool]] = []
 

--- a/tests/test_start_sends_big_emoji_once.py
+++ b/tests/test_start_sends_big_emoji_once.py
@@ -32,7 +32,7 @@ class FakeMessage:
 
 
 class FakeCallback:
-    def __init__(self, chat_id: int, data: str = "suno:start") -> None:
+    def __init__(self, chat_id: int, data: str = "music:suno:start") -> None:
         self.data = data
         self.message = FakeMessage(chat_id)
         self._answered: list[tuple[str | None, bool]] = []
@@ -89,7 +89,7 @@ def test_click_sends_correct_sticker_and_not_prinyato_again(monkeypatch):
     monkeypatch.setattr(bot_module, "_suno_notify", fake_notify)
 
     update = SimpleNamespace(
-        callback_query=FakeCallback(chat_id, data="suno:start"),
+        callback_query=FakeCallback(chat_id, data="music:suno:start"),
         effective_chat=SimpleNamespace(id=chat_id),
         effective_user=SimpleNamespace(id=user_id),
     )
@@ -167,7 +167,7 @@ def test_second_click_blocked(monkeypatch):
     monkeypatch.setattr(bot_module, "_suno_notify", fake_notify)
 
     update = SimpleNamespace(
-        callback_query=FakeCallback(chat_id, data="suno:start"),
+        callback_query=FakeCallback(chat_id, data="music:suno:start"),
         effective_chat=SimpleNamespace(id=chat_id),
         effective_user=SimpleNamespace(id=user_id),
     )
@@ -216,7 +216,7 @@ def test_start_sticker_fallback_to_emoji(monkeypatch):
     monkeypatch.setattr(bot_module, "safe_send_sticker", failing_sticker)
 
     update = SimpleNamespace(
-        callback_query=FakeCallback(chat_id, data="suno:start"),
+        callback_query=FakeCallback(chat_id, data="music:suno:start"),
         effective_chat=SimpleNamespace(id=chat_id),
         effective_user=SimpleNamespace(id=user_id),
     )

--- a/tests/test_start_with_state_flag_blocks_second_click.py
+++ b/tests/test_start_with_state_flag_blocks_second_click.py
@@ -29,7 +29,7 @@ class FakeMessage:
 
 class FakeCallback:
     def __init__(self, chat_id: int) -> None:
-        self.data = "suno:start"
+        self.data = "music:suno:start"
         self.message = FakeMessage(chat_id)
         self._answers: list[tuple[str | None, bool]] = []
 

--- a/tests/test_suno_flow.py
+++ b/tests/test_suno_flow.py
@@ -270,7 +270,7 @@ def test_start_message_sent_when_ready() -> None:
     assert SUNO_START_READY_MESSAGE in texts, "start message should be sent when ready"
     last_markup = bot.sent[-1].get("reply_markup")
     assert isinstance(last_markup, InlineKeyboardMarkup)
-    assert last_markup.inline_keyboard[0][0].callback_data == "suno:start"
+    assert last_markup.inline_keyboard[0][0].callback_data == "music:suno:start"
 
 
 def test_refresh_skips_duplicate_payload() -> None:


### PR DESCRIPTION
## Summary
- namespace main menu and AI dialog callback data and update keyboards accordingly
- adjust AI routing to edit the dialog card, open prompt master, and normalize `music:suno:*` callbacks while keeping the menu guard behaviour consistent
- update SUNO start handling and associated tests to expect the namespaced callback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e25b01d1d48322889f1c271b1cac2f