### PR TITLE
Fix knowledge base callbacks for inline and text entry

### DIFF
--- a/keyboards.py
+++ b/keyboards.py
@@ -26,7 +26,7 @@ EMOJI = {
 }
 
 NAV_PROFILE = "menu:profile"
-NAV_KB = "menu:kb"
+NAV_KB = "kb_open"
 NAV_PHOTO = "menu:photo"
 NAV_MUSIC = "menu:music"
 NAV_VIDEO = "menu:video"

--- a/tests/test_hub_menu.py
+++ b/tests/test_hub_menu.py
@@ -27,7 +27,7 @@ def test_build_hub_keyboard_layout():
     ]
     assert callbacks == [
         "menu:profile",
-        "menu:kb",
+        "kb_open",
         "menu:photo",
         "menu:music",
         "menu:video",

--- a/tests/test_keyboards_unified.py
+++ b/tests/test_keyboards_unified.py
@@ -32,7 +32,7 @@ def test_kb_home_menu_layout():
     ]
     assert callbacks == [
         "menu:profile",
-        "menu:kb",
+        "kb_open",
         "menu:photo",
         "menu:music",
         "menu:video",


### PR DESCRIPTION
## Summary
- add dedicated knowledge base open handlers that reuse the card renderer for inline callbacks and text triggers
- update menus to emit the unified `kb_open` callback and register a regex handler for the reply button message
- refresh tests to reflect the new callback id and behaviour

## Testing
- pytest tests/test_main_menu_navigation.py tests/test_hub_menu.py tests/test_keyboards_unified.py tests/test_kb_open.py

------
https://chatgpt.com/codex/tasks/task_e_68e8a45fbd588322a78a5095422b5c57