### PR TITLE
Stabilize profile navigation and banner handling

### DIFF
--- a/tests/test_chat_mode_switch.py
+++ b/tests/test_chat_mode_switch.py
@@ -80,7 +80,7 @@ def test_chat_mode_cleared_when_opening_video(monkeypatch, ctx):
     state_after = bot_module.state(ctx)
     assert state_after.get(bot_module.STATE_CHAT_MODE) is None
     assert video_calls, "Video menu should be opened"
-    assert any(entry.get("text") == "🛑 Режим диалога отключён." for entry in bot.sent)
+    assert not any(entry.get("text") == "🛑 Режим диалога отключён." for entry in bot.sent)
 
 
 def test_prompt_master_disabled_when_opening_profile(monkeypatch, ctx):
@@ -88,11 +88,23 @@ def test_prompt_master_disabled_when_opening_profile(monkeypatch, ctx):
 
     profile_calls = []
 
-    async def fake_show_balance(chat_id, context, *, force_new=False):
-        profile_calls.append((chat_id, force_new))
-        return None
+    async def fake_core_open(
+        update_param,
+        ctx_param,
+        *,
+        edit: bool,
+        suppress_nav: bool = True,
+        force_new: bool = False,
+        **_kwargs,
+    ):
+        profile_calls.append({
+            "suppress_nav": suppress_nav,
+            "edit": edit,
+            "force_new": force_new,
+        })
+        return 777
 
-    monkeypatch.setattr(bot_module, "show_balance_card", fake_show_balance)
+    monkeypatch.setattr(bot_module, "open_profile_card", fake_core_open)
 
     update, query = _make_update(chat_id=300, user_id=400)
 
@@ -112,4 +124,4 @@ def test_prompt_master_disabled_when_opening_profile(monkeypatch, ctx):
     assert state_after.get(bot_module.STATE_CHAT_MODE) is None
     assert profile_calls, "Profile card should be shown"
     assert not any("Обычный чат включён" in (entry.get("text") or "") for entry in bot.sent)
-    assert any(entry.get("text") == "🛑 Режим диалога отключён." for entry in bot.sent)
+    assert not any(entry.get("text") == "🛑 Режим диалога отключён." for entry in bot.sent)

--- a/tests/test_profile_open.py
+++ b/tests/test_profile_open.py
@@ -36,6 +36,7 @@ def test_open_from_inline_no_dialog_notice(monkeypatch):
         callback_query=query,
         effective_chat=message.chat,
         effective_user=query.from_user,
+        effective_message=message,
     )
 
     asyncio.run(profile_handlers.on_profile_menu(update, ctx))

--- a/tests/test_profile_open_from_quick.py
+++ b/tests/test_profile_open_from_quick.py
@@ -61,6 +61,16 @@ def test_quick_button_reuses_message(monkeypatch):
     monkeypatch.setattr(bot_module, "disable_chat_mode", fake_disable)
     monkeypatch.setattr(bot_module, "ensure_user_record", fake_ensure)
     monkeypatch.setattr(bot_module, "open_profile_card", fake_core_open)
+    time_values = [100.0, 101.0, 102.0, 103.0]
+    times = iter(time_values)
+
+    def fake_monotonic():
+        try:
+            return next(times)
+        except StopIteration:
+            return time_values[-1]
+
+    monkeypatch.setattr(profile_handlers.time, "monotonic", fake_monotonic)
 
     update = _build_update(chat_id=100, user_id=777)
 

--- a/tests/test_profile_opening.py
+++ b/tests/test_profile_opening.py
@@ -1,0 +1,166 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tests.suno_test_utils import FakeBot, bot_module
+import handlers.profile as profile_handlers
+
+
+def _make_context() -> SimpleNamespace:
+    bot = FakeBot()
+    ctx = SimpleNamespace(
+        bot=bot,
+        chat_data={},
+        user_data={},
+        application=SimpleNamespace(bot_data={}),
+    )
+    ctx._user_id_and_data = (999, {})
+    return ctx
+
+
+def test_quick_button_opens_profile_once(monkeypatch):
+    ctx = _make_context()
+
+    calls: list[dict[str, object]] = []
+
+    async def fake_open_card(chat_id, user_id, *, update, ctx: SimpleNamespace, suppress_nav, source):
+        calls.append({
+            "chat_id": chat_id,
+            "user_id": user_id,
+            "source": source,
+            "suppress_nav": suppress_nav,
+        })
+        ctx.chat_data["profile_msg_id"] = 111
+        return profile_handlers.OpenedProfile(msg_id=111, reused=False)
+
+    monkeypatch.setattr(profile_handlers, "open_profile_card", fake_open_card)
+
+    chat = SimpleNamespace(id=123)
+    message = SimpleNamespace(chat=chat, chat_id=123, message_id=7)
+    update = SimpleNamespace(
+        effective_chat=chat,
+        effective_user=SimpleNamespace(id=555),
+        effective_message=message,
+    )
+
+    async def scenario():
+        await profile_handlers.open_profile(update, ctx, source="quick")
+        await profile_handlers.open_profile(update, ctx, source="quick")
+
+    asyncio.run(scenario())
+
+    assert len(calls) == 1
+    assert calls[0]["source"] == "quick"
+    assert ctx.chat_data.get("profile_msg_id") == 111
+
+
+def test_menu_card_opens_profile_and_reuses_message(monkeypatch):
+    ctx = _make_context()
+
+    core_calls: list[dict[str, object]] = []
+
+    async def fake_core_open(update, context, *, suppress_nav, edit, force_new):
+        core_calls.append({"edit": edit, "force_new": force_new})
+        return 222
+
+    monkeypatch.setattr(bot_module, "open_profile_card", fake_core_open)
+
+    chat = SimpleNamespace(id=321)
+    message = SimpleNamespace(chat=chat, chat_id=321, message_id=42)
+    update = SimpleNamespace(
+        effective_chat=chat,
+        effective_user=SimpleNamespace(id=888),
+        effective_message=message,
+    )
+
+    async def scenario():
+        await profile_handlers.open_profile(update, ctx, source="menu")
+        ctx.chat_data["profile_open_at"] = 0.0
+        await profile_handlers.open_profile(update, ctx, source="menu")
+
+    asyncio.run(scenario())
+
+    assert ctx.chat_data.get("profile_msg_id") == 222
+    assert len(core_calls) == 2
+    assert core_calls[0] == {"edit": False, "force_new": True}
+    assert core_calls[1] == {"edit": True, "force_new": False}
+
+
+def test_profile_internal_buttons_do_not_spawn_new_messages(monkeypatch):
+    ctx = _make_context()
+    ctx.chat_data["profile_msg_id"] = 777
+
+    calls: list[dict[str, object]] = []
+
+    async def fake_edit_card(_ctx, chat_id, message_id, payload):
+        calls.append({"chat_id": chat_id, "message_id": message_id, "text": payload.get("text")})
+        return True
+
+    async def fake_history(_user_id):
+        return []
+
+    monkeypatch.setattr(profile_handlers, "_edit_card", fake_edit_card)
+    monkeypatch.setattr(profile_handlers, "_billing_history", fake_history)
+    monkeypatch.setattr(profile_handlers, "_bot_name", lambda: "mybot")
+
+    chat = SimpleNamespace(id=555)
+    message = SimpleNamespace(chat=chat, chat_id=555, message_id=777)
+
+    async def answer(_text=None):
+        return None
+
+    query = SimpleNamespace(message=message, answer=answer)
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_chat=chat,
+        effective_user=SimpleNamespace(id=111, username="tester"),
+        effective_message=message,
+    )
+
+    async def scenario():
+        await profile_handlers.on_profile_topup(update, ctx)
+        await profile_handlers.on_profile_history(update, ctx)
+        await profile_handlers.on_profile_invite(update, ctx)
+        await profile_handlers.on_profile_promo_start(update, ctx)
+        await profile_handlers.on_profile_back(update, ctx)
+
+    asyncio.run(scenario())
+
+    assert all(call["message_id"] == 777 for call in calls)
+    assert not ctx.bot.sent
+
+
+def test_no_dialog_disabled_on_navigation(monkeypatch):
+    ctx = _make_context()
+    ctx.chat_data["suppress_dialog_notice"] = True
+    state = bot_module.state(ctx)
+    state["mode"] = "chat"
+
+    asyncio.run(bot_module.reset_user_state(ctx, chat_id=123, notify_chat_off=True))
+
+    assert not any(entry.get("text") == "🛑 Режим диалога отключён." for entry in ctx.bot.sent)
+
+
+def test_dialog_disabled_only_after_plain_chat_exit():
+    ctx = _make_context()
+    ctx.chat_data["just_exited_plain_chat"] = True
+    state = bot_module.state(ctx)
+    state["mode"] = "chat"
+
+    asyncio.run(bot_module.reset_user_state(ctx, chat_id=123, notify_chat_off=True))
+
+    assert sum(1 for entry in ctx.bot.sent if entry.get("text") == "🛑 Режим диалога отключён.") == 1
+
+    state = bot_module.state(ctx)
+    state["mode"] = "chat"
+
+    asyncio.run(bot_module.reset_user_state(ctx, chat_id=123, notify_chat_off=True))
+
+    assert sum(1 for entry in ctx.bot.sent if entry.get("text") == "🛑 Режим диалога отключён.") == 1


### PR DESCRIPTION
## Summary
- add a centralized `open_profile` helper that debounces duplicate opens, reuses the existing message, and clears chat-data flags before rendering
- wire all profile entry points through the helper and persist the rendered hash while suppressing the dialog-disabled banner outside of chat exit
- extend profile/navigation tests to cover debounce, message reuse, internal callbacks, and dialog banner visibility rules

## Testing
- `pytest tests/test_profile_opening.py tests/test_profile_open.py tests/test_profile_open_from_quick.py tests/test_chat_mode_switch.py tests/test_text_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68e6d7186c288322bba44e3f244cc31b