### PR TITLE
Fix inline main menu navigation

### DIFF
--- a/handlers/dialog.py
+++ b/handlers/dialog.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, MutableMapping, Optional
+
+from telegram.ext import ContextTypes
+
+from handlers.menu import build_dialog_card
+
+log = logging.getLogger(__name__)
+
+_CARD_STATE_KEY = "dialog_menu_card"
+_MSG_IDS_KEY = "dialog"
+
+_send_menu: Optional[Callable[..., Awaitable[Optional[int]]]] = None
+_state_getter: Optional[Callable[[ContextTypes.DEFAULT_TYPE], MutableMapping[str, Any]]] = None
+
+
+def configure(
+    *,
+    send_menu: Callable[..., Awaitable[Optional[int]]],
+    state_getter: Callable[[ContextTypes.DEFAULT_TYPE], MutableMapping[str, Any]],
+) -> None:
+    global _send_menu
+    global _state_getter
+    _send_menu = send_menu
+    _state_getter = state_getter
+
+
+async def open_menu(
+    ctx: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    *,
+    suppress_nav: bool = False,
+    fallback_message_id: Optional[int] = None,
+) -> Optional[int]:
+    if _send_menu is None or _state_getter is None:
+        raise RuntimeError("dialog menu handler is not configured")
+
+    state_dict = _state_getter(ctx)
+    card = build_dialog_card()
+
+    message_id = await _send_menu(
+        ctx,
+        chat_id=chat_id,
+        text=card["text"],
+        reply_markup=card["reply_markup"],
+        state_key=_CARD_STATE_KEY,
+        msg_ids_key=_MSG_IDS_KEY,
+        state_dict=state_dict,
+        fallback_message_id=fallback_message_id,
+        parse_mode=card.get("parse_mode"),
+        disable_web_page_preview=card.get("disable_web_page_preview", True),
+        log_label="ui.dialog.menu",
+    )
+
+    log.debug(
+        "dialog.menu.opened",
+        extra={
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "suppress_nav": suppress_nav,
+            "fallback_mid": fallback_message_id,
+        },
+    )
+    return message_id
+
+
+__all__ = ["configure", "open_menu"]

--- a/handlers/knowledge_base.py
+++ b/handlers/knowledge_base.py
@@ -135,6 +135,7 @@ async def _send_card(
     *,
     log_label: str,
     active_card: Optional[str] = None,
+    fallback_message_id: Optional[int] = None,
 ) -> Optional[int]:
     if _send_menu is None:
         raise RuntimeError("knowledge_base.send_menu is not configured")
@@ -151,6 +152,7 @@ async def _send_card(
         "state_key": _CARD_STATE_KEY,
         "msg_ids_key": _CARD_MSG_KEY,
         "state_dict": state_dict,
+        "fallback_message_id": fallback_message_id,
         "parse_mode": card.get("parse_mode"),
         "disable_web_page_preview": card.get("disable_web_page_preview", True),
         "log_label": log_label,
@@ -164,14 +166,24 @@ async def _send_card(
     return result
 
 
-async def open_root(ctx: ContextTypes.DEFAULT_TYPE, chat_id: int) -> Optional[int]:
-    log.info("[KB] open", extra={"chat_id": chat_id})
+async def open_root(
+    ctx: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    *,
+    suppress_nav: bool = False,
+    fallback_message_id: Optional[int] = None,
+) -> Optional[int]:
+    log.info(
+        "[KB] open",
+        extra={"chat_id": chat_id, "suppress_nav": suppress_nav},
+    )
     return await _send_card(
         ctx,
         chat_id,
         _root_card(),
         log_label="ui.kb.root",
         active_card="kb:root",
+        fallback_message_id=fallback_message_id,
     )
 
 

--- a/handlers/music.py
+++ b/handlers/music.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, MutableMapping, Optional
+
+from telegram.ext import ContextTypes
+
+from handlers.menu import build_music_card
+
+log = logging.getLogger(__name__)
+
+_CARD_STATE_KEY = "music_menu_card"
+_MSG_IDS_KEY = "music"
+
+_send_menu: Optional[Callable[..., Awaitable[Optional[int]]]] = None
+_state_getter: Optional[Callable[[ContextTypes.DEFAULT_TYPE], MutableMapping[str, Any]]] = None
+
+
+def configure(
+    *,
+    send_menu: Callable[..., Awaitable[Optional[int]]],
+    state_getter: Callable[[ContextTypes.DEFAULT_TYPE], MutableMapping[str, Any]],
+) -> None:
+    global _send_menu
+    global _state_getter
+    _send_menu = send_menu
+    _state_getter = state_getter
+
+
+async def open_menu(
+    ctx: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    *,
+    suppress_nav: bool = False,
+    fallback_message_id: Optional[int] = None,
+) -> Optional[int]:
+    if _send_menu is None or _state_getter is None:
+        raise RuntimeError("music menu handler is not configured")
+
+    state_dict = _state_getter(ctx)
+    card = build_music_card()
+
+    message_id = await _send_menu(
+        ctx,
+        chat_id=chat_id,
+        text=card["text"],
+        reply_markup=card["reply_markup"],
+        state_key=_CARD_STATE_KEY,
+        msg_ids_key=_MSG_IDS_KEY,
+        state_dict=state_dict,
+        fallback_message_id=fallback_message_id,
+        parse_mode=card.get("parse_mode"),
+        disable_web_page_preview=card.get("disable_web_page_preview", True),
+        log_label="ui.music.menu",
+    )
+
+    log.debug(
+        "music.menu.opened",
+        extra={
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "suppress_nav": suppress_nav,
+            "fallback_mid": fallback_message_id,
+        },
+    )
+    return message_id
+
+
+__all__ = ["configure", "open_menu"]

--- a/handlers/photo.py
+++ b/handlers/photo.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, MutableMapping, Optional
+
+from telegram.ext import ContextTypes
+
+from handlers.menu import build_photo_card
+
+log = logging.getLogger(__name__)
+
+_CARD_STATE_KEY = "photo_menu_card"
+_MSG_IDS_KEY = "photo"
+
+_send_menu: Optional[Callable[..., Awaitable[Optional[int]]]] = None
+_state_getter: Optional[Callable[[ContextTypes.DEFAULT_TYPE], MutableMapping[str, Any]]] = None
+
+
+def configure(
+    *,
+    send_menu: Callable[..., Awaitable[Optional[int]]],
+    state_getter: Callable[[ContextTypes.DEFAULT_TYPE], MutableMapping[str, Any]],
+) -> None:
+    global _send_menu
+    global _state_getter
+    _send_menu = send_menu
+    _state_getter = state_getter
+
+
+async def open_menu(
+    ctx: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    *,
+    suppress_nav: bool = False,
+    fallback_message_id: Optional[int] = None,
+) -> Optional[int]:
+    if _send_menu is None or _state_getter is None:
+        raise RuntimeError("photo menu handler is not configured")
+
+    state_dict = _state_getter(ctx)
+    card = build_photo_card()
+
+    message_id = await _send_menu(
+        ctx,
+        chat_id=chat_id,
+        text=card["text"],
+        reply_markup=card["reply_markup"],
+        state_key=_CARD_STATE_KEY,
+        msg_ids_key=_MSG_IDS_KEY,
+        state_dict=state_dict,
+        fallback_message_id=fallback_message_id,
+        parse_mode=card.get("parse_mode"),
+        disable_web_page_preview=card.get("disable_web_page_preview", True),
+        log_label="ui.photo.menu",
+    )
+
+    log.debug(
+        "photo.menu.opened",
+        extra={
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "suppress_nav": suppress_nav,
+            "fallback_mid": fallback_message_id,
+        },
+    )
+    return message_id
+
+
+__all__ = ["configure", "open_menu"]

--- a/tests/test_main_menu_navigation.py
+++ b/tests/test_main_menu_navigation.py
@@ -1,0 +1,181 @@
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tests.suno_test_utils import FakeBot, bot_module
+
+
+def test_menu_callbacks_route_ok(monkeypatch):
+    ctx = SimpleNamespace(chat_data={}, user_data={}, application=SimpleNamespace(bot_data={}))
+
+    calls: list[tuple[str, tuple, dict]] = []
+
+    async def fake_profile(update, context, *, suppress_nav, edit, force_new=False):
+        calls.append(("profile", (update, context), {"suppress_nav": suppress_nav}))
+        return 101
+
+    async def fake_kb(context, chat_id, *, suppress_nav, fallback_message_id=None):
+        calls.append(("kb", (context, chat_id), {"suppress_nav": suppress_nav, "fallback": fallback_message_id}))
+        return 102
+
+    async def fake_photo(context, chat_id, *, suppress_nav, fallback_message_id=None):
+        calls.append(("photo", (context, chat_id), {"suppress_nav": suppress_nav, "fallback": fallback_message_id}))
+        return 103
+
+    async def fake_music(context, chat_id, *, suppress_nav, fallback_message_id=None):
+        calls.append(("music", (context, chat_id), {"suppress_nav": suppress_nav, "fallback": fallback_message_id}))
+        return 104
+
+    async def fake_video(
+        context,
+        chat_id,
+        *,
+        veo_fast_cost,
+        veo_photo_cost,
+        suppress_nav,
+        fallback_message_id=None,
+    ):
+        calls.append(
+            (
+                "video",
+                (context, chat_id),
+                {
+                    "suppress_nav": suppress_nav,
+                    "fallback": fallback_message_id,
+                    "fast": veo_fast_cost,
+                    "photo": veo_photo_cost,
+                },
+            )
+        )
+        return 105
+
+    async def fake_dialog(context, chat_id, *, suppress_nav, fallback_message_id=None):
+        calls.append(("dialog", (context, chat_id), {"suppress_nav": suppress_nav, "fallback": fallback_message_id}))
+        return 106
+
+    monkeypatch.setattr(bot_module, "open_profile_card", fake_profile)
+    monkeypatch.setattr(bot_module, "knowledge_base_open_root", fake_kb)
+    monkeypatch.setattr(bot_module, "photo_open_menu", fake_photo)
+    monkeypatch.setattr(bot_module, "music_open_menu", fake_music)
+    monkeypatch.setattr(bot_module, "video_open_menu", fake_video)
+    monkeypatch.setattr(bot_module, "dialog_open_menu", fake_dialog)
+
+    async def fake_answer():
+        return None
+
+    tests = [
+        ("profile", bot_module._PROFILE_MSG_ID_KEY, 101),
+        ("kb", bot_module._KB_MSG_ID_KEY, 102),
+        ("photo", bot_module._PHOTO_MSG_ID_KEY, 103),
+        ("music", bot_module._MUSIC_MSG_ID_KEY, 104),
+        ("video", bot_module._VIDEO_MSG_ID_KEY, 105),
+        ("dialog", bot_module._DIALOG_MSG_ID_KEY, 106),
+    ]
+
+    async def scenario():
+        for item, key, mid in tests:
+            calls.clear()
+            ctx.chat_data.clear()
+            query = SimpleNamespace(
+                data=f"menu:{item}",
+                message=SimpleNamespace(
+                    chat=SimpleNamespace(id=500 + len(item)),
+                    chat_id=500 + len(item),
+                ),
+                from_user=SimpleNamespace(id=900 + len(item)),
+                answer=fake_answer,
+            )
+            update = SimpleNamespace(
+                callback_query=query,
+                effective_chat=query.message.chat,
+                effective_user=query.from_user,
+            )
+
+            await bot_module.handle_main_menu_callback(update, ctx)
+
+            assert calls and calls[0][0] == item
+            assert calls[0][2]["suppress_nav"] is True
+            assert ctx.chat_data.get(key) == mid
+            assert ctx.chat_data.get("nav_event") is None
+
+    asyncio.run(scenario())
+
+
+def test_menu_open_no_duplicates(monkeypatch):
+    ctx = SimpleNamespace(chat_data={}, user_data={}, application=SimpleNamespace(bot_data={}))
+
+    fallback_values: list[object] = []
+
+    async def fake_kb(context, chat_id, *, suppress_nav, fallback_message_id=None):
+        fallback_values.append(fallback_message_id)
+        return 777
+
+    monkeypatch.setattr(bot_module, "knowledge_base_open_root", fake_kb)
+
+    async def fake_answer():
+        return None
+
+    query = SimpleNamespace(
+        data="menu:kb",
+        message=SimpleNamespace(chat=SimpleNamespace(id=42), chat_id=42),
+        from_user=SimpleNamespace(id=321),
+        answer=fake_answer,
+    )
+    update = SimpleNamespace(callback_query=query, effective_chat=query.message.chat, effective_user=query.from_user)
+
+    async def scenario():
+        await bot_module.handle_main_menu_callback(update, ctx)
+        assert fallback_values == [None]
+        assert ctx.chat_data.get(bot_module._KB_MSG_ID_KEY) == 777
+
+        await bot_module.handle_main_menu_callback(update, ctx)
+        assert fallback_values == [None, 777]
+        assert ctx.chat_data.get(bot_module._KB_MSG_ID_KEY) == 777
+
+    asyncio.run(scenario())
+
+
+def test_menu_suppresses_dialog_notice(monkeypatch):
+    bot = FakeBot()
+    ctx = SimpleNamespace(bot=bot, chat_data={}, user_data={}, application=SimpleNamespace(bot_data={}))
+
+    async def fake_photo(context, chat_id, *, suppress_nav, fallback_message_id=None):
+        assert context.chat_data.get("nav_event") is True
+        return 888
+
+    async def fake_answer():
+        return None
+
+    async def fake_ensure(update):
+        return None
+
+    monkeypatch.setattr(bot_module, "photo_open_menu", fake_photo)
+    monkeypatch.setattr(bot_module, "ensure_user_record", fake_ensure)
+
+    query = SimpleNamespace(
+        data="menu:photo",
+        message=SimpleNamespace(chat=SimpleNamespace(id=77), chat_id=77),
+        from_user=SimpleNamespace(id=55),
+        answer=fake_answer,
+    )
+    update = SimpleNamespace(callback_query=query, effective_chat=query.message.chat, effective_user=query.from_user)
+
+    async def scenario():
+        await bot_module.handle_main_menu_callback(update, ctx)
+
+        assert ctx.chat_data.get(bot_module._PHOTO_MSG_ID_KEY) == 888
+        assert ctx.chat_data.get("nav_event") is None
+
+        text_message = SimpleNamespace(text="привет", chat_id=77, chat=SimpleNamespace(id=77))
+        text_update = SimpleNamespace(message=text_message, effective_message=text_message, effective_user=None)
+
+        await bot_module.on_text(text_update, ctx)
+
+        assert not bot.sent
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- route main menu callbacks through a dedicated helper that logs navigation, reuses previous cards, and suppresses dialog-off notices
- add menu open helpers for photo, music, video, and dialog sections and configure them to use safe edits
- extend the knowledge base opener for fallback reuse and cover the behaviour with new menu navigation tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e67a3daad4832282c5a24c9f5ab36a