### PR TITLE
Add progress helper for VEO UX statuses

### DIFF
--- a/handlers/veo_fast.py
+++ b/handlers/veo_fast.py
@@ -8,6 +8,7 @@ from typing import Any, Awaitable, Callable, Mapping, MutableMapping, Optional
 from telegram.ext import ContextTypes
 
 from helpers.errors import send_user_error
+from helpers.progress import PROGRESS_STORAGE_KEY, send_progress_message
 
 logger = logging.getLogger("veo.fast")
 
@@ -111,6 +112,13 @@ async def handle_veo_fast_error(
     mode: str = "veo_fast",
 ) -> None:
     """Map backend errors to user-facing messages and send them."""
+
+    chat_data = getattr(context, "chat_data", None)
+    if isinstance(chat_data, MutableMapping):
+        progress = chat_data.get(PROGRESS_STORAGE_KEY)
+        if isinstance(progress, MutableMapping):
+            progress["success"] = False
+    await send_progress_message(context, "finish")
 
     kind = "backend_fail"
     reason: Optional[str] = None

--- a/helpers/progress.py
+++ b/helpers/progress.py
@@ -1,0 +1,172 @@
+"""Utility helpers for sending progress updates to users."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import suppress
+from typing import Any, MutableMapping, Optional
+
+from telegram.ext import ContextTypes
+
+
+logger = logging.getLogger("progress")
+
+PROGRESS_STORAGE_KEY = "_progress_message"
+_PROGRESS_CLEANUP_DELAY = 5 * 60.0
+
+
+def _get_progress_state(
+    ctx: ContextTypes.DEFAULT_TYPE,
+) -> Optional[MutableMapping[str, Any]]:
+    chat_data = getattr(ctx, "chat_data", None)
+    if not isinstance(chat_data, MutableMapping):
+        return None
+    state = chat_data.get(PROGRESS_STORAGE_KEY)
+    if not isinstance(state, MutableMapping):
+        return None
+    return state
+
+
+async def _auto_cleanup(job_ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    data = getattr(job_ctx, "data", None) or {}
+    chat_id = data.get("chat_id")
+    message_id = data.get("message_id")
+    if not chat_id or not message_id:
+        return
+    try:
+        await job_ctx.bot.delete_message(chat_id=chat_id, message_id=message_id)
+    except Exception:  # pragma: no cover - defensive cleanup
+        logger.debug("progress.cleanup_fail chat_id=%s", chat_id)
+    chat_data = getattr(job_ctx, "chat_data", None)
+    if isinstance(chat_data, MutableMapping):
+        stored = chat_data.get(PROGRESS_STORAGE_KEY)
+        if isinstance(stored, MutableMapping) and stored.get("message_id") == message_id:
+            chat_data.pop(PROGRESS_STORAGE_KEY, None)
+
+
+def _schedule_cleanup(
+    ctx: ContextTypes.DEFAULT_TYPE,
+    progress: MutableMapping[str, Any],
+    *,
+    message_id: int,
+) -> Any:
+    job_queue = getattr(ctx, "job_queue", None)
+    if job_queue is None:
+        return None
+    data = {
+        "chat_id": progress.get("chat_id"),
+        "message_id": message_id,
+        "mode": progress.get("mode"),
+        "user_id": progress.get("user_id"),
+        "job_id": progress.get("job_id"),
+    }
+    return job_queue.run_once(_auto_cleanup, _PROGRESS_CLEANUP_DELAY, data=data)
+
+
+async def send_progress_message(ctx: ContextTypes.DEFAULT_TYPE, phase: str) -> None:
+    """Send or update a progress indicator message for the current chat."""
+
+    progress = _get_progress_state(ctx)
+    if not progress:
+        return
+
+    bot = getattr(ctx, "bot", None)
+    if bot is None:
+        return
+
+    chat_id = progress.get("chat_id")
+    if chat_id is None:
+        return
+
+    user_id = progress.get("user_id")
+    mode = progress.get("mode") or "unknown"
+    job_id = progress.get("job_id")
+    last_phase = progress.get("phase")
+
+    if phase == "start":
+        if last_phase == "start":
+            return
+        reply_to = progress.get("reply_to_message_id")
+        params = {
+            "chat_id": chat_id,
+            "text": "🎬 Отправляю задачу в обработку…",
+            "disable_notification": True,
+        }
+        if reply_to:
+            params["reply_to_message_id"] = reply_to
+            params["allow_sending_without_reply"] = True
+        try:
+            message = await bot.send_message(**params)
+        except Exception:  # pragma: no cover - defensive guard
+            logger.exception("progress.start_fail user_id=%s chat_id=%s", user_id, chat_id)
+            return
+        message_id = getattr(message, "message_id", None)
+        if message_id is not None:
+            progress["message_id"] = int(message_id)
+            cleanup_job = _schedule_cleanup(ctx, progress, message_id=int(message_id))
+            if cleanup_job is not None:
+                progress["cleanup_job"] = cleanup_job
+        progress["phase"] = "start"
+        logger.info(
+            "progress.start user_id=%s chat_id=%s mode=%s job_id=%s",
+            user_id,
+            chat_id,
+            mode,
+            job_id,
+        )
+        return
+
+    message_id = progress.get("message_id")
+    if not message_id:
+        return
+
+    if phase == "render":
+        if last_phase == "render":
+            return
+        try:
+            await bot.edit_message_text(
+                chat_id=chat_id,
+                message_id=message_id,
+                text="💫 Видео обрабатывается — оставайтесь на связи.",
+            )
+        except Exception:  # pragma: no cover - defensive guard
+            logger.debug("progress.render_fail user_id=%s chat_id=%s", user_id, chat_id)
+        else:
+            progress["phase"] = "render"
+            logger.info(
+                "progress.render user_id=%s chat_id=%s mode=%s job_id=%s",
+                user_id,
+                chat_id,
+                mode,
+                job_id,
+            )
+        return
+
+    if phase == "finish":
+        cleanup_job = progress.get("cleanup_job")
+        if cleanup_job is not None:
+            with suppress(Exception):
+                cleanup_job.schedule_removal()
+        success = bool(progress.get("success"))
+        try:
+            if success:
+                await bot.edit_message_text(
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    text="✅ Готово!",
+                )
+            else:
+                await bot.delete_message(chat_id=chat_id, message_id=message_id)
+        except Exception:  # pragma: no cover - defensive guard
+            logger.debug("progress.finish_fail user_id=%s chat_id=%s", user_id, chat_id)
+        logger.info(
+            "progress.finish user_id=%s chat_id=%s mode=%s job_id=%s",
+            user_id,
+            chat_id,
+            mode,
+            job_id,
+        )
+        chat_data = getattr(ctx, "chat_data", None)
+        if isinstance(chat_data, MutableMapping):
+            chat_data.pop(PROGRESS_STORAGE_KEY, None)
+

--- a/tests/test_progress_flow.py
+++ b/tests/test_progress_flow.py
@@ -1,0 +1,111 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from helpers.progress import PROGRESS_STORAGE_KEY, send_progress_message
+
+
+class DummyJob:
+    def __init__(self, callback, data):
+        self.callback = callback
+        self.data = data
+        self.removed = False
+
+    def schedule_removal(self) -> None:
+        self.removed = True
+
+
+class DummyJobQueue:
+    def __init__(self) -> None:
+        self.jobs: list[DummyJob] = []
+
+    def run_once(self, callback, when, data=None):  # type: ignore[override]
+        job = DummyJob(callback, data or {})
+        self.jobs.append(job)
+        return job
+
+
+class DummyBot:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self.edits: list[dict] = []
+        self.deleted: list[dict] = []
+
+    async def send_message(self, **kwargs):  # type: ignore[override]
+        self.sent.append(kwargs)
+        return SimpleNamespace(message_id=len(self.sent))
+
+    async def edit_message_text(self, **kwargs):  # type: ignore[override]
+        self.edits.append(kwargs)
+
+    async def delete_message(self, **kwargs):  # type: ignore[override]
+        self.deleted.append(kwargs)
+
+
+def _make_context() -> SimpleNamespace:
+    bot = DummyBot()
+    job_queue = DummyJobQueue()
+    return SimpleNamespace(bot=bot, chat_data={}, job_queue=job_queue)
+
+
+def test_progress_flow_success_path() -> None:
+    ctx = _make_context()
+    progress = {
+        "chat_id": 100,
+        "user_id": 200,
+        "mode": "veo_animate",
+        "reply_to_message_id": 55,
+        "success": False,
+    }
+    ctx.chat_data[PROGRESS_STORAGE_KEY] = progress
+
+    asyncio.run(send_progress_message(ctx, "start"))
+
+    assert ctx.bot.sent == [
+        {
+            "chat_id": 100,
+            "text": "🎬 Отправляю задачу в обработку…",
+            "disable_notification": True,
+            "reply_to_message_id": 55,
+            "allow_sending_without_reply": True,
+        }
+    ]
+    assert "message_id" in progress
+    assert len(ctx.job_queue.jobs) == 1
+
+    progress["job_id"] = "job-123"
+    asyncio.run(send_progress_message(ctx, "render"))
+
+    assert ctx.bot.edits and ctx.bot.edits[0]["text"].startswith("💫 Видео")
+    assert progress["phase"] == "render"
+
+    progress["success"] = True
+    asyncio.run(send_progress_message(ctx, "finish"))
+
+    assert ctx.bot.edits[-1]["text"] == "✅ Готово!"
+    assert PROGRESS_STORAGE_KEY not in ctx.chat_data
+    job = ctx.job_queue.jobs[0]
+    assert job.removed is True
+
+
+def test_progress_flow_failure_deletes_message() -> None:
+    ctx = _make_context()
+    progress = {
+        "chat_id": 1,
+        "user_id": 2,
+        "mode": "veo_fast",
+        "reply_to_message_id": 7,
+        "success": False,
+    }
+    ctx.chat_data[PROGRESS_STORAGE_KEY] = progress
+
+    asyncio.run(send_progress_message(ctx, "start"))
+    asyncio.run(send_progress_message(ctx, "finish"))
+
+    assert ctx.bot.deleted == [{"chat_id": 1, "message_id": 1}]
+    assert PROGRESS_STORAGE_KEY not in ctx.chat_data

--- a/tests/test_veo_animate.py
+++ b/tests/test_veo_animate.py
@@ -66,7 +66,7 @@ def test_veo_animate_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
         calls.append((image_url, prompt))
         return "job-1"
 
-    async def fake_wait(job_id: str) -> tuple[list[str], dict]:
+    async def fake_wait(job_id: str, *, context=None) -> tuple[list[str], dict]:
         assert job_id == "job-1"
         return ["https://cdn.example/video.mp4"], {"status": "done"}
 
@@ -100,7 +100,7 @@ def test_veo_animate_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_start(image_url: str, prompt: str | None) -> str:
         return "job-2"
 
-    async def fake_wait(job_id: str) -> tuple[list[str], dict]:
+    async def fake_wait(job_id: str, *, context=None) -> tuple[list[str], dict]:
         raise video_module.VeoAnimateTimeout("timeout")
 
     monkeypatch.setattr(video_module, "_start_animation", fake_start)
@@ -164,7 +164,7 @@ def test_veo_animate_list_of_urls(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_start(image_url: str, prompt: str | None) -> str:
         return "job-3"
 
-    async def fake_wait(job_id: str) -> tuple[list[str], dict]:
+    async def fake_wait(job_id: str, *, context=None) -> tuple[list[str], dict]:
         return ["https://cdn.example/a.mp4", "https://cdn.example/b.mp4"], {"status": "done"}
 
     monkeypatch.setattr(video_module, "_start_animation", fake_start)
@@ -193,7 +193,7 @@ def test_veo_animate_waits_for_photo(monkeypatch: pytest.MonkeyPatch) -> None:
         call_counter.append(image_url)
         return "job-4"
 
-    async def fake_wait(job_id: str) -> tuple[list[str], dict]:
+    async def fake_wait(job_id: str, *, context=None) -> tuple[list[str], dict]:
         return ["https://cdn.example/auto.mp4"], {"status": "done"}
 
     monkeypatch.setattr(video_module, "_start_animation", fake_start)


### PR DESCRIPTION
## Summary
- add a reusable progress helper that sends start, render, and finish updates with auto-cleanup
- integrate the helper into the VEO animate flow and ensure VEO fast errors clear any progress notice
- cover the behaviour with a dedicated progress test suite and adapt existing tests

## Testing
- `pytest tests/test_progress_flow.py tests/test_veo_animate.py tests/test_veo_errors.py`


------
https://chatgpt.com/codex/tasks/task_e_68e65f4ee2cc83228179c9713059054b