### PR TITLE
Stabilize profile and knowledge base navigation

### DIFF
--- a/hub_router.py
+++ b/hub_router.py
@@ -6,6 +6,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass
+from collections.abc import MutableMapping
 from typing import Any, Awaitable, Callable, Dict, Optional
 
 from telegram import InlineKeyboardMarkup, Update
@@ -315,6 +316,12 @@ async def _dispatch_route(
         return False
 
     lock_acquired = False
+    chat_data_obj = getattr(ctx, "chat_data", None)
+    if (
+        isinstance(chat_data_obj, MutableMapping)
+        and (namespace, action) in {("menu", "click"), ("kb", "open")}
+    ):
+        chat_data_obj["nav_event"] = True
     try:
         if apply_text_lock:
             if not user_lock(chat_id, "reply-nav", ttl=1):

--- a/tests/test_kb_open.py
+++ b/tests/test_kb_open.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tests.suno_test_utils import FakeBot  # noqa: E402
+import handlers.knowledge_base as kb  # noqa: E402
+
+
+def test_kb_send_then_edit(monkeypatch):
+    ctx = SimpleNamespace(
+        bot=FakeBot(),
+        chat_data={},
+        user_data={},
+        application=SimpleNamespace(bot_data={}),
+    )
+
+    state_store: dict[str, object] = {}
+    fallbacks: list[object] = []
+    sent_ids = iter([200, 200])
+
+    async def fake_send_menu(**kwargs):
+        fallbacks.append(kwargs.get("fallback_message_id"))
+        return next(sent_ids)
+
+    kb.configure(send_menu=fake_send_menu, state_getter=lambda _ctx: state_store)
+
+    first = asyncio.run(kb.open_root(ctx, 123))
+    second = asyncio.run(kb.open_root(ctx, 123))
+
+    assert first == 200
+    assert second == 200
+    assert fallbacks[0] is None
+    assert fallbacks[1] == 200
+    assert ctx.chat_data.get("kb_msg_id") == 200

--- a/tests/test_nav_suppression.py
+++ b/tests/test_nav_suppression.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tests.suno_test_utils import FakeBot, bot_module  # noqa: E402
+
+
+def test_nav_event_suppresses_notice():
+    bot = FakeBot()
+    ctx = SimpleNamespace(
+        bot=bot,
+        chat_data={"nav_event": True},
+        user_data={},
+        application=SimpleNamespace(bot_data={}),
+    )
+
+    asyncio.run(bot_module.reset_user_state(ctx, chat_id=123, notify_chat_off=True))
+
+    assert ctx.chat_data.get("nav_event") is None
+    assert not any(entry.get("text") == "🛑 Режим диалога отключён." for entry in bot.sent)

--- a/tests/test_profile_inner_buttons.py
+++ b/tests/test_profile_inner_buttons.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tests.suno_test_utils import FakeBot  # noqa: E402
+import handlers.profile as profile_handlers  # noqa: E402
+
+
+def _build_update(chat_id: int, message_id: int, user_id: int):
+    async def fake_answer():
+        return None
+
+    message = SimpleNamespace(
+        chat=SimpleNamespace(id=chat_id),
+        chat_id=chat_id,
+        message_id=message_id,
+    )
+    query = SimpleNamespace(
+        message=message,
+        from_user=SimpleNamespace(id=user_id),
+        answer=fake_answer,
+    )
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_chat=message.chat,
+        effective_user=query.from_user,
+    )
+    return update
+
+
+def test_inner_buttons_edit_same_message(monkeypatch):
+    bot = FakeBot()
+    ctx = SimpleNamespace(
+        bot=bot,
+        chat_data={"profile_msg_id": 900},
+        user_data={},
+        application=SimpleNamespace(bot_data={}),
+    )
+
+    edits: list[dict[str, int]] = []
+
+    async def fake_edit(ctx_obj, chat_id, message_id, payload):
+        edits.append({"chat_id": chat_id, "message_id": message_id, "title": payload.get("text", "")})
+        return True
+
+    monkeypatch.setattr("handlers.profile._edit_card", fake_edit)
+    async def fake_history(_uid):
+        return []
+
+    monkeypatch.setattr(profile_handlers, "_billing_history", fake_history)
+    monkeypatch.setattr(profile_handlers, "_topup_url", lambda: None)
+    monkeypatch.setattr(profile_handlers, "_bot_name", lambda: "ExampleBot")
+    monkeypatch.setattr(profile_handlers, "set_wait_state", lambda *args, **kwargs: None)
+    monkeypatch.setattr(profile_handlers, "_activate_promo_wait", lambda *args, **kwargs: None)
+    monkeypatch.setattr(profile_handlers, "clear_promo_wait", lambda _ctx: None)
+
+    update = _build_update(chat_id=100, message_id=900, user_id=500)
+
+    asyncio.run(profile_handlers.on_profile_topup(update, ctx))
+    asyncio.run(profile_handlers.on_profile_history(update, ctx))
+    asyncio.run(profile_handlers.on_profile_promo_start(update, ctx))
+
+    monkeypatch.setattr(
+        "handlers.menu.build_main_menu_card",
+        lambda: {"text": "Main", "reply_markup": None},
+    )
+    asyncio.run(profile_handlers.on_profile_back(update, ctx))
+
+    assert edits, "no edits performed"
+    assert all(entry["message_id"] == 900 for entry in edits)
+    assert ctx.chat_data.get("profile_msg_id") is None
+    assert not bot.sent

--- a/tests/test_profile_open.py
+++ b/tests/test_profile_open.py
@@ -62,7 +62,6 @@ def test_open_from_quick_no_dialog_notice(monkeypatch):
         user_id,
         *,
         suppress_nav,
-        reused_msg,
         update,
         ctx,
         source,
@@ -72,13 +71,12 @@ def test_open_from_quick_no_dialog_notice(monkeypatch):
                 "chat_id": chat_id,
                 "user_id": user_id,
                 "suppress_nav": suppress_nav,
-                "reused_msg": reused_msg,
                 "source": source,
                 "nav": getattr(ctx, "nav_event", False),
             }
         )
         ctx.chat_data["profile_msg_id"] = 300
-        return 300
+        return profile_handlers.OpenedProfile(msg_id=300, reused=True)
 
     async def fake_disable(*_args, **_kwargs):
         return False
@@ -155,7 +153,6 @@ def test_single_render_no_duplicates(monkeypatch):
             update=update,
             ctx=ctx,
             suppress_nav=True,
-            reused_msg=True,
             source="inline",
         )
         second = await profile_handlers.open_profile_card(
@@ -164,10 +161,9 @@ def test_single_render_no_duplicates(monkeypatch):
             update=update,
             ctx=ctx,
             suppress_nav=True,
-            reused_msg=True,
             source="inline",
         )
-        assert first == second == ctx.chat_data.get("profile_msg_id")
+        assert first.msg_id == second.msg_id == ctx.chat_data.get("profile_msg_id")
 
     asyncio.run(scenario())
 

--- a/tests/test_profile_open_from_quick.py
+++ b/tests/test_profile_open_from_quick.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tests.suno_test_utils import FakeBot, bot_module  # noqa: E402
+import handlers.profile as profile_handlers  # noqa: E402
+
+
+def _build_update(chat_id: int, user_id: int):
+    message = SimpleNamespace(
+        text="Профиль",
+        chat_id=chat_id,
+        chat=SimpleNamespace(id=chat_id),
+        replies=[],
+    )
+
+    async def reply_text(text, **_kwargs):
+        message.replies.append(text)
+
+    message.reply_text = reply_text
+
+    update = SimpleNamespace(
+        message=message,
+        effective_message=message,
+        effective_chat=message.chat,
+        effective_user=SimpleNamespace(id=user_id),
+    )
+    return update
+
+
+def test_quick_button_reuses_message(monkeypatch):
+    bot = FakeBot()
+    ctx = SimpleNamespace(
+        bot=bot,
+        chat_data={},
+        user_data={},
+        application=SimpleNamespace(bot_data={}),
+    )
+    ctx._user_id_and_data = (777, {})
+
+    async def fake_disable(*_args, **_kwargs):
+        return None
+
+    async def fake_ensure(_update):
+        return None
+
+    calls: list[dict[str, object]] = []
+
+    async def fake_core_open(update, context, *, suppress_nav, edit, force_new):
+        calls.append({"edit": edit, "force_new": force_new, "suppress": suppress_nav})
+        context.chat_data["profile_msg_id"] = 555
+        return 555
+
+    monkeypatch.setattr(bot_module, "disable_chat_mode", fake_disable)
+    monkeypatch.setattr(bot_module, "ensure_user_record", fake_ensure)
+    monkeypatch.setattr(bot_module, "open_profile_card", fake_core_open)
+
+    update = _build_update(chat_id=100, user_id=777)
+
+    asyncio.run(bot_module.on_text(update, ctx))
+    asyncio.run(bot_module.on_text(update, ctx))
+
+    assert len(calls) == 2
+    assert calls[0]["edit"] is False
+    assert calls[1]["edit"] is True
+    assert ctx.chat_data.get("profile_msg_id") == 555
+    assert not any(entry.get("text") == "🛑 Режим диалога отключён." for entry in bot.sent)


### PR DESCRIPTION
## Summary
- add a dedicated profile card opener that stores message ids, reuses the same card for sub-actions, and edits back to the main menu
- persist the knowledge base card id, reuse it on reopen, and suppress dialog-off notices via nav_event coordination
- cover the navigation flows with unit tests for quick profile access, inner profile buttons, knowledge base reopening, and nav suppression

## Testing
- pytest tests/test_profile_open_from_quick.py
- pytest tests/test_profile_inner_buttons.py
- pytest tests/test_kb_open.py
- pytest tests/test_nav_suppression.py
- pytest tests/test_profile_open.py

------
https://chatgpt.com/codex/tasks/task_e_68e6b4857a8c8322af2ea341232ee66f