### PR TITLE
Add shared Telegram Stars top-up screen

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -111,6 +111,7 @@ from hub_router import (
     set_fallback as set_hub_fallback,
 )
 from handlers import profile as profile_handlers
+from handlers.stars import open_stars_menu
 
 from state import state as redis_state
 
@@ -14879,7 +14880,21 @@ async def dialog_command(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
 
 async def buy_command(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     await ensure_user_record(update)
-    await topup(update, ctx)
+
+    message = update.effective_message
+    chat = update.effective_chat
+    chat_id = getattr(chat, "id", None)
+    if chat_id is None and message is not None:
+        chat_id = getattr(message, "chat_id", None)
+    message_id = getattr(message, "message_id", None) if message is not None else None
+
+    await open_stars_menu(
+        ctx,
+        chat_id=chat_id,
+        message_id=message_id,
+        edit_message=False,
+        source="command",
+    )
 
 
 async def lang_command(update: Update, ctx: ContextTypes.DEFAULT_TYPE):

--- a/handlers/stars.py
+++ b/handlers/stars.py
@@ -1,0 +1,129 @@
+import logging
+from typing import List, Optional, Sequence
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message
+
+log = logging.getLogger(__name__)
+
+STARS_TIERS: Sequence[tuple[int, int]] = (
+    (50, 50),
+    (100, 110),
+    (200, 220),
+    (300, 330),
+    (400, 440),
+    (500, 550),
+)
+
+
+def render_stars_text() -> str:
+    """Render the Stars top-up description."""
+
+    return (
+        "💎 <b>Пополнение через Telegram Stars</b>\n"
+        "Если звёзд не хватает — купите в официальном боте @PremiumBot."
+    )
+
+
+def build_stars_kb() -> InlineKeyboardMarkup:
+    rows: List[List[InlineKeyboardButton]] = []
+    for stars, gems in STARS_TIERS:
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=f"⭐️ {stars} → 💎 {gems}",
+                    callback_data=f"stars:buy:{stars}",
+                )
+            ]
+        )
+
+    rows.append([InlineKeyboardButton("🛒 Где купить Stars", url="https://t.me/PremiumBot")])
+    rows.append([InlineKeyboardButton("⬅️ Назад", callback_data="nav:back")])
+    return InlineKeyboardMarkup(rows)
+
+
+def _resolve_chat_id(chat_id: Optional[int], ctx) -> Optional[int]:
+    if chat_id is not None:
+        return chat_id
+
+    chat = getattr(ctx, "chat", None)
+    if chat is not None:
+        resolved = getattr(chat, "id", None)
+        if isinstance(resolved, int):
+            return resolved
+
+    chat_data = getattr(ctx, "chat_data", None)
+    if isinstance(chat_data, dict):
+        candidate = chat_data.get("chat_id")
+        if isinstance(candidate, int):
+            return candidate
+
+    return None
+
+
+def _resolve_message_id(message_id: Optional[int], ctx) -> Optional[int]:
+    if message_id is not None:
+        return message_id
+
+    message = getattr(ctx, "message", None)
+    if message is not None:
+        candidate = getattr(message, "message_id", None)
+        if isinstance(candidate, int):
+            return candidate
+
+    return None
+
+
+async def open_stars_menu(
+    ctx,
+    *,
+    chat_id: Optional[int] = None,
+    message_id: Optional[int] = None,
+    edit_message: bool = True,
+    source: Optional[str] = None,
+) -> Optional[Message]:
+    """Show the Stars purchase screen."""
+
+    bot = getattr(ctx, "bot", None)
+    if bot is None:
+        log.warning("stars.open missing_bot", extra={"source": source})
+        return None
+
+    target_chat_id = _resolve_chat_id(chat_id, ctx)
+    target_message_id = _resolve_message_id(message_id, ctx)
+
+    log.info("stars.open", extra={"source": source or "unknown", "chat_id": target_chat_id})
+
+    text = render_stars_text()
+    keyboard = build_stars_kb()
+
+    if edit_message and target_chat_id is not None and target_message_id is not None:
+        try:
+            return await bot.edit_message_text(
+                chat_id=target_chat_id,
+                message_id=target_message_id,
+                text=text,
+                reply_markup=keyboard,
+                parse_mode="HTML",
+                disable_web_page_preview=True,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            log.info(
+                "stars.render fallback=send",
+                extra={
+                    "source": source or "unknown",
+                    "chat_id": target_chat_id,
+                    "error": str(exc),
+                },
+            )
+
+    if target_chat_id is None:
+        log.warning("stars.render missing_chat", extra={"source": source})
+        return None
+
+    return await bot.send_message(
+        chat_id=target_chat_id,
+        text=text,
+        reply_markup=keyboard,
+        parse_mode="HTML",
+        disable_web_page_preview=True,
+    )

--- a/tests/test_stars_view.py
+++ b/tests/test_stars_view.py
@@ -1,0 +1,117 @@
+import asyncio
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("LEDGER_BACKEND", "memory")
+
+import bot as bot_module
+import handlers.profile as profile_handlers
+from handlers import profile_simple
+from handlers.stars import STARS_TIERS, build_stars_kb, render_stars_text
+
+
+def test_render_stars_text_no_bonus():
+    text = render_stars_text()
+    lowered = text.lower()
+    assert "бонус" not in lowered
+    assert "скоро" not in lowered
+
+
+def test_build_stars_kb_structure():
+    keyboard = build_stars_kb()
+    rows = keyboard.inline_keyboard
+    assert len(rows) == 8
+    for index, (stars, gems) in enumerate(STARS_TIERS):
+        button = rows[index][0]
+        assert button.text == f"⭐️ {stars} → 💎 {gems}"
+        assert button.callback_data == f"stars:buy:{stars}"
+    assert rows[6][0].url == "https://t.me/PremiumBot"
+    assert rows[7][0].callback_data == "nav:back"
+
+
+def test_buy_command_opens_stars(monkeypatch):
+    async def run() -> None:
+        ensure_mock = AsyncMock()
+        monkeypatch.setattr(bot_module, "ensure_user_record", ensure_mock)
+        open_mock = AsyncMock()
+        monkeypatch.setattr(bot_module, "open_stars_menu", open_mock)
+
+        chat = SimpleNamespace(id=777)
+        message = SimpleNamespace(message_id=55, chat=chat, chat_id=chat.id)
+        update = SimpleNamespace(effective_chat=chat, effective_message=message)
+        ctx = SimpleNamespace()
+
+        await bot_module.buy_command(update, ctx)
+
+        ensure_mock.assert_awaited_once()
+        open_mock.assert_awaited_once()
+        kwargs = open_mock.call_args.kwargs
+        assert kwargs["edit_message"] is False
+        assert kwargs["source"] == "command"
+        assert kwargs["chat_id"] == chat.id
+        assert kwargs["message_id"] == message.message_id
+
+    asyncio.run(run())
+
+
+def test_profile_topup_uses_stars(monkeypatch):
+    async def run() -> None:
+        monkeypatch.setattr(profile_handlers, "_simple_profile_enabled", lambda: False)
+        open_mock = AsyncMock()
+        monkeypatch.setattr(profile_handlers, "open_stars_menu", open_mock)
+
+        chat = SimpleNamespace(id=1001)
+        message = SimpleNamespace(message_id=202, chat=chat, chat_id=chat.id)
+        query = SimpleNamespace(message=message)
+        update = SimpleNamespace(
+            callback_query=query,
+            effective_chat=chat,
+            effective_message=message,
+        )
+        ctx = SimpleNamespace()
+
+        await profile_handlers.on_profile_topup(update, ctx)
+
+        open_mock.assert_awaited_once()
+        kwargs = open_mock.call_args.kwargs
+        assert kwargs["edit_message"] is True
+        assert kwargs["source"] == "profile"
+
+    asyncio.run(run())
+
+
+def test_profile_simple_topup_uses_stars(monkeypatch):
+    async def run() -> None:
+        open_mock = AsyncMock()
+        monkeypatch.setattr(profile_simple, "open_stars_menu", open_mock)
+
+        chat = SimpleNamespace(id=900)
+        message = SimpleNamespace(message_id=77, chat=chat, chat_id=chat.id)
+        async def answer(*_args, **_kwargs):
+            return None
+
+        query = SimpleNamespace(message=message, answer=answer)
+        update = SimpleNamespace(
+            callback_query=query,
+            effective_chat=chat,
+            effective_message=message,
+        )
+        ctx = SimpleNamespace()
+
+        await profile_simple.profile_topup(update, ctx)
+
+        open_mock.assert_awaited_once()
+        kwargs = open_mock.call_args.kwargs
+        assert kwargs["edit_message"] is True
+        assert kwargs["source"] == "profile"
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add a shared Telegram Stars purchase renderer with safe edit/send fallback logging
- wire /buy and profile top-up actions (classic and simple) to open the Stars screen
- update profile view expectations and add tests covering the Stars view helpers

## Testing
- pytest tests/test_profile_views.py
- pytest tests/test_stars_view.py

------
https://chatgpt.com/codex/tasks/task_e_68e837392d6083228be10584c9cf6ffa