### PR TITLE
Fix startup helper and add debug logging

### DIFF
--- a/ui_helpers.py
+++ b/ui_helpers.py
@@ -424,6 +424,14 @@ async def refresh_suno_card(
         generating=generating,
         waiting_enqueue=waiting_enqueue,
     )
+    logger.debug(
+        "suno.refresh_card | chat=%s mode=%s generating=%s waiting=%s ready=%s",
+        chat_id,
+        getattr(suno_state_obj, "mode", None),
+        generating,
+        waiting_enqueue,
+        ready,
+    )
     card_state_raw = state_dict.get("suno_card")
     card_state: MutableMapping[str, Any]
     if isinstance(card_state_raw, MutableMapping):


### PR DESCRIPTION
## Summary
- add a shared `_strip_optional` helper, bot username fallback, dialog flag parsing, and startup logging in settings
- log startup config, callback routing, profile invite links, and Suno start button activity while keeping balance card updates compatible
- add detailed debug output when rendering the Suno card UI

## Testing
- pytest tests/test_text_router.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e3d124bfc083228db6c5e435f1be30