### PR TITLE
Fix profile inner actions

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -131,7 +131,9 @@ class Settings(BaseSettings):
     PUBLIC_BASE_URL: Optional[str] = Field(default=None)
 
     TOPUP_URL: str = Field(default="")
-
+    STARS_PAYMENT_URL: Optional[str] = Field(default=None)
+    CARD_PAYMENT_URL: Optional[str] = Field(default=None)
+    
     YOOKASSA_SHOP_ID: Optional[str] = Field(default=None)
     YOOKASSA_SECRET_KEY: Optional[str] = Field(default=None)
     YOOKASSA_RETURN_URL: Optional[str] = Field(default=None)

--- a/settings.py
+++ b/settings.py
@@ -75,12 +75,14 @@ def _populate_from_settings() -> None:
     g["UPLOAD_FALLBACK_ENABLED"] = bool(settings.UPLOAD_FALLBACK_ENABLED)
 
     g["TOPUP_URL"] = settings.TOPUP_URL or ""
+    g["STARS_PAYMENT_URL"] = settings.STARS_PAYMENT_URL or ""
+    g["CARD_PAYMENT_URL"] = settings.CARD_PAYMENT_URL or ""
 
     g["YOOKASSA_SHOP_ID"] = settings.YOOKASSA_SHOP_ID
     g["YOOKASSA_SECRET_KEY"] = settings.YOOKASSA_SECRET_KEY
     g["YOOKASSA_RETURN_URL"] = settings.YOOKASSA_RETURN_URL
     g["YOOKASSA_CURRENCY"] = settings.YOOKASSA_CURRENCY
-    g["CRYPTO_PAYMENT_URL"] = settings.CRYPTO_PAYMENT_URL
+    g["CRYPTO_PAYMENT_URL"] = settings.CRYPTO_PAYMENT_URL or ""
 
     g["SORA2_ENABLED"] = bool(settings.SORA2_ENABLED)
     g["SORA2_API_KEY"] = settings.SORA2_API_KEY_EFFECTIVE

--- a/tests/test_profile_views.py
+++ b/tests/test_profile_views.py
@@ -69,8 +69,8 @@ def test_profile_callbacks_route_all_views(monkeypatch):
         return []
 
     monkeypatch.setattr(profile_handlers, "_prepare_root_payload", fake_prepare)
-    monkeypatch.setattr(profile_handlers, "_topup_url", lambda: "https://pay.example")
-    monkeypatch.setattr(profile_handlers, "_billing_history", fake_history)
+    monkeypatch.setattr(profile_handlers, "_payment_urls", lambda: {"card": "https://pay.example"})
+    monkeypatch.setattr(profile_handlers, "get_user_transactions", fake_history)
     monkeypatch.setattr(profile_handlers, "_bot_name", lambda: "TestBot")
 
     def fake_render(ctx, view, data=None):
@@ -115,8 +115,8 @@ def test_profile_edit_fallback_when_msg_missing():
 def test_profile_no_empty_screens():
     ctx = _make_ctx()
 
-    text_topup, _ = profile_handlers.render_profile_view(ctx, "topup", {"topup_url": ""})
-    assert "Пополнение будет доступно позже" in text_topup
+    text_topup, _ = profile_handlers.render_profile_view(ctx, "topup", {"payment_urls": {}})
+    assert "Пополнение — в разработке" in text_topup
 
     text_invite, _ = profile_handlers.render_profile_view(ctx, "invite", {"invite_link": None})
     assert "Ссылка станет доступна позже" in text_invite


### PR DESCRIPTION
## Summary
- add dedicated payment URLs and update the top-up view to show all supported methods with a fallback message
- fetch and format the last five user transactions for the history view and expose an invite copy callback that returns the referral link
- adjust profile tests for the new helpers and empty-state messaging

## Testing
- pytest tests/test_profile_views.py
- pytest tests/test_profile_navigation.py

------
https://chatgpt.com/codex/tasks/task_e_68e7f34d8a4c83229b17a04e3aca0816