### PR TITLE
feat: refresh banana card ux

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -161,6 +161,7 @@ from keyboards import (
     AI_MENU_CB,
     AI_TO_PROMPTMASTER_CB,
     AI_TO_SIMPLE_CB,
+    kb_banana_templates,
     CB,
     CB_FAQ_PREFIX,
     CB_MAIN_BACK,
@@ -3392,7 +3393,8 @@ async def _deliver_banana_media(
     user_id: int,
     file_path: Path,
     caption: str,
-    reply_markup: Optional[Any] = None,
+    photo_reply_markup: Optional[Any] = None,
+    document_reply_markup: Optional[Any] = None,
     send_document: bool = True,
 ) -> bool:
     try:
@@ -3422,7 +3424,7 @@ async def _deliver_banana_media(
                 chat_id=chat_id,
                 photo=InputFile(handle, filename=file_path.name),
                 caption=caption,
-                reply_markup=reply_markup,
+                reply_markup=photo_reply_markup,
                 kind="banana_photo",
             )
         duration_ms = int((time.monotonic() - photo_start) * 1000)
@@ -3467,7 +3469,7 @@ async def _deliver_banana_media(
                     chat_id=chat_id,
                     document=InputFile(handle, filename=doc_filename),
                     caption=None,
-                    reply_markup=reply_markup,
+                    reply_markup=document_reply_markup,
                     kind="banana_document",
                     disable_notification=True,
                 )
@@ -6972,16 +6974,6 @@ async def mj_entry(chat_id: int, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     s["_last_text_mj"] = None
     await show_mj_format_card(chat_id, ctx, force_new=True)
 
-def banana_examples_block() -> str:
-    return (
-        "💡 <b>Примеры запросов:</b>\n"
-        "• поменяй фон на городской вечер\n"
-        "• смени одежду на чёрный пиджак\n"
-        "• добавь лёгкий макияж, подчеркни глаза\n"
-        "• убери лишние предметы со стола\n"
-        "• поставь нас на одну фотографию"
-    )
-
 BANANA_MODE_HINT_MD = (
     "🍌 Banana включён\n"
     "Сначала пришлите до *4 фото* (можно по одному). Когда будут готовы — пришлите *текст-промпт*, что изменить."
@@ -6991,11 +6983,15 @@ MJ_MODE_HINT_TEXT = (
     "🖼 Midjourney включён. Введите промпт сообщением и нажмите «Подтвердить»."
 )
 
+BANANA_HELPER_LINE = "Пришлите до 4 фото и текст-промпт, что изменить."
+
+
 def banana_card_text(s: Dict[str, Any]) -> str:
     n = len(s.get("banana_images") or [])
     prompt = (s.get("last_prompt") or "").strip()
     prompt_html = html.escape(prompt)
     has_prompt = "есть" if prompt else "нет"
+    s["banana_helper_line"] = BANANA_HELPER_LINE
     lines = [
         "🍌 <b>Карточка Banana</b>",
         f"🧩 Фото: <b>{n}/4</b>  •  Промпт: <b>{has_prompt}</b>",
@@ -7003,7 +6999,7 @@ def banana_card_text(s: Dict[str, Any]) -> str:
         "🖊️ <b>Промпт:</b>",
         f"<code>{prompt_html}</code>" if prompt else "<code></code>",
         "",
-        banana_examples_block()
+        BANANA_HELPER_LINE,
     ]
     balance = s.get("banana_balance")
     if balance is not None:
@@ -7014,7 +7010,10 @@ def banana_kb() -> InlineKeyboardMarkup:
     rows = [
         [InlineKeyboardButton("➕ Добавить ещё фото", callback_data="banana:add_more")],
         [InlineKeyboardButton("🧹 Очистить фото", callback_data="banana:reset_imgs")],
-        [InlineKeyboardButton("✍️ Изменить промпт", callback_data="banana:edit_prompt")],
+        [
+            InlineKeyboardButton("✍️ Изменить промпт", callback_data="banana:edit_prompt"),
+            InlineKeyboardButton("✨ Готовые шаблоны", callback_data="banana_templates"),
+        ],
         [InlineKeyboardButton("🚀 Начать генерацию Banana", callback_data="banana:start")],
         [InlineKeyboardButton("🔁 Сменить движок", callback_data="banana:switch_engine")],
         [InlineKeyboardButton("⬅️ Назад", callback_data="back")],
@@ -7022,12 +7021,10 @@ def banana_kb() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(rows)
 
 
-def banana_result_keyboard() -> ReplyKeyboardMarkup:
-    rows = [
-        [KeyboardButton("🔁 Повторить")],
-        [KeyboardButton("⬅️ Назад в меню")],
-    ]
-    return ReplyKeyboardMarkup(rows, resize_keyboard=True)
+def banana_result_inline_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [[InlineKeyboardButton("🔁 Сгенерировать ещё", callback_data="banana_regenerate_fresh")]]
+    )
 
 
 # --------- Suno Helpers ----------
@@ -14314,6 +14311,54 @@ async def on_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         await handle_pm_insert_to_veo(update, ctx, data)
         return
 
+    if data == "banana_templates":
+        if message is None:
+            await q.answer("Карточка недоступна", show_alert=True)
+            return
+        s["_last_text_banana"] = None
+        await _safe_edit_message_text(
+            q.edit_message_text,
+            "✨ Готовые шаблоны для Banana\nВыберите заготовку, она подставится в поле промпта:",
+            reply_markup=kb_banana_templates(),
+        )
+        await q.answer()
+        return
+
+    if data == "banana_back_to_card":
+        s["_last_text_banana"] = None
+        if chat_id is not None:
+            await show_banana_card(chat_id, ctx, force_new=True)
+        await q.answer()
+        return
+
+    if data.startswith("btpl_"):
+        template_mapping = {
+            "btpl_bg_remove": "удали фон на прозрачный/однотонный",
+            "btpl_bg_studio": "замени фон на студийный (чистая белая/серая подложка)",
+            "btpl_outfit_black": "измени одежду на чёрный пиджак",
+            "btpl_makeup_soft": "добавь лёгкий макияж, подчеркни глаза (естественно)",
+            "btpl_desk_clean": "убери лишние предметы со стола",
+        }
+        prompt_text = template_mapping.get(data)
+        if prompt_text is None:
+            await q.answer("Шаблон не найден", show_alert=True)
+            return
+        s["last_prompt"] = prompt_text
+        s["_last_text_banana"] = None
+        if chat_id is not None:
+            await show_banana_card(chat_id, ctx, force_new=True)
+        await q.answer("Шаблон подставлен ✅")
+        return
+
+    if data == "banana_regenerate_fresh":
+        s["banana_images"] = []
+        s["last_prompt"] = None
+        s["_last_text_banana"] = None
+        if chat_id is not None:
+            await show_banana_card(chat_id, ctx, force_new=True)
+        await q.answer("Новая карточка Banana ✨")
+        return
+
     await q.answer()
 
     if data.startswith("tx:"):
@@ -15752,22 +15797,11 @@ async def _banana_run_and_send(
             user_id=user_id,
             file_path=temp_path,
             caption=caption,
-            reply_markup=None,
+            photo_reply_markup=banana_result_inline_keyboard(),
+            document_reply_markup=None,
             send_document=BANANA_SEND_AS_DOCUMENT,
         )
-        if delivered:
-            try:
-                await ctx.bot.send_message(
-                    chat_id,
-                    "Галерея сгенерирована.",
-                    reply_markup=banana_result_keyboard(),
-                )
-            except Exception as exc:
-                log.warning(
-                    "banana.result.keyboard_fail",
-                    extra={"meta": {"chat_id": chat_id, "error": str(exc)}},
-                )
-        else:
+        if not delivered:
             await ctx.bot.send_message(
                 chat_id,
                 "❌ Не удалось отправить изображение Banana. Попробуйте позже.",

--- a/keyboards.py
+++ b/keyboards.py
@@ -100,6 +100,18 @@ def build_menu(rows: list[list[tuple[str, str]]]) -> InlineKeyboardMarkup:
         markup_rows.append([kb_btn(text, cb) for text, cb in row])
     return InlineKeyboardMarkup(markup_rows)
 
+
+def kb_banana_templates() -> InlineKeyboardMarkup:
+    rows = [
+        [InlineKeyboardButton("🧼 Удалить фон", callback_data="btpl_bg_remove")],
+        [InlineKeyboardButton("🎨 Сменить фон на студию", callback_data="btpl_bg_studio")],
+        [InlineKeyboardButton("👕 Сменить одежду на чёрный пиджак", callback_data="btpl_outfit_black")],
+        [InlineKeyboardButton("💄 Лёгкий макияж, подчеркнуть глаза", callback_data="btpl_makeup_soft")],
+        [InlineKeyboardButton("🧼 Очистить стол от лишнего", callback_data="btpl_desk_clean")],
+        [InlineKeyboardButton("⬅️ Назад", callback_data="banana_back_to_card")],
+    ]
+    return InlineKeyboardMarkup(rows)
+
 CB_FAQ_PREFIX = "faq:"
 CB_PM_PREFIX = "pm:"
 

--- a/tests/test_banana_card_ui.py
+++ b/tests/test_banana_card_ui.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def bot_module(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "dummy-token")
+    monkeypatch.setenv("SUNO_API_BASE", "https://example.com")
+    monkeypatch.setenv("SUNO_API_TOKEN", "test-token")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    module = importlib.import_module("bot")
+    return importlib.reload(module)
+
+
+def test_banana_card_shows_helper_line(bot_module):
+    state = {"banana_images": [{"url": "https://example.com"}], "last_prompt": "", "banana_balance": 15}
+
+    text = bot_module.banana_card_text(state)
+
+    assert "Примеры запросов" not in text
+    assert bot_module.BANANA_HELPER_LINE in text
+    assert state.get("banana_helper_line") == bot_module.BANANA_HELPER_LINE

--- a/tests/test_banana_flow.py
+++ b/tests/test_banana_flow.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from pathlib import Path
 
 import pytest
-from telegram import ReplyKeyboardMarkup
+from telegram import InlineKeyboardMarkup
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -81,10 +81,12 @@ def test_banana_generate_flow(monkeypatch, tmp_path, bot_module):
     assert len(fake_bot.photo_calls) == 1
     assert len(fake_bot.document_calls) == 1
     assert menu_calls == []
-    assert len(fake_bot.messages) >= 2
-    follow_up = fake_bot.messages[-1]
-    assert follow_up["text"] == "Галерея сгенерирована."
-    markup = follow_up.get("reply_markup")
-    assert isinstance(markup, ReplyKeyboardMarkup)
-    keyboard_text = [[getattr(button, "text", button) for button in row] for row in markup.keyboard]
-    assert keyboard_text == [["🔁 Повторить"], ["⬅️ Назад в меню"]]
+    assert len(fake_bot.messages) == 1
+    first_message = fake_bot.messages[0]
+    assert first_message["text"].startswith("🍌 Задача Banana")
+    photo_call = fake_bot.photo_calls[0]
+    markup = photo_call.get("reply_markup")
+    assert isinstance(markup, InlineKeyboardMarkup)
+    buttons = markup.inline_keyboard
+    assert buttons and buttons[0][0].text == "🔁 Сгенерировать ещё"
+    assert buttons[0][0].callback_data == "banana_regenerate_fresh"

--- a/tests/test_banana_regenerate.py
+++ b/tests/test_banana_regenerate.py
@@ -1,0 +1,79 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def bot_module(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "dummy-token")
+    monkeypatch.setenv("SUNO_API_BASE", "https://example.com")
+    monkeypatch.setenv("SUNO_API_TOKEN", "test-token")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    module = importlib.import_module("bot")
+    return importlib.reload(module)
+
+
+def _build_ctx():
+    return SimpleNamespace(bot=None, user_data={})
+
+
+def _build_update(data: str, chat_id: int = 888):
+    answers: list[dict[str, object]] = []
+
+    async def _answer(text: str | None = None, **kwargs):
+        payload: dict[str, object] = {}
+        if text is not None:
+            payload["text"] = text
+        payload.update(kwargs)
+        answers.append(payload)
+
+    message = SimpleNamespace(chat_id=chat_id)
+    query = SimpleNamespace(data=data, message=message, answer=_answer)
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=101),
+        _answers=answers,
+    )
+    return update
+
+
+def test_banana_regenerate_clears_state(monkeypatch, bot_module):
+    ctx = _build_ctx()
+    update = _build_update("banana_regenerate_fresh")
+    state_dict: dict[str, object] = {
+        "banana_images": [{"url": "https://example.com/a.jpg"}],
+        "last_prompt": "make it dramatic",
+        "_last_text_banana": "cached",
+        "banana_balance": 12,
+    }
+
+    async def fake_ensure_user_record(_update):
+        return None
+
+    calls: list[tuple[int, dict[str, object]]] = []
+
+    async def fake_show_banana_card(chat_id, _ctx, *, force_new=False):
+        calls.append((chat_id, {"force_new": force_new}))
+
+    monkeypatch.setattr(bot_module, "ensure_user_record", fake_ensure_user_record)
+    monkeypatch.setattr(bot_module, "state", lambda _ctx: state_dict)
+    monkeypatch.setattr(bot_module, "show_banana_card", fake_show_banana_card)
+
+    asyncio.run(bot_module.on_callback(update, ctx))
+
+    assert state_dict["banana_images"] == []
+    assert state_dict.get("last_prompt") is None
+    assert not state_dict.get("_last_text_banana")
+    assert calls and calls[-1][0] == update.effective_chat.id
+    assert calls[-1][1]["force_new"] is True
+    assert update._answers and update._answers[-1]["text"] == "Новая карточка Banana ✨"

--- a/tests/test_banana_templates.py
+++ b/tests/test_banana_templates.py
@@ -1,0 +1,138 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from telegram import InlineKeyboardMarkup
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def bot_module(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "dummy-token")
+    monkeypatch.setenv("SUNO_API_BASE", "https://example.com")
+    monkeypatch.setenv("SUNO_API_TOKEN", "test-token")
+    monkeypatch.setenv("LEDGER_BACKEND", "memory")
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    module = importlib.import_module("bot")
+    return importlib.reload(module)
+
+
+def _build_ctx():
+    return SimpleNamespace(bot=None, user_data={})
+
+
+def _build_update(data: str, chat_id: int = 777):
+    answers: list[dict[str, object]] = []
+
+    async def _answer(text: str | None = None, **kwargs):
+        payload: dict[str, object] = {}
+        if text is not None:
+            payload["text"] = text
+        payload.update(kwargs)
+        answers.append(payload)
+
+    async def _edit_message_text(*args, **kwargs):
+        return None
+
+    message = SimpleNamespace(chat_id=chat_id)
+    query = SimpleNamespace(
+        data=data,
+        message=message,
+        answer=_answer,
+        edit_message_text=_edit_message_text,
+    )
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=42),
+        _answers=answers,
+    )
+    return update
+
+
+def test_banana_templates_menu(monkeypatch, bot_module):
+    ctx = _build_ctx()
+    update = _build_update("banana_templates")
+    state_dict: dict[str, object] = {"_last_text_banana": "cached"}
+
+    edits: list[dict[str, object]] = []
+
+    async def fake_ensure_user_record(_update):
+        return None
+
+    async def fake_safe_edit(_callable, text, **kwargs):
+        edits.append({"text": text, "reply_markup": kwargs.get("reply_markup")})
+
+    monkeypatch.setattr(bot_module, "ensure_user_record", fake_ensure_user_record)
+    monkeypatch.setattr(bot_module, "state", lambda _ctx: state_dict)
+    monkeypatch.setattr(bot_module, "_safe_edit_message_text", fake_safe_edit)
+
+    asyncio.run(bot_module.on_callback(update, ctx))
+
+    assert not state_dict.get("_last_text_banana")
+    assert edits, "expected edit to be performed"
+    payload = edits[-1]
+    assert "Готовые шаблоны" in payload["text"]
+    markup = payload["reply_markup"]
+    assert isinstance(markup, InlineKeyboardMarkup)
+    buttons = [button.callback_data for row in markup.inline_keyboard for button in row]
+    assert "btpl_bg_remove" in buttons
+    assert "banana_back_to_card" in buttons
+    assert update._answers and update._answers[-1] == {}
+
+
+def test_banana_template_apply_sets_prompt(monkeypatch, bot_module):
+    ctx = _build_ctx()
+    update = _build_update("btpl_bg_studio")
+    state_dict: dict[str, object] = {"last_prompt": "", "_last_text_banana": "cached"}
+
+    async def fake_ensure_user_record(_update):
+        return None
+
+    called: list[tuple[int, dict[str, object]]] = []
+
+    async def fake_show_banana_card(chat_id, _ctx, *, force_new=False):
+        called.append((chat_id, {"force_new": force_new}))
+
+    monkeypatch.setattr(bot_module, "ensure_user_record", fake_ensure_user_record)
+    monkeypatch.setattr(bot_module, "state", lambda _ctx: state_dict)
+    monkeypatch.setattr(bot_module, "show_banana_card", fake_show_banana_card)
+
+    asyncio.run(bot_module.on_callback(update, ctx))
+
+    assert state_dict["last_prompt"] == "замени фон на студийный (чистая белая/серая подложка)"
+    assert not state_dict.get("_last_text_banana")
+    assert called and called[-1][0] == update.effective_chat.id
+    assert called[-1][1]["force_new"] is True
+    assert update._answers and update._answers[-1]["text"] == "Шаблон подставлен ✅"
+
+
+def test_banana_templates_back_to_card(monkeypatch, bot_module):
+    ctx = _build_ctx()
+    update = _build_update("banana_back_to_card")
+    state_dict: dict[str, object] = {"_last_text_banana": "cached"}
+
+    async def fake_ensure_user_record(_update):
+        return None
+
+    calls: list[tuple[int, dict[str, object]]] = []
+
+    async def fake_show_banana_card(chat_id, _ctx, *, force_new=False):
+        calls.append((chat_id, {"force_new": force_new}))
+
+    monkeypatch.setattr(bot_module, "ensure_user_record", fake_ensure_user_record)
+    monkeypatch.setattr(bot_module, "state", lambda _ctx: state_dict)
+    monkeypatch.setattr(bot_module, "show_banana_card", fake_show_banana_card)
+
+    asyncio.run(bot_module.on_callback(update, ctx))
+
+    assert not state_dict.get("_last_text_banana")
+    assert calls and calls[-1][0] == update.effective_chat.id
+    assert calls[-1][1]["force_new"] is True
+    assert update._answers and update._answers[-1] == {}

--- a/tests/test_handlers_image.py
+++ b/tests/test_handlers_image.py
@@ -49,7 +49,8 @@ def test_banana_deliver_photo_and_document(monkeypatch, tmp_path, bot_module):
             user_id=2,
             file_path=path,
             caption=caption,
-            reply_markup=None,
+            photo_reply_markup=None,
+            document_reply_markup=None,
             send_document=True,
         )
     )
@@ -90,7 +91,8 @@ def test_banana_deliver_skips_document(monkeypatch, tmp_path, bot_module):
             user_id=20,
             file_path=path,
             caption="Caption",
-            reply_markup=None,
+            photo_reply_markup=None,
+            document_reply_markup=None,
             send_document=False,
         )
     )


### PR DESCRIPTION
## Summary
- remove the Banana example list and show a concise helper line with a new templates control on the card
- add Banana template selection handlers, quick-regenerate callback, and attach the regenerate button directly to generated media
- cover the new UI flow with dedicated unit tests and update existing Banana delivery expectations

## Testing
- pytest tests/test_banana_card_ui.py tests/test_banana_templates.py tests/test_banana_regenerate.py
- pytest tests/test_banana_templates.py

------
https://chatgpt.com/codex/tasks/task_e_68e2ba08eb1c8322924374cdf592b647