### PR TITLE
Fix chat-mode routing and add knowledge base navigation

### DIFF
--- a/keyboards.py
+++ b/keyboards.py
@@ -14,20 +14,20 @@ EMOJI = {
     "music": "🎵",
     "chat": "💬",
     "prompt": "🧠",
-    "profile": "👥",
+    "profile": "👤",
     "back": "⬅️",
     "pay": "💎",
 }
 
-AI_MENU_CB = "ai:menu"
-AI_TO_SIMPLE_CB = "dialog_default"
-AI_TO_PROMPTMASTER_CB = "prompt_master"
+AI_MENU_CB = "menu_chat_ai"
+AI_TO_SIMPLE_CB = "chat_mode_normal"
+AI_TO_PROMPTMASTER_CB = "chat_mode_pm"
 
-VIDEO_MENU_CB = "video:menu"
-IMAGE_MENU_CB = "image:menu"
-MUSIC_MENU_CB = "music:menu"
-PROFILE_MENU_CB = "profile:menu"
-KNOWLEDGE_MENU_CB = "kb:menu"
+VIDEO_MENU_CB = "video_menu"
+IMAGE_MENU_CB = "image_menu"
+MUSIC_MENU_CB = "music_menu"
+PROFILE_MENU_CB = "menu_profile"
+KNOWLEDGE_MENU_CB = "kb_entry"
 
 # Backward compatible aliases (deprecated)
 CB_PROFILE = PROFILE_MENU_CB
@@ -38,10 +38,10 @@ CB_VIDEO = VIDEO_MENU_CB
 CB_CHAT = AI_MENU_CB
 
 
-def main_menu_kb() -> InlineKeyboardMarkup:
+def kb_main() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         [
-            [InlineKeyboardButton(text="👥 Профиль", callback_data=PROFILE_MENU_CB)],
+            [InlineKeyboardButton(text="👤 Профиль", callback_data=PROFILE_MENU_CB)],
             [InlineKeyboardButton(text="📚 База знаний", callback_data=KNOWLEDGE_MENU_CB)],
             [
                 InlineKeyboardButton(text="📸 Режим фото", callback_data=IMAGE_MENU_CB),
@@ -55,14 +55,18 @@ def main_menu_kb() -> InlineKeyboardMarkup:
     )
 
 
+def main_menu_kb() -> InlineKeyboardMarkup:
+    return kb_main()
+
+
 def kb_home_menu() -> InlineKeyboardMarkup:
-    return main_menu_kb()
+    return kb_main()
 
 
 def reply_kb_home() -> ReplyKeyboardMarkup:
     return ReplyKeyboardMarkup(
         keyboard=[
-            [KeyboardButton(text="👥 Профиль")],
+            [KeyboardButton(text="👤 Профиль")],
             [KeyboardButton(text="📚 База знаний")],
             [
                 KeyboardButton(text="📸 Режим фото"),
@@ -414,4 +418,29 @@ def kb_ai_dialog_modes() -> InlineKeyboardMarkup:
         ]
     ]
     return InlineKeyboardMarkup(rows)
+
+
+def kb_kb_root() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("🪄 Примеры генераций", callback_data="kb_examples")],
+            [InlineKeyboardButton("✨ Готовые шаблоны", callback_data="kb_templates")],
+            [InlineKeyboardButton("💡 Мини видео уроки", callback_data="kb_lessons")],
+            [InlineKeyboardButton("❓ Частые вопросы", callback_data="kb_faq")],
+            [InlineKeyboardButton("⬅️ Назад (в главное)", callback_data="menu_main")],
+        ]
+    )
+
+
+def kb_kb_templates() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("🎬 Генерация видео", callback_data="tpl_video")],
+            [InlineKeyboardButton("🖼️ Генерация фото", callback_data="tpl_image")],
+            [InlineKeyboardButton("🎵 Генерация музыки", callback_data="tpl_music")],
+            [InlineKeyboardButton("🍌 Редактор фото", callback_data="tpl_banana")],
+            [InlineKeyboardButton("🤖 ИИ-фотограф", callback_data="tpl_ai_photo")],
+            [InlineKeyboardButton("⬅️ Назад", callback_data="kb_entry")],
+        ]
+    )
 

--- a/tests/test_chat_mode_switch.py
+++ b/tests/test_chat_mode_switch.py
@@ -1,0 +1,115 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tests.suno_test_utils import FakeBot, bot_module
+
+
+@pytest.fixture
+def ctx():
+    bot = FakeBot()
+    return SimpleNamespace(bot=bot, user_data={}, chat_data={}, application=SimpleNamespace(logger=bot_module.log))
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    async def fake_ensure(_update):
+        return None
+
+    monkeypatch.setattr(bot_module, "ensure_user_record", fake_ensure)
+
+    async def fake_safe_edit_message(ctx_param, chat_id_param, message_id_param, text_param, reply_markup_param, **kwargs):
+        return True
+
+    monkeypatch.setattr(bot_module, "safe_edit_message", fake_safe_edit_message)
+
+    yield
+
+
+def _make_update(chat_id: int, user_id: int):
+    message = SimpleNamespace(message_id=42, chat=SimpleNamespace(id=chat_id), chat_id=chat_id)
+
+    async def answer():
+        return None
+
+    query = SimpleNamespace(data=None, message=message, answer=answer)
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+        effective_message=message,
+    )
+    return update, query
+
+
+def test_chat_mode_cleared_when_opening_video(monkeypatch, ctx):
+    bot = ctx.bot
+
+    video_calls = []
+
+    async def fake_start_video_menu(update, context):
+        video_calls.append(update.callback_query.data)
+        return None
+
+    monkeypatch.setattr(bot_module, "start_video_menu", fake_start_video_menu)
+
+    update, query = _make_update(chat_id=100, user_id=200)
+
+    # Open AI modes menu
+    query.data = bot_module.AI_MENU_CB
+    asyncio.run(bot_module.hub_router(update, ctx))
+
+    # Enable normal chat mode
+    query.data = bot_module.AI_TO_SIMPLE_CB
+    asyncio.run(bot_module.hub_router(update, ctx))
+
+    state = bot_module.state(ctx)
+    assert state.get(bot_module.STATE_CHAT_MODE) == "normal"
+
+    # Navigate to video section
+    query.data = bot_module.VIDEO_MENU_CB
+    asyncio.run(bot_module.hub_router(update, ctx))
+
+    state_after = bot_module.state(ctx)
+    assert state_after.get(bot_module.STATE_CHAT_MODE) is None
+    assert video_calls, "Video menu should be opened"
+    assert any(entry.get("text") == "🛑 Режим диалога отключён." for entry in bot.sent)
+
+
+def test_prompt_master_disabled_when_opening_profile(monkeypatch, ctx):
+    bot = ctx.bot
+
+    profile_calls = []
+
+    async def fake_show_balance(chat_id, context, *, force_new=False):
+        profile_calls.append((chat_id, force_new))
+        return None
+
+    monkeypatch.setattr(bot_module, "show_balance_card", fake_show_balance)
+
+    update, query = _make_update(chat_id=300, user_id=400)
+
+    query.data = bot_module.AI_MENU_CB
+    asyncio.run(bot_module.hub_router(update, ctx))
+
+    query.data = bot_module.AI_TO_PROMPTMASTER_CB
+    asyncio.run(bot_module.hub_router(update, ctx))
+
+    state = bot_module.state(ctx)
+    assert state.get(bot_module.STATE_CHAT_MODE) == "prompt_master"
+
+    query.data = bot_module.PROFILE_MENU_CB
+    asyncio.run(bot_module.hub_router(update, ctx))
+
+    state_after = bot_module.state(ctx)
+    assert state_after.get(bot_module.STATE_CHAT_MODE) is None
+    assert profile_calls, "Profile card should be shown"
+    assert not any("Обычный чат включён" in (entry.get("text") or "") for entry in bot.sent)
+    assert any(entry.get("text") == "🛑 Режим диалога отключён." for entry in bot.sent)

--- a/tests/test_hub_menu.py
+++ b/tests/test_hub_menu.py
@@ -18,7 +18,7 @@ def test_build_hub_keyboard_layout():
     callbacks = [button.callback_data for row in rows for button in row]
 
     assert texts == [
-        "👥 Профиль",
+        "👤 Профиль",
         "📚 База знаний",
         "📸 Режим фото",
         "🎧 Режим музыки",
@@ -26,12 +26,12 @@ def test_build_hub_keyboard_layout():
         "🧠 Диалог с ИИ",
     ]
     assert callbacks == [
-        "profile:menu",
-        "kb:menu",
-        "image:menu",
-        "music:menu",
-        "video:menu",
-        "ai:menu",
+        "menu_profile",
+        "kb_entry",
+        "image_menu",
+        "music_menu",
+        "video_menu",
+        "menu_chat_ai",
     ]
 
 

--- a/tests/test_kb_navigation.py
+++ b/tests/test_kb_navigation.py
@@ -1,0 +1,77 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tests.suno_test_utils import FakeBot, bot_module
+from texts import TXT_KNOWLEDGE_INTRO
+
+
+@pytest.fixture
+def ctx():
+    bot = FakeBot()
+    return SimpleNamespace(bot=bot, user_data={}, chat_data={}, application=SimpleNamespace(logger=bot_module.log))
+
+
+@pytest.fixture(autouse=True)
+def _setup(monkeypatch):
+    async def fake_ensure(_update):
+        return None
+
+    monkeypatch.setattr(bot_module, "ensure_user_record", fake_ensure)
+    yield
+
+
+def _make_update(chat_id: int, user_id: int):
+    message = SimpleNamespace(message_id=77, chat=SimpleNamespace(id=chat_id), chat_id=chat_id)
+
+    async def answer():
+        return None
+
+    query = SimpleNamespace(data=None, message=message, answer=answer)
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+        effective_message=message,
+    )
+    return update, query
+
+
+def test_kb_templates_to_video(monkeypatch, ctx):
+    bot = ctx.bot
+    edit_calls = []
+    video_calls = []
+
+    async def fake_safe_edit_message(ctx_param, chat_id_param, message_id_param, text_param, reply_markup_param, **kwargs):
+        edit_calls.append(text_param)
+        return True
+
+    async def fake_start_video_menu(update, context):
+        video_calls.append(True)
+        return None
+
+    monkeypatch.setattr(bot_module, "safe_edit_message", fake_safe_edit_message)
+    monkeypatch.setattr(bot_module, "start_video_menu", fake_start_video_menu)
+
+    update, query = _make_update(chat_id=555, user_id=777)
+
+    query.data = bot_module.KNOWLEDGE_MENU_CB
+    asyncio.run(bot_module.hub_router(update, ctx))
+
+    meaningful = [entry for entry in bot.sent if (entry.get("text") or "").strip()]
+    assert any(entry.get("text") == TXT_KNOWLEDGE_INTRO for entry in meaningful)
+
+    query.data = "kb_templates"
+    asyncio.run(bot_module.hub_router(update, ctx))
+    assert edit_calls and "✨ Готовые шаблоны" in edit_calls[-1]
+
+    query.data = "tpl_video"
+    asyncio.run(bot_module.hub_router(update, ctx))
+    assert video_calls, "Video menu should be triggered from templates"

--- a/tests/test_keyboards_unified.py
+++ b/tests/test_keyboards_unified.py
@@ -23,7 +23,7 @@ def test_kb_home_menu_layout():
     callbacks = [button.callback_data for row in rows for button in row]
 
     assert texts == [
-        "👥 Профиль",
+        "👤 Профиль",
         "📚 База знаний",
         "📸 Режим фото",
         "🎧 Режим музыки",
@@ -31,12 +31,12 @@ def test_kb_home_menu_layout():
         "🧠 Диалог с ИИ",
     ]
     assert callbacks == [
-        "profile:menu",
-        "kb:menu",
-        "image:menu",
-        "music:menu",
-        "video:menu",
-        "ai:menu",
+        "menu_profile",
+        "kb_entry",
+        "image_menu",
+        "music_menu",
+        "video_menu",
+        "menu_chat_ai",
     ]
 
 

--- a/tests/test_menu_command.py
+++ b/tests/test_menu_command.py
@@ -36,7 +36,7 @@ def test_main_menu_keyboard_layout():
     labels = [[button.text for button in row] for row in rows]
 
     assert labels == [
-        ["👥 Профиль"],
+        ["👤 Профиль"],
         ["📚 База знаний"],
         ["📸 Режим фото", "🎧 Режим музыки"],
         ["📹 Режим видео", "🧠 Диалог с ИИ"],

--- a/tests/test_no_quick_keyboard.py
+++ b/tests/test_no_quick_keyboard.py
@@ -1,0 +1,76 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from telegram import ReplyKeyboardRemove
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tests.suno_test_utils import FakeBot, bot_module
+
+
+@pytest.fixture
+def ctx():
+    bot = FakeBot()
+    return SimpleNamespace(bot=bot, user_data={}, chat_data={}, application=SimpleNamespace(logger=bot_module.log))
+
+
+@pytest.fixture(autouse=True)
+def _patch_ensure(monkeypatch):
+    async def fake_ensure(_update):
+        return None
+
+    monkeypatch.setattr(bot_module, "ensure_user_record", fake_ensure)
+
+    async def fake_safe_edit_message(ctx_param, chat_id_param, message_id_param, text_param, reply_markup_param, **kwargs):
+        return True
+
+    monkeypatch.setattr(bot_module, "safe_edit_message", fake_safe_edit_message)
+    yield
+
+
+def _make_update(chat_id: int, user_id: int):
+    message = SimpleNamespace(message_id=11, chat=SimpleNamespace(id=chat_id), chat_id=chat_id)
+
+    async def answer():
+        return None
+
+    query = SimpleNamespace(data=None, message=message, answer=answer)
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+        effective_message=message,
+    )
+    return update, query
+
+
+def test_quick_keyboard_sent_once(monkeypatch, ctx):
+    bot = ctx.bot
+
+    async def fake_start_video_menu(update, context):
+        return None
+
+    monkeypatch.setattr(bot_module, "start_video_menu", fake_start_video_menu)
+
+    command_update = SimpleNamespace(
+        callback_query=None,
+        effective_chat=SimpleNamespace(id=999),
+        effective_user=SimpleNamespace(id=888),
+        effective_message=SimpleNamespace(message_id=21, chat_id=999),
+        message=SimpleNamespace(message_id=21, chat_id=999),
+    )
+
+    asyncio.run(bot_module.handle_menu(command_update, ctx))
+
+    update, query = _make_update(chat_id=999, user_id=888)
+
+    query.data = bot_module.VIDEO_MENU_CB
+    asyncio.run(bot_module.hub_router(update, ctx))
+
+    removals = [entry for entry in bot.sent if isinstance(entry.get("reply_markup"), ReplyKeyboardRemove)]
+    assert len(removals) == 1

--- a/texts.py
+++ b/texts.py
@@ -7,8 +7,8 @@ from suno.cover_source import MAX_AUDIO_MB
 FAQ_INTRO = "🧾 *FAQ*\nВыберите раздел:"
 
 TXT_MENU_TITLE = "📋 Главное меню"
-TXT_PROFILE_TITLE = "👥 Профиль"
-TXT_KB_PROFILE = "👥 Профиль"
+TXT_PROFILE_TITLE = "👤 Профиль"
+TXT_KB_PROFILE = "👤 Профиль"
 TXT_KB_KNOWLEDGE = "📚 База знаний"
 TXT_KB_PHOTO = "📸 Режим фото"
 TXT_KB_MUSIC = "🎧 Режим музыки"
@@ -24,7 +24,7 @@ TXT_PAY_CRYPTO_OPEN_LINK = "Открыть оплату в браузере"
 TXT_AI_DIALOG_NORMAL = "💬 Обычный чат"
 TXT_AI_DIALOG_PM = "📝 Prompt-Master"
 TXT_AI_DIALOG_CHOOSE = "Выберите режим диалога:"
-TXT_KNOWLEDGE_INTRO = "📚 База знаний\nВыберите нужный раздел:"
+TXT_KNOWLEDGE_INTRO = "📚 База знаний\nВыберите раздел:"
 
 COMMON_TEXTS_RU = {
     "topup.menu.title": "Выберите способ пополнения:",


### PR DESCRIPTION
## Summary
- add utilities to hide the quick keyboard, manage chat modes, and ensure the AI dialog is disabled when navigating elsewhere
- add knowledge base sections with template shortcuts and update menu callback identifiers
- refresh profile emoji usage across menus and align existing tests with the new callbacks

## Testing
- pytest tests/test_chat_mode_switch.py tests/test_kb_navigation.py tests/test_no_quick_keyboard.py

------
https://chatgpt.com/codex/tasks/task_e_68e2b18562248322b0efb0672ff3ff97