### PR TITLE
Stabilize profile card handling and sanitize Telegram HTML

### DIFF
--- a/helpers/telegram_html.py
+++ b/helpers/telegram_html.py
@@ -15,13 +15,26 @@ ALLOWED: frozenset[str] = frozenset({
     "pre",
     "a",
     "tg-spoiler",
+    "blockquote",
 })
 
 _ALLOWED_ATTRS: dict[str, frozenset[str]] = {
     "a": frozenset({"href"}),
 }
 
-_MAX_TEXT_LENGTH = 4000
+_MAX_TEXT_LENGTH = 3800
+
+
+def tg_html_safe(text: str) -> str:
+    """Return text adapted for Telegram HTML."""
+
+    if not text:
+        return ""
+
+    safe = text.replace("<br/>", "\n").replace("<BR/>", "\n")
+    if len(safe) > _MAX_TEXT_LENGTH:
+        safe = safe[: _MAX_TEXT_LENGTH - 1].rstrip() + "…"
+    return safe
 
 
 class _ProfileHTMLSanitizer(HTMLParser):


### PR DESCRIPTION
## Summary
- simplify the profile card workflow by sanitizing HTML via a new tg_html_safe helper and updating the Telegram HTML allow list
- replace the complex edit loop with a single-attempt edit plus send fallback, persist the last profile message id, and refresh the top up/history/invite cards
- gate dialog reset notifications behind an explicit flag so the dialog-disabled banner only appears on /cancel, and refresh the accompanying tests

## Testing
- pytest tests/test_profile_views.py::test_open_profile_send_fallback tests/test_profile_views.py::test_inner_buttons_back tests/test_profile_views.py::test_html_br_sanitized


------
https://chatgpt.com/codex/tasks/task_e_68e82872ec2883229789f1d4927899eb