### PR TITLE
Fix Sora2 video flow and KIE integration

### DIFF
--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -74,7 +74,7 @@ def build_video_card(*, veo_fast_cost: int, veo_photo_cost: int, sora2_cost: int
         ],
         [
             InlineKeyboardButton(
-                f"🎬 Sora2 — текст → видео — 💎 {sora2_cost}",
+                f"🎬 Sora2 — генерация по тексту — 💎 {sora2_cost}",
                 callback_data="video:type:sora2",
             )
         ],


### PR DESCRIPTION
## Summary
- fix the KIE async client to add the missing /api/v1 prefix, send JSON headers, default aspect/quality values, and log structured poll responses
- refresh the Sora2 card/menu flow so the video menu renders the updated copy, locks prompt input via WAIT state, and provides start/back controls
- harden the Sora2 prompt handler to support legacy wait states, move charging after task creation, add balance checks, and emit detailed success/failure logs

## Testing
- pytest tests/test_video_sora2.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e95426608483228cec3cd706575d0c