### PR TITLE
Add Sora2 option to video menu and refine prompt flow

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6169,6 +6169,7 @@ async def _open_menu_section(
             chat_id,
             veo_fast_cost=TOKEN_COSTS.get("veo_fast", 0),
             veo_photo_cost=TOKEN_COSTS.get("veo_photo", 0),
+            sora2_cost=TOKEN_COSTS.get("sora2_ttv", 0),
             suppress_nav=suppress_nav,
             fallback_message_id=fallback_message_id,
         )
@@ -6493,7 +6494,11 @@ async def show_images_menu(chat_id: int, ctx: ContextTypes.DEFAULT_TYPE) -> None
 
 
 async def show_video_menu(chat_id: int, ctx: ContextTypes.DEFAULT_TYPE) -> None:
-    card = build_video_card(veo_fast_cost=TOKEN_COSTS["veo_fast"], veo_photo_cost=TOKEN_COSTS["veo_photo"])
+    card = build_video_card(
+        veo_fast_cost=TOKEN_COSTS["veo_fast"],
+        veo_photo_cost=TOKEN_COSTS["veo_photo"],
+        sora2_cost=TOKEN_COSTS["sora2_ttv"],
+    )
     await ctx.bot.send_message(chat_id, **card)
 
 
@@ -7191,12 +7196,10 @@ def video_menu_kb() -> InlineKeyboardMarkup:
 
 
 def sora2_intro_text() -> str:
-    example = "человек идёт по пляжу на закате, волны блестят, медленная камера"
     return (
         "🎬 *Sora2 — генерация видео по тексту*\n\n"
-        "Отправьте текстовое описание сцены, которую хотите создать.\n"
         f"Стоимость: 💎 {PRICE_SORA2_TEXT}\n\n"
-        f"_Пример:_ {example}"
+        "Нажмите «🚀 Начать генерацию», затем отправьте текстовое описание сцены."
     )
 
 
@@ -11301,9 +11304,8 @@ def sora2_card_text(s: Dict[str, Any]) -> str:
         intro_title = "🎬 <b>Sora2 — видео из изображений</b>"
     lines = [intro_title, f"💎 Стоимость генерации: <b>{PRICE_SORA2_TEXT}</b>"]
     if is_text_mode:
-        lines.append("Отправьте текстовое описание сцены, которую хотите создать.")
         lines.append(
-            "<i>Пример: человек идёт по пляжу на закате, волны блестят, медленная камера</i>"
+            "Нажмите «🚀 Начать генерацию», затем отправьте текстовое описание сцены."
         )
     else:
         lines.append("Прикрепите 1–4 ссылок на изображения и добавьте описание сцены.")
@@ -15371,7 +15373,7 @@ async def video_menu_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) ->
                     message_id = await safe_edit_or_send_menu(
                         ctx,
                         chat_id=chat_id,
-                        text="✏️ Введите текст для Sora2 (описание сцены).",
+                        text="✏️ Отправьте текстовое описание сцены для Sora2.",
                         reply_markup=InlineKeyboardMarkup(
                             [[InlineKeyboardButton("⬅️ Отменить", callback_data="video:menu")]]
                         ),
@@ -15416,12 +15418,7 @@ async def video_menu_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) ->
             target_chat = chat_id if chat_id is not None else (user_id if user_id else None)
             if target_chat is not None:
                 await _clear_video_menu_state(target_chat, user_id=user_id, ctx=ctx)
-                await show_emoji_hub_for_chat(
-                    target_chat,
-                    ctx,
-                    user_id=user_id,
-                    replace=True,
-                )
+                await show_main_menu(target_chat, ctx)
             return
     finally:
         await _answer()

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -58,7 +58,7 @@ def build_music_card() -> dict:
     return build_card(TXT_KB_MUSIC, "Выберите режим:", rows)
 
 
-def build_video_card(*, veo_fast_cost: int, veo_photo_cost: int) -> dict:
+def build_video_card(*, veo_fast_cost: int, veo_photo_cost: int, sora2_cost: int) -> dict:
     rows = [
         [
             InlineKeyboardButton(
@@ -70,6 +70,12 @@ def build_video_card(*, veo_fast_cost: int, veo_photo_cost: int) -> dict:
             InlineKeyboardButton(
                 f"Оживить изображение (Veo) — 💎 {veo_photo_cost}",
                 callback_data=CB.VIDEO_VEO_ANIMATE,
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                f"🎬 Sora2 — текст → видео — 💎 {sora2_cost}",
+                callback_data="video:type:sora2",
             )
         ],
         [InlineKeyboardButton("⬅️ Назад", callback_data="back")],

--- a/handlers/video.py
+++ b/handlers/video.py
@@ -56,6 +56,7 @@ async def open_menu(
     *,
     veo_fast_cost: int,
     veo_photo_cost: int,
+    sora2_cost: int,
     suppress_nav: bool = False,
     fallback_message_id: Optional[int] = None,
 ) -> Optional[int]:
@@ -63,7 +64,11 @@ async def open_menu(
         raise RuntimeError("video menu handler is not configured")
 
     state_dict = _state_getter(ctx)
-    card = build_video_card(veo_fast_cost=veo_fast_cost, veo_photo_cost=veo_photo_cost)
+    card = build_video_card(
+        veo_fast_cost=veo_fast_cost,
+        veo_photo_cost=veo_photo_cost,
+        sora2_cost=sora2_cost,
+    )
 
     message_id = await _send_menu(
         ctx,

--- a/tests/test_main_menu_navigation.py
+++ b/tests/test_main_menu_navigation.py
@@ -38,6 +38,7 @@ def test_menu_callbacks_route_ok(monkeypatch):
         *,
         veo_fast_cost,
         veo_photo_cost,
+        sora2_cost,
         suppress_nav,
         fallback_message_id=None,
     ):
@@ -50,6 +51,7 @@ def test_menu_callbacks_route_ok(monkeypatch):
                     "fallback": fallback_message_id,
                     "fast": veo_fast_cost,
                     "photo": veo_photo_cost,
+                    "sora2": sora2_cost,
                 },
             )
         )

--- a/tests/test_video_sora2.py
+++ b/tests/test_video_sora2.py
@@ -148,7 +148,7 @@ def test_video_sora2_start_sets_wait_state(monkeypatch, bot_module):
     assert wait_state.kind == WaitKind.SORA2_PROMPT
     assert wait_state.meta.get("mode") == "sora2_simple"
     assert wait_state.meta.get("suppress_ack") is True
-    assert "Введите текст" in captured[0]["text"]
+    assert "Отправьте текстовое описание сцены" in captured[0]["text"]
 
     clear_wait_state(101)
 


### PR DESCRIPTION
## Summary
- add a Sora2 entry to the video mode card and plumb the new cost parameter through menu helpers
- refresh the Sora2 intro and prompt instructions while ensuring the back button restores the main menu
- update unit tests to cover the new callbacks and copy

## Testing
- pytest tests/test_video_sora2.py tests/test_main_menu_navigation.py tests/test_video_menu_single_card.py tests/test_menu_command.py

------
https://chatgpt.com/codex/tasks/task_e_68e94a184b448322b6f991232a09d470