### PR TITLE
Implement VEO animate flow for Telegram bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -72,12 +72,15 @@ from handlers import (
     faq_command,
     help_command,
     get_pm_prompt,
+    handle_veo_animate_photo,
     prompt_master_callback,
     prompt_master_handle_text,
     prompt_master_open,
     prompt_master_process,
     prompt_master_reset,
     clear_pm_prompts,
+    veo_animate,
+    veo_animate_command,
 )
 
 from prompt_master import (
@@ -5299,6 +5302,7 @@ VIDEO_CALLBACK_ALIASES = {
     "mode:sora2_ttv": CB.VIDEO_MODE_SORA_TEXT,
     "mode:sora2_itv": CB.VIDEO_MODE_SORA_IMAGE,
     "video:back": CB.VIDEO_MENU_BACK,
+    "video:veo_animate": CB.VIDEO_VEO_ANIMATE,
 }
 VIDEO_MODE_CALLBACK_MAP = {
     CB.VIDEO_MODE_VEO_FAST: "veo_text_fast",
@@ -14588,6 +14592,10 @@ async def video_menu_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) ->
                 answer_payload["text"] = "Обрабатываю…"
             return
 
+        if data in {CB.VIDEO_VEO_ANIMATE, "video:veo_animate"}:
+            await veo_animate(update, ctx)
+            return
+
         if data == CB.VIDEO_PICK_VEO:
             if chat_id is None:
                 return
@@ -17242,6 +17250,7 @@ async def on_photo(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     await message.reply_text("🖼️ Фото принято как референс.")
     if chat_id is not None and s.get("mode") in ("veo_text_fast", "veo_photo"):
         await show_veo_card(chat_id, ctx)
+    await handle_veo_animate_photo(update, ctx, image_url=url)
 
 
 async def on_document(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
@@ -18206,6 +18215,7 @@ PRIORITY_COMMAND_SPECS: List[tuple[tuple[str, ...], Any]] = [
     (("history",), chat_history_command),
     (("image", "mj"), image_command),
     (("video", "veo"), video_command),
+    (("veo_animate", "animate"), veo_animate_command),
     (("music", "suno"), suno_command),
     (("balance",), balance_command),
     (("kb", "knowledge_base"), kb_command),

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -11,6 +11,7 @@ from .prompt_master_handler import (
     prompt_master_process,
     prompt_master_reset,
 )
+from .video import handle_veo_animate_photo, veo_animate, veo_animate_command
 
 __all__ = [
     "clear_pm_prompts",
@@ -25,4 +26,7 @@ __all__ = [
     "prompt_master_open",
     "prompt_master_process",
     "prompt_master_reset",
+    "veo_animate",
+    "veo_animate_command",
+    "handle_veo_animate_photo",
 ]

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -4,7 +4,7 @@ from typing import Sequence
 
 from telegram import InlineKeyboardButton
 
-from keyboards import kb_main
+from keyboards import CB, kb_main
 from texts import (
     TXT_AI_DIALOG_CHOOSE,
     TXT_AI_DIALOG_NORMAL,
@@ -69,7 +69,7 @@ def build_video_card(*, veo_fast_cost: int, veo_photo_cost: int) -> dict:
         [
             InlineKeyboardButton(
                 f"Оживить изображение (Veo) — 💎 {veo_photo_cost}",
-                callback_data="mode:veo_photo",
+                callback_data=CB.VIDEO_VEO_ANIMATE,
             )
         ],
         [InlineKeyboardButton("⬅️ Назад", callback_data="back")],

--- a/handlers/video.py
+++ b/handlers/video.py
@@ -1,0 +1,467 @@
+"""Handlers for the simplified VEO animate flow."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any, Mapping, MutableMapping, Optional, Sequence
+from urllib.parse import urlparse
+
+import httpx
+from telegram import Update
+from telegram.ext import ContextTypes
+from telegram.error import TelegramError
+
+from settings import (
+    HTTP_TIMEOUT_CONNECT,
+    HTTP_TIMEOUT_READ,
+    HTTP_TIMEOUT_TOTAL,
+    KIE_API_KEY,
+    KIE_BASE_URL,
+    KIE_GEN_PATH,
+    KIE_HD_PATH,
+    KIE_STATUS_PATH,
+)
+
+from redis_utils import remember_veo_anim_job
+
+logger = logging.getLogger("veo.anim")
+
+_POLL_INTERVAL = 2.0
+_POLL_TIMEOUT = 240.0
+_MAX_VIDEO_BYTES = 50 * 1024 * 1024
+_WAIT_FLAG = "veo_animate_waiting_photo"
+
+_ERROR_TIMEOUT = "Не удалось оживить изображение вовремя. Попробуйте ещё раз."
+_ERROR_BAD_REQUEST = (
+    "Запрос отклонён. Измените описание и избегайте запрещённого контента."
+)
+_ERROR_GENERIC = "Что-то пошло не так. Попробуйте другой кадр или запрос."
+_PROMPT_PHOTO = "📸 Отправьте фото, и я сразу попробую его оживить."
+
+
+class VeoAnimateError(RuntimeError):
+    """Base class for VEO animate errors."""
+
+
+class VeoAnimateBadRequest(VeoAnimateError):
+    """Raised when backend rejects the request due to bad input."""
+
+
+class VeoAnimateTimeout(VeoAnimateError):
+    """Raised when polling timed out."""
+
+
+class VeoAnimateHTTPError(VeoAnimateError):
+    """Raised for non-2xx HTTP responses."""
+
+    def __init__(self, status_code: int, payload: Mapping[str, Any]):
+        super().__init__(f"HTTP {status_code}")
+        self.status_code = int(status_code)
+        self.payload = payload
+
+
+def _http_timeout() -> httpx.Timeout:
+    total = float(HTTP_TIMEOUT_TOTAL or 75.0)
+    connect = float(HTTP_TIMEOUT_CONNECT or 10.0)
+    read = float(HTTP_TIMEOUT_READ or 60.0)
+    return httpx.Timeout(timeout=total, connect=connect, read=read)
+
+
+def _headers(method: str) -> Mapping[str, str]:
+    token = (KIE_API_KEY or "").strip()
+    if token and not token.lower().startswith("bearer "):
+        token = f"Bearer {token}"
+    headers = {"Authorization": token} if token else {}
+    if method.upper() == "POST":
+        headers = {**headers, "Content-Type": "application/json"}
+    return headers
+
+
+async def _request_json(
+    method: str,
+    path: str,
+    *,
+    json_payload: Optional[Mapping[str, Any]] = None,
+    params: Optional[Mapping[str, Any]] = None,
+    client: Optional[httpx.AsyncClient] = None,
+) -> Mapping[str, Any]:
+    own_client = client is None
+    if own_client:
+        client = httpx.AsyncClient(base_url=KIE_BASE_URL, timeout=_http_timeout())
+    try:
+        response = await client.request(
+            method,
+            path,
+            json=json_payload,
+            params=params,
+            headers=_headers(method),
+            follow_redirects=True,
+        )
+    except httpx.TimeoutException as exc:  # pragma: no cover - network guard
+        raise VeoAnimateError("timeout") from exc
+    except httpx.RequestError as exc:  # pragma: no cover - network guard
+        raise VeoAnimateError("network") from exc
+    finally:
+        if own_client:
+            await client.aclose()
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = {"raw": response.text}
+    if response.status_code >= 400:
+        raise VeoAnimateHTTPError(response.status_code, payload)
+    if not isinstance(payload, Mapping):
+        return {"value": payload}
+    return payload
+
+
+def _ensure_state(context: ContextTypes.DEFAULT_TYPE) -> MutableMapping[str, Any]:
+    user_data = getattr(context, "user_data", None)
+    if not isinstance(user_data, MutableMapping):
+        user_data = {}
+        setattr(context, "user_data", user_data)
+    state = user_data.get("state")
+    if not isinstance(state, MutableMapping):
+        state = {}
+        user_data["state"] = state
+    return state
+
+
+def _extract_mapping(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    data = payload.get("data")
+    if isinstance(data, Mapping):
+        return data
+    return payload
+
+
+def _normalize_status(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    mapping = {
+        "success": "done",
+        "succeeded": "done",
+        "completed": "done",
+        "finish": "done",
+        "finished": "done",
+        "ok": "done",
+        "1": "done",
+        "true": "done",
+        "pending": "pending",
+        "queued": "pending",
+        "queue": "pending",
+        "wait": "pending",
+        "waiting": "pending",
+        "processing": "processing",
+        "in_progress": "processing",
+    }
+    if text in mapping:
+        return mapping[text]
+    if text.startswith("done") or text.startswith("success"):
+        return "done"
+    if text.startswith("pend") or text.startswith("wait"):
+        return "pending"
+    if text.startswith("process"):
+        return "processing"
+    if text in {"0", "false"}:
+        return "pending"
+    return text or None
+
+
+def _extract_status(payload: Mapping[str, Any]) -> Optional[str]:
+    data = _extract_mapping(payload)
+    for key in ("status", "state", "jobStatus", "successFlag"):
+        value = data.get(key) if key in data else payload.get(key)
+        normalized = _normalize_status(value)
+        if normalized:
+            return normalized
+    return None
+
+
+def _normalize_url_values(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        if text.startswith("["):
+            try:
+                parsed = json.loads(text)
+            except ValueError:
+                pass
+            else:
+                return _normalize_url_values(parsed)
+        if text.lower().startswith("http"):
+            return [text]
+        return []
+    if isinstance(value, Mapping):
+        collected: list[str] = []
+        for key in ("url", "resultUrl", "originUrl", "videoUrl"):
+            collected.extend(_normalize_url_values(value.get(key)))
+        if "urls" in value:
+            collected.extend(_normalize_url_values(value.get("urls")))
+        return collected
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        collected: list[str] = []
+        for item in value:
+            collected.extend(_normalize_url_values(item))
+        return collected
+    return []
+
+
+def _extract_result_candidates(payload: Mapping[str, Any]) -> list[str]:
+    urls: list[str] = []
+    if isinstance(payload, Mapping):
+        urls.extend(_normalize_url_values(payload.get("result")))
+        urls.extend(_normalize_url_values(payload.get("resultUrl")))
+        urls.extend(_normalize_url_values(payload.get("resultUrls")))
+        urls.extend(_normalize_url_values(payload.get("videoUrl")))
+        urls.extend(_normalize_url_values(payload.get("videoUrls")))
+        urls.extend(_normalize_url_values(payload.get("urls")))
+    data = _extract_mapping(payload)
+    if data is not payload:
+        urls.extend(_extract_result_candidates(data))
+    unique: list[str] = []
+    seen: set[str] = set()
+    for url in urls:
+        if url and url not in seen:
+            unique.append(url)
+            seen.add(url)
+    return unique
+
+
+def _extract_hd_task_id(payload: Mapping[str, Any]) -> Optional[str]:
+    data = _extract_mapping(payload)
+    for key in (
+        "hdTaskId",
+        "hd_task_id",
+        "hdTaskID",
+        "taskHdId",
+        "1080TaskId",
+    ):
+        value = data.get(key) if key in data else payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+async def _fetch_hd_urls(
+    client: httpx.AsyncClient,
+    task_id: str,
+) -> list[str]:
+    try:
+        payload = await _request_json("GET", KIE_HD_PATH, params={"taskId": task_id}, client=client)
+    except VeoAnimateHTTPError:
+        return []
+    except VeoAnimateError:  # pragma: no cover - defensive fallback
+        return []
+    return _extract_result_candidates(payload)
+
+
+async def _start_animation(image_url: str, prompt: Optional[str]) -> str:
+    payload = {"image_url": image_url}
+    if prompt:
+        payload["prompt"] = prompt
+    try:
+        data = await _request_json("POST", KIE_GEN_PATH, json_payload=payload)
+    except VeoAnimateHTTPError as exc:
+        if 400 <= exc.status_code < 500:
+            raise VeoAnimateBadRequest("start rejected") from exc
+        raise VeoAnimateError("start failed") from exc
+    job_id = None
+    for key in ("job_id", "jobId", "taskId", "id"):
+        if key in data:
+            job_id = data[key]
+            break
+        inner = data.get("data") if isinstance(data.get("data"), Mapping) else None
+        if inner and key in inner:
+            job_id = inner[key]
+            break
+    if job_id is None:
+        raise VeoAnimateError("missing job id")
+    return str(job_id)
+
+
+async def _wait_for_result(job_id: str) -> tuple[list[str], Mapping[str, Any]]:
+    deadline = time.monotonic() + _POLL_TIMEOUT
+    async with httpx.AsyncClient(base_url=KIE_BASE_URL, timeout=_http_timeout()) as client:
+        while time.monotonic() < deadline:
+            try:
+                payload = await _request_json(
+                    "GET",
+                    KIE_STATUS_PATH,
+                    params={"taskId": job_id},
+                    client=client,
+                )
+            except VeoAnimateHTTPError as exc:
+                if 400 <= exc.status_code < 500:
+                    raise VeoAnimateBadRequest("status rejected") from exc
+                raise VeoAnimateError("status failed") from exc
+            status = _extract_status(payload)
+            normalized = status or "pending"
+            if normalized in {"pending", "queue", "waiting"}:
+                await asyncio.sleep(_POLL_INTERVAL)
+                continue
+            if normalized == "processing":
+                await asyncio.sleep(_POLL_INTERVAL)
+                continue
+            if normalized in {"done", "success", "succeed", "completed"}:
+                urls = _extract_result_candidates(payload)
+                if urls:
+                    return urls, payload
+                hd_task = _extract_hd_task_id(payload)
+                if hd_task:
+                    hd_urls = await _fetch_hd_urls(client, hd_task)
+                    if hd_urls:
+                        return hd_urls, payload
+                raise VeoAnimateError("result missing")
+            if normalized in {"failed", "error", "blocked", "rejected"}:
+                raise VeoAnimateBadRequest("generation rejected")
+            await asyncio.sleep(_POLL_INTERVAL)
+    raise VeoAnimateTimeout("poll timeout")
+
+
+async def _fetch_content_length(url: str) -> Optional[int]:
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+            response = await client.head(url, follow_redirects=True)
+    except Exception:  # pragma: no cover - network guard
+        return None
+    value = response.headers.get("Content-Length") or response.headers.get("content-length")
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        return None
+
+
+def _shorten_url(url: str) -> str:
+    try:
+        parsed = urlparse(url)
+    except ValueError:  # pragma: no cover - defensive guard
+        return url[:60]
+    host = parsed.netloc
+    tail = parsed.path.rstrip("/").split("/")[-1]
+    if host and tail:
+        return f"{host}/{tail}"[-60:]
+    if host:
+        return host
+    return url[:60]
+
+
+async def _send_error(bot: Any, chat_id: Optional[int], text: str) -> None:
+    if chat_id is None:
+        return
+    try:
+        await bot.send_message(chat_id=chat_id, text=text)
+    except TelegramError:  # pragma: no cover - defensive guard
+        logger.exception("veo.anim.error_message_fail chat=%s", chat_id)
+    except Exception:  # pragma: no cover - defensive guard
+        logger.exception("veo.anim.error_message_fail chat=%s", chat_id)
+
+
+async def veo_animate(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    *,
+    image_url: Optional[str] = None,
+    auto_started: bool = False,
+) -> None:
+    chat = update.effective_chat
+    chat_id = chat.id if chat else None
+    user = update.effective_user
+    user_id = user.id if user else None
+    state = _ensure_state(context)
+    source_url = image_url or state.get("last_image_url")
+    prompt = state.get("last_prompt") if isinstance(state.get("last_prompt"), str) else None
+
+    if not source_url:
+        state[_WAIT_FLAG] = True
+        if not auto_started:
+            await _send_error(context.bot, chat_id, _PROMPT_PHOTO)
+        return
+
+    state[_WAIT_FLAG] = False
+
+    try:
+        job_id = await _start_animation(source_url, prompt)
+    except VeoAnimateBadRequest:
+        logger.info("veo.anim.fail user=%s reason=bad_request", user_id)
+        await _send_error(context.bot, chat_id, _ERROR_BAD_REQUEST)
+        return
+    except VeoAnimateError:
+        logger.info("veo.anim.fail user=%s reason=error", user_id)
+        await _send_error(context.bot, chat_id, _ERROR_GENERIC)
+        return
+
+    if user_id is not None:
+        remember_veo_anim_job(user_id, job_id)
+    logger.info("veo.anim.request user=%s job=%s", user_id, job_id)
+
+    try:
+        urls, _payload = await _wait_for_result(job_id)
+    except VeoAnimateTimeout:
+        logger.info("veo.anim.fail user=%s reason=timeout", user_id)
+        await _send_error(context.bot, chat_id, _ERROR_TIMEOUT)
+        return
+    except VeoAnimateBadRequest:
+        logger.info("veo.anim.fail user=%s reason=bad_request", user_id)
+        await _send_error(context.bot, chat_id, _ERROR_BAD_REQUEST)
+        return
+    except VeoAnimateError:
+        logger.info("veo.anim.fail user=%s reason=error", user_id)
+        await _send_error(context.bot, chat_id, _ERROR_GENERIC)
+        return
+
+    if not urls:
+        logger.info("veo.anim.fail user=%s reason=error", user_id)
+        await _send_error(context.bot, chat_id, _ERROR_GENERIC)
+        return
+
+    result_url = urls[0]
+    logger.info("veo.anim.done user=%s url=%s", user_id, _shorten_url(result_url))
+    if chat_id is None:
+        return
+
+    size = await _fetch_content_length(result_url)
+    try:
+        if size is not None and size > _MAX_VIDEO_BYTES:
+            await context.bot.send_document(chat_id=chat_id, document=result_url)
+        else:
+            await context.bot.send_video(chat_id=chat_id, video=result_url)
+    except TelegramError:
+        logger.exception("veo.anim.telegram_send_fail user=%s", user_id)
+        await _send_error(context.bot, chat_id, _ERROR_GENERIC)
+    except Exception:  # pragma: no cover - defensive guard
+        logger.exception("veo.anim.telegram_send_fail user=%s", user_id)
+        await _send_error(context.bot, chat_id, _ERROR_GENERIC)
+
+
+async def veo_animate_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await veo_animate(update, context)
+
+
+async def handle_veo_animate_photo(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    *,
+    image_url: str,
+) -> None:
+    state = _ensure_state(context)
+    if not state.get(_WAIT_FLAG):
+        return
+    state[_WAIT_FLAG] = False
+    await veo_animate(update, context, image_url=image_url, auto_started=True)
+
+
+__all__ = [
+    "VeoAnimateBadRequest",
+    "VeoAnimateError",
+    "VeoAnimateTimeout",
+    "handle_veo_animate_photo",
+    "veo_animate",
+    "veo_animate_command",
+]

--- a/keyboards.py
+++ b/keyboards.py
@@ -323,6 +323,7 @@ class CB:
     VIDEO_MODE_VEO_PHOTO = "cb:video:veo:mode:photo"
     VIDEO_MODE_SORA_TEXT = "cb:video:sora2:mode:ttv"
     VIDEO_MODE_SORA_IMAGE = "cb:video:sora2:mode:itv"
+    VIDEO_VEO_ANIMATE = "cb:video:veo:animate"
 
 
 # Backwards compatibility constants (to be removed once call sites migrate).

--- a/settings.py
+++ b/settings.py
@@ -37,6 +37,9 @@ def _populate_from_settings() -> None:
 
     g["KIE_BASE_URL"] = settings.KIE_BASE_URL
     g["KIE_API_KEY"] = settings.KIE_API_KEY
+    g["KIE_GEN_PATH"] = settings.KIE_GEN_PATH
+    g["KIE_STATUS_PATH"] = settings.KIE_STATUS_PATH
+    g["KIE_HD_PATH"] = settings.KIE_HD_PATH
 
     g["TELEGRAM_TOKEN"] = settings.TELEGRAM_TOKEN
     g["REDIS_URL"] = settings.REDIS_URL

--- a/tests/test_veo_animate.py
+++ b/tests/test_veo_animate.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("TELEGRAM_TOKEN", "test-token")
+os.environ.setdefault("REDIS_URL", "memory://test")
+os.environ.setdefault("KIE_API_KEY", "test-kie-key")
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from handlers import video as video_module
+
+
+class DummyBot:
+    def __init__(self) -> None:
+        self.sent_messages: list[tuple[int, str]] = []
+        self.sent_videos: list[tuple[int, str]] = []
+        self.sent_documents: list[tuple[int, str]] = []
+
+    async def send_message(self, *, chat_id: int, text: str) -> SimpleNamespace:  # type: ignore[override]
+        self.sent_messages.append((chat_id, text))
+        return SimpleNamespace(message_id=len(self.sent_messages))
+
+    async def send_video(self, *, chat_id: int, video: str) -> SimpleNamespace:  # type: ignore[override]
+        self.sent_videos.append((chat_id, video))
+        return SimpleNamespace(message_id=len(self.sent_videos))
+
+    async def send_document(self, *, chat_id: int, document: str) -> SimpleNamespace:  # type: ignore[override]
+        self.sent_documents.append((chat_id, document))
+        return SimpleNamespace(message_id=len(self.sent_documents))
+
+
+def _make_update(chat_id: int = 101, user_id: int = 202) -> SimpleNamespace:
+    return SimpleNamespace(
+        effective_chat=SimpleNamespace(id=chat_id),
+        effective_user=SimpleNamespace(id=user_id),
+        effective_message=None,
+        callback_query=None,
+    )
+
+
+def _make_context(bot: DummyBot, state: dict | None = None) -> SimpleNamespace:
+    return SimpleNamespace(bot=bot, user_data={"state": state or {}})
+
+
+def test_veo_animate_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = DummyBot()
+    ctx = _make_context(bot, {"last_image_url": "https://img.example/photo.jpg", "last_prompt": "smile"})
+    update = _make_update()
+
+    calls: list[tuple[str, str | None]] = []
+
+    async def fake_start(image_url: str, prompt: str | None) -> str:
+        calls.append((image_url, prompt))
+        return "job-1"
+
+    async def fake_wait(job_id: str) -> tuple[list[str], dict]:
+        assert job_id == "job-1"
+        return ["https://cdn.example/video.mp4"], {"status": "done"}
+
+    async def fake_fetch(url: str) -> int:
+        return 10 * 1024 * 1024
+
+    monkeypatch.setattr(video_module, "_start_animation", fake_start)
+    monkeypatch.setattr(video_module, "_wait_for_result", fake_wait)
+    monkeypatch.setattr(video_module, "_fetch_content_length", fake_fetch)
+    stored: list[tuple[int, str]] = []
+
+    def fake_remember(user_id: int, job_id: str, *, ttl: int = 0) -> None:
+        stored.append((user_id, job_id))
+
+    monkeypatch.setattr(video_module, "remember_veo_anim_job", fake_remember)
+
+    asyncio.run(video_module.veo_animate(update, ctx))
+
+    assert calls == [("https://img.example/photo.jpg", "smile")]
+    assert bot.sent_videos == [(101, "https://cdn.example/video.mp4")]
+    assert bot.sent_documents == []
+    assert bot.sent_messages == []
+    assert stored == [(202, "job-1")]
+
+
+def test_veo_animate_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = DummyBot()
+    ctx = _make_context(bot, {"last_image_url": "https://img.example/photo.jpg"})
+    update = _make_update()
+
+    async def fake_start(image_url: str, prompt: str | None) -> str:
+        return "job-2"
+
+    async def fake_wait(job_id: str) -> tuple[list[str], dict]:
+        raise video_module.VeoAnimateTimeout("timeout")
+
+    monkeypatch.setattr(video_module, "_start_animation", fake_start)
+    monkeypatch.setattr(video_module, "_wait_for_result", fake_wait)
+    async def fake_fetch(url: str) -> int:
+        return 0
+
+    monkeypatch.setattr(video_module, "_fetch_content_length", fake_fetch)
+    monkeypatch.setattr(video_module, "remember_veo_anim_job", lambda *args, **kwargs: None)
+
+    asyncio.run(video_module.veo_animate(update, ctx))
+
+    assert bot.sent_videos == []
+    assert bot.sent_documents == []
+    assert bot.sent_messages == [(101, video_module._ERROR_TIMEOUT)]
+
+
+def test_veo_animate_bad_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = DummyBot()
+    ctx = _make_context(bot, {"last_image_url": "https://img.example/photo.jpg"})
+    update = _make_update()
+
+    async def fake_start(image_url: str, prompt: str | None) -> str:
+        raise video_module.VeoAnimateBadRequest("bad")
+
+    monkeypatch.setattr(video_module, "_start_animation", fake_start)
+    async def fake_fetch(url: str) -> int:
+        return 0
+
+    monkeypatch.setattr(video_module, "_fetch_content_length", fake_fetch)
+    monkeypatch.setattr(video_module, "remember_veo_anim_job", lambda *args, **kwargs: None)
+
+    asyncio.run(video_module.veo_animate(update, ctx))
+
+    assert bot.sent_messages == [(101, video_module._ERROR_BAD_REQUEST)]
+    assert bot.sent_videos == []
+
+
+def test_veo_animate_list_of_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = DummyBot()
+    ctx = _make_context(bot, {"last_image_url": "https://img.example/photo.jpg"})
+    update = _make_update()
+
+    async def fake_start(image_url: str, prompt: str | None) -> str:
+        return "job-3"
+
+    async def fake_wait(job_id: str) -> tuple[list[str], dict]:
+        return ["https://cdn.example/a.mp4", "https://cdn.example/b.mp4"], {"status": "done"}
+
+    monkeypatch.setattr(video_module, "_start_animation", fake_start)
+    monkeypatch.setattr(video_module, "_wait_for_result", fake_wait)
+    async def fake_fetch(url: str) -> None:
+        return None
+
+    monkeypatch.setattr(video_module, "_fetch_content_length", fake_fetch)
+    monkeypatch.setattr(video_module, "remember_veo_anim_job", lambda *args, **kwargs: None)
+
+    asyncio.run(video_module.veo_animate(update, ctx))
+
+    assert bot.sent_videos == [(101, "https://cdn.example/a.mp4")]
+    assert all("http" in msg for _, msg in bot.sent_videos)
+    assert bot.sent_messages == []
+
+
+def test_veo_animate_waits_for_photo(monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = DummyBot()
+    ctx = _make_context(bot)
+    update = _make_update()
+
+    call_counter: list[str] = []
+
+    async def fake_start(image_url: str, prompt: str | None) -> str:
+        call_counter.append(image_url)
+        return "job-4"
+
+    async def fake_wait(job_id: str) -> tuple[list[str], dict]:
+        return ["https://cdn.example/auto.mp4"], {"status": "done"}
+
+    monkeypatch.setattr(video_module, "_start_animation", fake_start)
+    monkeypatch.setattr(video_module, "_wait_for_result", fake_wait)
+    async def fake_fetch(url: str) -> int:
+        return 0
+
+    monkeypatch.setattr(video_module, "_fetch_content_length", fake_fetch)
+    monkeypatch.setattr(video_module, "remember_veo_anim_job", lambda *args, **kwargs: None)
+
+    asyncio.run(video_module.veo_animate(update, ctx))
+    assert bot.sent_messages == [(101, video_module._PROMPT_PHOTO)]
+    assert video_module._WAIT_FLAG in ctx.user_data["state"]
+
+    asyncio.run(
+        video_module.handle_veo_animate_photo(
+            update, ctx, image_url="https://img.example/new.jpg"
+        )
+    )
+
+    assert call_counter == ["https://img.example/new.jpg"]
+    assert bot.sent_videos[-1] == (101, "https://cdn.example/auto.mp4")


### PR DESCRIPTION
## Summary
- add a dedicated VEO animate handler that calls the KIE backend, polls for completion, and delivers videos or localized errors
- wire the video menu button, command, and photo handler to trigger the animation flow and record jobs in Redis
- expose the required settings, keyboard constant, and add coverage for happy path, timeouts, bad requests, and list results

## Testing
- pytest tests/test_veo_animate.py

------
https://chatgpt.com/codex/tasks/task_e_68e64031b3e8832283962e04c6078fb7