### PR TITLE
Fix reply menu routing and balance consistency

### DIFF
--- a/core/balance_provider.py
+++ b/core/balance_provider.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, Optional
+
+try:  # pragma: no cover - optional dependency in tests
+    from ledger import LedgerStorage
+except Exception:  # pragma: no cover - missing dependency fallback
+    LedgerStorage = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency in tests
+    from redis_utils import get_balance as redis_get_balance
+except Exception:  # pragma: no cover - missing dependency fallback
+    redis_get_balance = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency in tests
+    from settings import DATABASE_URL, LEDGER_BACKEND
+except Exception:  # pragma: no cover - default fallback
+    DATABASE_URL = ""
+    LEDGER_BACKEND = "memory"
+
+__all__ = [
+    "BALANCE_PLACEHOLDER",
+    "BALANCE_WARNING",
+    "BalanceSnapshot",
+    "aget_balance_snapshot",
+    "get_balance_snapshot",
+    "set_ledger_storage",
+]
+
+log = logging.getLogger(__name__)
+
+BALANCE_PLACEHOLDER = "—"
+BALANCE_WARNING = "⚠️ Сервер недоступен. Попробуйте позже."
+
+
+@dataclass(frozen=True)
+class BalanceSnapshot:
+    value: Optional[int]
+    display: str
+    warning: Optional[str] = None
+
+    @property
+    def is_available(self) -> bool:
+        return self.value is not None
+
+
+_LEDGER_STORAGE: Optional[Any] = None
+
+
+def set_ledger_storage(storage: LedgerStorage) -> None:
+    global _LEDGER_STORAGE
+    _LEDGER_STORAGE = storage
+
+
+def _get_ledger_storage() -> Optional[LedgerStorage]:
+    global _LEDGER_STORAGE
+    if (_LEDGER_STORAGE is None) and DATABASE_URL and LedgerStorage is not None:
+        try:
+            _LEDGER_STORAGE = LedgerStorage(DATABASE_URL, backend=LEDGER_BACKEND)
+        except Exception as exc:  # pragma: no cover - defensive
+            log.warning("balance.ledger_init_failed | err=%s", exc)
+            _LEDGER_STORAGE = None
+    return _LEDGER_STORAGE
+
+
+def _build_snapshot(value: Optional[int], warning: Optional[str] = None) -> BalanceSnapshot:
+    if value is None:
+        return BalanceSnapshot(value=None, display=BALANCE_PLACEHOLDER, warning=warning or BALANCE_WARNING)
+    return BalanceSnapshot(value=int(value), display=str(int(value)), warning=None)
+
+
+def get_balance_snapshot(user_id: int, *, retries: int = 2) -> BalanceSnapshot:
+    attempts = max(int(retries), 1)
+    if redis_get_balance is not None:
+        for attempt in range(attempts):
+            try:
+                value = redis_get_balance(user_id)
+            except Exception as exc:
+                log.warning(
+                    "balance.fetch_retry | user=%s attempt=%s err=%s",
+                    user_id,
+                    attempt + 1,
+                    exc,
+                )
+            else:
+                return _build_snapshot(value)
+    else:
+        log.warning("balance.redis_unavailable | user=%s", user_id)
+
+    ledger = _get_ledger_storage()
+    if ledger is not None and hasattr(ledger, "get_balance"):
+        try:
+            value = ledger.get_balance(user_id)
+        except Exception as exc:  # pragma: no cover - database unavailable
+            log.warning("balance.fetch_db_failed | user=%s err=%s", user_id, exc)
+        else:
+            return _build_snapshot(value)
+
+    return _build_snapshot(None)
+
+
+async def aget_balance_snapshot(user_id: int, *, retries: int = 2) -> BalanceSnapshot:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, partial(get_balance_snapshot, user_id, retries=retries))

--- a/pydantic_settings.py
+++ b/pydantic_settings.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from pydantic import BaseModel
+
+
+class SettingsConfigDict(dict):
+    """Lightweight stand-in for :class:`pydantic_settings.SettingsConfigDict`."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - simple wrapper
+        super().__init__(*args, **kwargs)
+
+
+class BaseSettings(BaseModel):
+    """Minimal fallback implementation used in tests."""
+
+    model_config: SettingsConfigDict = SettingsConfigDict()
+
+    def __init__(self, **data: Any) -> None:  # pragma: no cover - simple env loader
+        env_values: Dict[str, Any] = {}
+        for field_name in self.model_fields:
+            env_key = field_name.upper()
+            if env_key in os.environ:
+                env_values[field_name] = os.environ[env_key]
+        env_values.update(data)
+        super().__init__(**env_values)
+
+    def model_dump(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - passthrough
+        return super().model_dump(*args, **kwargs)

--- a/redis_utils.py
+++ b/redis_utils.py
@@ -552,6 +552,19 @@ def user_lock(user_id: Optional[int], key: str, ttl: int = 30) -> bool:
     return _memory_set_if_absent(lock_key, "1", ttl_value)
 
 
+def release_user_lock(user_id: Optional[int], key: str) -> None:
+    if not user_id:
+        return
+    lock_key = _user_lock_key(int(user_id), key)
+    if _r:
+        try:
+            _r.delete(lock_key)
+        except Exception as exc:  # pragma: no cover - network errors
+            _logger.debug("user_lock.release_error | key=%s err=%s", lock_key, exc)
+    else:
+        _memory_delete(lock_key)
+
+
 def acquire_action_lock(
     user_id: Optional[int],
     action: str,

--- a/tests/test_balance_consistency.py
+++ b/tests/test_balance_consistency.py
@@ -1,0 +1,86 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import os
+
+os.environ.setdefault("TELEGRAM_TOKEN", "test-token")
+os.environ.setdefault("REDIS_URL", "memory://")
+os.environ.setdefault("KIE_API_KEY", "test-key")
+os.environ.setdefault("LEDGER_BACKEND", "memory")
+
+import bot as bot_module
+from core.balance_provider import BalanceSnapshot
+
+
+def _make_context() -> SimpleNamespace:
+    return SimpleNamespace(user_data={}, application=SimpleNamespace(logger=None))
+
+
+def test_balance_memoization_between_cards(monkeypatch):
+    ctx = _make_context()
+    uid = 777
+
+    snapshots = [
+        BalanceSnapshot(value=495, display="495"),
+        BalanceSnapshot(value=777, display="777"),
+    ]
+
+    def fake_get_balance_snapshot(user_id: int):
+        assert user_id == uid
+        return snapshots.pop(0)
+
+    monkeypatch.setattr(bot_module, "get_balance_snapshot", fake_get_balance_snapshot)
+
+    welcome = bot_module.render_welcome_for(uid, ctx)
+    assert "495" in welcome
+
+    cached = bot_module._resolve_balance_snapshot(ctx, uid, prefer_cached=True)
+    assert cached.display == "495"
+
+
+def test_balance_profile_uses_cached_snapshot(monkeypatch):
+    ctx = _make_context()
+    uid = 555
+
+    snapshots = [
+        BalanceSnapshot(value=495, display="495"),
+        BalanceSnapshot(value=123, display="123"),
+    ]
+
+    def fake_get_balance_snapshot(user_id: int):
+        assert user_id == uid
+        return snapshots.pop(0)
+
+    monkeypatch.setattr(bot_module, "get_balance_snapshot", fake_get_balance_snapshot)
+
+    bot_module.render_welcome_for(uid, ctx)
+
+    profile_snapshot = bot_module._resolve_balance_snapshot(ctx, uid, prefer_cached=True)
+    profile_text = bot_module._profile_balance_text(profile_snapshot)
+    assert "495" in profile_text
+    assert "123" not in profile_text
+
+
+def test_balance_error_shows_placeholder(monkeypatch):
+    ctx = _make_context()
+    uid = 888
+
+    fallback = BalanceSnapshot(value=None, display="—", warning="⚠️ Сервер недоступен")
+
+    monkeypatch.setattr(bot_module, "get_balance_snapshot", lambda user_id: fallback)
+
+    welcome = bot_module.render_welcome_for(uid, ctx, balance=fallback)
+    assert "—" in welcome
+    assert "сервер недоступен" in welcome.lower()
+    assert "0" not in welcome
+
+    profile_text = bot_module._profile_balance_text(fallback)
+    assert "—" in profile_text
+    assert "сервер недоступен" in profile_text.lower()

--- a/tests/test_reply_buttons.py
+++ b/tests/test_reply_buttons.py
@@ -1,0 +1,86 @@
+import asyncio
+from types import SimpleNamespace
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import os
+
+os.environ.setdefault("TELEGRAM_TOKEN", "test-token")
+os.environ.setdefault("REDIS_URL", "memory://")
+os.environ.setdefault("KIE_API_KEY", "test-key")
+
+import hub_router
+from keyboards import TEXT_ACTION_VARIANTS
+
+
+class StubBot:
+    async def edit_message_text(self, **kwargs):  # pragma: no cover - not used
+        return SimpleNamespace(message_id=kwargs.get("message_id"))
+
+    async def edit_message_reply_markup(self, **kwargs):  # pragma: no cover - not used
+        return SimpleNamespace(message_id=kwargs.get("message_id"))
+
+    async def send_message(self, **kwargs):  # pragma: no cover - not used
+        return SimpleNamespace(message_id=kwargs.get("message_id", 42))
+
+
+@pytest.fixture(autouse=True)
+def _clean_router(monkeypatch):
+    monkeypatch.setattr(hub_router, "_ROUTES", {})
+    monkeypatch.setattr(hub_router, "_FALLBACK_HANDLER", None)
+    yield
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("Профиль", ("menu", "profile")),
+        ("База знаний", ("menu", "kb")),
+        ("Фото", ("menu", "photo")),
+        ("Музыка", ("menu", "music")),
+        ("Видео", ("menu", "video")),
+        ("Диалог", ("menu", "dialog")),
+    ],
+)
+def test_reply_button_routes_text_dispatch(text, expected):
+    calls = []
+
+    @hub_router.register(*expected)
+    async def _handler(ctx: hub_router.CallbackContext) -> None:  # type: ignore[override]
+        calls.append((ctx.namespace, ctx.action))
+
+    ctx = SimpleNamespace(
+        bot=StubBot(),
+        user_data={},
+        application=SimpleNamespace(logger=None),
+    )
+    message = SimpleNamespace(
+        text=text,
+        chat=SimpleNamespace(id=123),
+        message_id=77,
+    )
+    update = SimpleNamespace(
+        effective_message=message,
+        effective_chat=message.chat,
+        effective_user=SimpleNamespace(id=999),
+        callback_query=None,
+    )
+
+    asyncio.run(hub_router.route_text(update, ctx))
+
+    assert calls == [expected]
+
+
+@pytest.mark.parametrize("label", list(TEXT_ACTION_VARIANTS.keys()))
+def test_text_action_variants_cover_reply_labels(label):
+    normalized = hub_router.resolve_text_action(label)
+    assert normalized is not None

--- a/utils/text_normalizer.py
+++ b/utils/text_normalizer.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+__all__ = ["normalize_btn_text"]
+
+
+_LEADING_SYMBOLS_RE = re.compile(r"^[\W_]+", re.UNICODE)
+_MULTI_SPACE_RE = re.compile(r"\s+")
+
+
+def normalize_btn_text(value: Optional[str]) -> str:
+    """Normalize button text for routing purposes."""
+
+    if not value:
+        return ""
+
+    text = str(value).strip()
+    if not text:
+        return ""
+
+    text = _LEADING_SYMBOLS_RE.sub("", text)
+    if not text:
+        return ""
+
+    text = _MULTI_SPACE_RE.sub(" ", text).strip()
+    return text.lower()


### PR DESCRIPTION
## Summary
- add a dedicated balance provider with retry-aware snapshot helpers and reuse them across the bot UI
- normalize reply keyboard texts, lazily map them to callback actions, and update the hub router to dispatch text events with logging and debounce cleanup
- refresh hub/profile balance rendering to show warnings consistently and extend test coverage for reply buttons and balance memoization

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4f79b62b883229d5c40a52fafc577