### PR TITLE
Update Telegram Stars top-up UI

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -14414,10 +14414,9 @@ def stars_topup_kb() -> InlineKeyboardMarkup:
         diamonds = STARS_TO_DIAMONDS.get(stars)
         if not diamonds:
             continue
-        bonus = max(diamonds - stars, 0)
-        cap = f"⭐ {stars} → 💎 {diamonds}" + (f" +{bonus}💎 бонус" if bonus else "")
+        label = f"⭐ {stars} → 💎 {diamonds}"
         rows.append(
-            [InlineKeyboardButton(cap, callback_data=f"buy:stars:{stars}:{diamonds}")]
+            [InlineKeyboardButton(label, callback_data=f"buy:stars:{stars}:{diamonds}")]
         )
     rows.append([InlineKeyboardButton("🛒 Где купить Stars", url=STARS_BUY_URL)])
     rows.append([InlineKeyboardButton(common_text("topup.menu.back"), callback_data="topup:open")])
@@ -14535,39 +14534,15 @@ async def handle_topup_callback(
 
         if normalized == "topup:stars":
             await query.answer()
-            text = "\n".join(
-                filter(
-                    None,
-                    [
-                        common_text("topup.stars.title"),
-                        common_text("topup.stars.info"),
-                    ],
-                )
+            text = (
+                "💎 Пополнение через Telegram Stars\n"
+                "Если звёзд не хватает — купите в официальном боте @PremiumBot."
             )
-            edit_callable = getattr(query, "edit_message_text", None)
-            try:
-                if callable(edit_callable):
-                    await _safe_edit_message_text(
-                        edit_callable,
-                        text,
-                        reply_markup=stars_topup_kb(),
-                    )
-                elif message is not None and getattr(ctx.bot, "edit_message_text", None):
-                    await _safe_edit_message_text(
-                        ctx.bot.edit_message_text,
-                        chat_id=chat_id,
-                        message_id=message.message_id,
-                        text=text,
-                        reply_markup=stars_topup_kb(),
-                    )
-                else:
-                    raise AttributeError("edit_message_text not available")
-            except Exception:
-                await ctx.bot.send_message(
-                    chat_id=chat_id,
-                    text=text,
-                    reply_markup=stars_topup_kb(),
-                )
+            await ctx.bot.send_message(
+                chat_id=chat_id,
+                text=text,
+                reply_markup=stars_topup_kb(),
+            )
             return True
 
         if normalized == "topup:yookassa":

--- a/tests/test_callbacks_backward_compat.py
+++ b/tests/test_callbacks_backward_compat.py
@@ -44,4 +44,6 @@ def test_old_topup_callbacks_still_routed(monkeypatch):
 
     assert handled_stars is True
     assert handled_card is True
-    assert len(calls) == 2
+    assert len(calls) == 1
+    assert len(bot.sent) == 1
+    assert bot.sent[0]["text"].startswith("💎 Пополнение через Telegram Stars")

--- a/tests/test_topup.py
+++ b/tests/test_topup.py
@@ -57,6 +57,13 @@ def test_stars_button_label():
     assert keyboard.inline_keyboard[1][0].text == TXT_PAY_CARD
 
 
+def test_stars_topup_keyboard_labels():
+    keyboard = bot.stars_topup_kb()
+    for index, stars in enumerate(bot.STARS_PACK_ORDER):
+        expected = f"⭐ {stars} → 💎 {bot.STARS_TO_DIAMONDS[stars]}"
+        assert keyboard.inline_keyboard[index][0].text == expected
+
+
 @pytest.fixture
 def yk_environment(monkeypatch):
     monkeypatch.setenv("YOOKASSA_SHOP_ID", "shop")


### PR DESCRIPTION
## Summary
- remove the bonus suffix from Telegram Stars pack buttons and send a plain-text message when opening the Stars screen
- keep the Stars screen header consistent with the simplified copy and avoid editing existing messages
- update tests to cover the new keyboard labels and callback flow

## Testing
- pytest tests/test_topup.py tests/test_callbacks_backward_compat.py

------
https://chatgpt.com/codex/tasks/task_e_68e83336b7888322ac1b39d7dd95cf2c