### PR TITLE
Restore knowledge base menu handler

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7743,6 +7743,17 @@ async def show_balance_card(
     return mid
 
 
+@register_callback_action("menu", "kb", module="kb")
+async def handle_menu_kb(callback: HubCallbackContext) -> None:
+    await _perform_menu_open(
+        "kb",
+        update=callback.update,
+        ctx=callback.application_context,
+        query=callback.query,
+        log_click=False,
+    )
+
+
 @register_callback_action("menu", "profile", module="profile")
 async def handle_menu_profile(callback: HubCallbackContext) -> None:
     ctx = callback.application_context


### PR DESCRIPTION
## Summary
- register the `menu:kb` callback with the hub router so the knowledge base button reuses the existing menu logic

## Testing
- pytest tests/test_main_menu_navigation.py::test_menu_callbacks_route_ok


------
https://chatgpt.com/codex/tasks/task_e_68e88752f9e08322a96f903e4a50c6bb