### PR TITLE
Refine chat navigation state management

### DIFF
--- a/keyboards.py
+++ b/keyboards.py
@@ -22,12 +22,19 @@ EMOJI = {
     "pay": "💎",
 }
 
-HOME_CB_PROFILE = "home:profile"
-HOME_CB_KB = "home:kb"
-HOME_CB_PHOTO = "home:photo"
-HOME_CB_MUSIC = "home:music"
-HOME_CB_VIDEO = "home:video"
-HOME_CB_DIALOG = "home:dialog"
+NAV_PROFILE = "nav:profile"
+NAV_KB = "nav:kbase"
+NAV_PHOTO = "nav:photo"
+NAV_MUSIC = "nav:music"
+NAV_VIDEO = "nav:video"
+NAV_DIALOG = "nav:dialog"
+
+HOME_CB_PROFILE = NAV_PROFILE
+HOME_CB_KB = NAV_KB
+HOME_CB_PHOTO = NAV_PHOTO
+HOME_CB_MUSIC = NAV_MUSIC
+HOME_CB_VIDEO = NAV_VIDEO
+HOME_CB_DIALOG = NAV_DIALOG
 
 def iter_home_menu_buttons() -> Iterable[Tuple[str, str]]:
     """Yield flattened pairs of ``(text, callback_data)`` for the home layout."""
@@ -40,6 +47,9 @@ def iter_home_menu_buttons() -> Iterable[Tuple[str, str]]:
 AI_MENU_CB = HOME_CB_DIALOG
 AI_TO_SIMPLE_CB = "chat_mode_normal"
 AI_TO_PROMPTMASTER_CB = "chat_mode_pm"
+
+DIALOG_PICK_REGULAR = "dialog:choose_regular"
+DIALOG_PICK_PM = "dialog:choose_promptmaster"
 
 VIDEO_MENU_CB = HOME_CB_VIDEO
 IMAGE_MENU_CB = HOME_CB_PHOTO
@@ -78,6 +88,17 @@ def build_main_reply_kb() -> ReplyKeyboardMarkup:
     for layout_row in layout:
         rows.append([KeyboardButton(text=label) for label, _ in layout_row])
     return ReplyKeyboardMarkup(keyboard=rows, resize_keyboard=True, is_persistent=True)
+
+
+def dialog_picker_inline() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("💬 Обычный чат", callback_data=DIALOG_PICK_REGULAR),
+                InlineKeyboardButton("📝 Prompt-Master", callback_data=DIALOG_PICK_PM),
+            ]
+        ]
+    )
 
 
 def build_empty_reply_kb() -> ReplyKeyboardRemove:

--- a/session_state.py
+++ b/session_state.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+from enum import Enum
+
+from telegram.ext import ContextTypes
+
+
+class ChatMode(str, Enum):
+    OFF = "off"
+    REGULAR = "regular"
+
+
+@dataclass
+class Session:
+    chat_mode: ChatMode = ChatMode.OFF
+
+
+_SESSION_KEY = "__session__"
+
+
+def get_session(ctx: ContextTypes.DEFAULT_TYPE) -> Session:
+    """Return the per-user session object stored in the Telegram context."""
+
+    user_data = getattr(ctx, "user_data", None)
+    if not isinstance(user_data, dict):
+        session = Session()
+        try:
+            setattr(ctx, "user_data", {_SESSION_KEY: session})
+        except Exception:
+            return session
+        return session
+
+    session_obj = user_data.get(_SESSION_KEY)
+    if isinstance(session_obj, Session):
+        return session_obj
+
+    session = Session()
+    user_data[_SESSION_KEY] = session
+    return session
+
+
+def enable_regular_chat(ctx: ContextTypes.DEFAULT_TYPE) -> Session:
+    session = get_session(ctx)
+    session.chat_mode = ChatMode.REGULAR
+    return session
+
+
+def disable_chat(ctx: ContextTypes.DEFAULT_TYPE) -> Session:
+    session = get_session(ctx)
+    session.chat_mode = ChatMode.OFF
+    return session
+
+
+def is_chat_enabled(ctx: ContextTypes.DEFAULT_TYPE) -> bool:
+    return get_session(ctx).chat_mode == ChatMode.REGULAR

--- a/tests/test_keyboards_unified.py
+++ b/tests/test_keyboards_unified.py
@@ -31,12 +31,12 @@ def test_kb_home_menu_layout():
         "🧠 Диалог",
     ]
     assert callbacks == [
-        "home:profile",
-        "home:kb",
-        "home:photo",
-        "home:music",
-        "home:video",
-        "home:dialog",
+        "nav:profile",
+        "nav:kbase",
+        "nav:photo",
+        "nav:music",
+        "nav:video",
+        "nav:dialog",
     ]
 
 


### PR DESCRIPTION
## Summary
- add a dedicated session state helper to track the chat mode locally
- update menu routing to use nav:* and dialog:* callbacks with explicit chat enablement
- refresh inline and reply keyboards plus unit tests to cover the new callback data

## Testing
- pytest tests/test_chat_mode_switch.py tests/test_dialog_modes_exclusive.py tests/test_menu_command.py tests/test_keyboards_unified.py

------
https://chatgpt.com/codex/tasks/task_e_68e2d46d98fc83229b835763ea07ac98