### PR TITLE
Fix profile card lock and update music callbacks

### DIFF
--- a/keyboards.py
+++ b/keyboards.py
@@ -359,7 +359,7 @@ def menu_pay_unified() -> InlineKeyboardMarkup:
 
 
 def suno_start_keyboard() -> InlineKeyboardMarkup:
-    rows = [[InlineKeyboardButton("▶️ Начать генерацию", callback_data="music:suno:start")]]
+    rows = [[InlineKeyboardButton("▶️ Начать генерацию", callback_data="music:start")]]
     return InlineKeyboardMarkup(rows)
 
 

--- a/settings.py
+++ b/settings.py
@@ -32,6 +32,8 @@ class _AppSettings(BaseModel):
     MAX_IN_LOG_BODY: int = Field(default=2048, ge=256, le=65536)
     SUPPORT_USERNAME: str = Field(default="BestAi_Support")
     SUPPORT_USER_ID: int = Field(default=7223448532)
+    BOT_USERNAME: Optional[str] = Field(default=None)
+    REF_BONUS_HINT_ENABLED: bool = Field(default=False)
 
     HTTP_TIMEOUT_CONNECT: float = Field(default=10.0, ge=0.1, le=300.0)
     HTTP_TIMEOUT_READ: float = Field(default=60.0, ge=1.0, le=600.0)
@@ -190,6 +192,15 @@ class _AppSettings(BaseModel):
         text = text.lstrip("@")
         return text or "BestAi_Support"
 
+    @field_validator("BOT_USERNAME", mode="before")
+    def _normalize_bot_username(cls, value: object) -> Optional[str]:
+        if value is None:
+            return None
+        text = str(value).strip()
+        if not text:
+            return None
+        return text.lstrip("@") or None
+
 
 def _load_settings() -> _AppSettings:
     values: dict[str, str] = {}
@@ -232,6 +243,8 @@ SUNO_LOG_KEY = f"{REDIS_PREFIX}:suno:logs"
 UPLOAD_FALLBACK_ENABLED = bool(_APP_SETTINGS.UPLOAD_FALLBACK_ENABLED)
 SUPPORT_USERNAME = _APP_SETTINGS.SUPPORT_USERNAME
 SUPPORT_USER_ID = int(_APP_SETTINGS.SUPPORT_USER_ID)
+BOT_USERNAME = _strip_optional(_APP_SETTINGS.BOT_USERNAME)
+REF_BONUS_HINT_ENABLED = bool(_APP_SETTINGS.REF_BONUS_HINT_ENABLED)
 
 
 def _strip_optional(value: Optional[str]) -> Optional[str]:

--- a/tests/test_start_calls_existing_handler.py
+++ b/tests/test_start_calls_existing_handler.py
@@ -24,7 +24,7 @@ class FakeMessage:
 
 class FakeCallback:
     def __init__(self, chat_id: int) -> None:
-        self.data = "music:suno:start"
+        self.data = "music:start"
         self.message = FakeMessage(chat_id)
         self._answered: list[tuple[str | None, bool]] = []
 

--- a/tests/test_start_idempotent_under_race.py
+++ b/tests/test_start_idempotent_under_race.py
@@ -29,7 +29,7 @@ class FakeMessage:
 
 class FakeCallback:
     def __init__(self, chat_id: int) -> None:
-        self.data = "music:suno:start"
+        self.data = "music:start"
         self.message = FakeMessage(chat_id)
         self._answers: list[tuple[str | None, bool]] = []
 

--- a/tests/test_start_redis_lock_blocks_duplicates.py
+++ b/tests/test_start_redis_lock_blocks_duplicates.py
@@ -29,7 +29,7 @@ class FakeMessage:
 
 class FakeCallback:
     def __init__(self, chat_id: int) -> None:
-        self.data = "music:suno:start"
+        self.data = "music:start"
         self.message = FakeMessage(chat_id)
         self._answers: list[tuple[str | None, bool]] = []
 

--- a/tests/test_start_sends_big_emoji_once.py
+++ b/tests/test_start_sends_big_emoji_once.py
@@ -32,7 +32,7 @@ class FakeMessage:
 
 
 class FakeCallback:
-    def __init__(self, chat_id: int, data: str = "music:suno:start") -> None:
+    def __init__(self, chat_id: int, data: str = "music:start") -> None:
         self.data = data
         self.message = FakeMessage(chat_id)
         self._answered: list[tuple[str | None, bool]] = []
@@ -89,7 +89,7 @@ def test_click_sends_correct_sticker_and_not_prinyato_again(monkeypatch):
     monkeypatch.setattr(bot_module, "_suno_notify", fake_notify)
 
     update = SimpleNamespace(
-        callback_query=FakeCallback(chat_id, data="music:suno:start"),
+        callback_query=FakeCallback(chat_id, data="music:start"),
         effective_chat=SimpleNamespace(id=chat_id),
         effective_user=SimpleNamespace(id=user_id),
     )
@@ -167,7 +167,7 @@ def test_second_click_blocked(monkeypatch):
     monkeypatch.setattr(bot_module, "_suno_notify", fake_notify)
 
     update = SimpleNamespace(
-        callback_query=FakeCallback(chat_id, data="music:suno:start"),
+        callback_query=FakeCallback(chat_id, data="music:start"),
         effective_chat=SimpleNamespace(id=chat_id),
         effective_user=SimpleNamespace(id=user_id),
     )
@@ -216,7 +216,7 @@ def test_start_sticker_fallback_to_emoji(monkeypatch):
     monkeypatch.setattr(bot_module, "safe_send_sticker", failing_sticker)
 
     update = SimpleNamespace(
-        callback_query=FakeCallback(chat_id, data="music:suno:start"),
+        callback_query=FakeCallback(chat_id, data="music:start"),
         effective_chat=SimpleNamespace(id=chat_id),
         effective_user=SimpleNamespace(id=user_id),
     )

--- a/tests/test_start_with_state_flag_blocks_second_click.py
+++ b/tests/test_start_with_state_flag_blocks_second_click.py
@@ -29,7 +29,7 @@ class FakeMessage:
 
 class FakeCallback:
     def __init__(self, chat_id: int) -> None:
-        self.data = "music:suno:start"
+        self.data = "music:start"
         self.message = FakeMessage(chat_id)
         self._answers: list[tuple[str | None, bool]] = []
 

--- a/tests/test_suno_flow.py
+++ b/tests/test_suno_flow.py
@@ -270,7 +270,7 @@ def test_start_message_sent_when_ready() -> None:
     assert SUNO_START_READY_MESSAGE in texts, "start message should be sent when ready"
     last_markup = bot.sent[-1].get("reply_markup")
     assert isinstance(last_markup, InlineKeyboardMarkup)
-    assert last_markup.inline_keyboard[0][0].callback_data == "music:suno:start"
+    assert last_markup.inline_keyboard[0][0].callback_data == "music:start"
 
 
 def test_refresh_skips_duplicate_payload() -> None:


### PR DESCRIPTION
## Summary
- add short-lived action locks and a unified profile card renderer with referral hints and logging
- switch the profile invite button to deeplinks while keeping legacy callbacks backwards compatible
- refresh the music menu and callback router to the new music:* schema and log start events

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3beeba15c832281faaacda97ddc06