### PR TITLE
Fix video callback responsiveness

### DIFF
--- a/helpers/debounce.py
+++ b/helpers/debounce.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import time
+from threading import RLock
+from typing import Hashable
+
+__all__ = ["debounce"]
+
+
+_last_clicks: dict[tuple[Hashable, Hashable], float] = {}
+_lock = RLock()
+
+
+def debounce(user_id: Hashable, action: Hashable, *, delay: float = 1.0) -> bool:
+    """Return ``True`` if the action should be processed.
+
+    A simple in-memory debounce helper that filters out duplicate callback
+    invocations that arrive within ``delay`` seconds for the same user and
+    action key. ``user_id`` and ``action`` can be any hashable values; ``None``
+    is treated as a shared bucket.
+    """
+
+    now = time.monotonic()
+    key = (user_id, action)
+    with _lock:
+        last = _last_clicks.get(key)
+        if last is not None and now - last < delay:
+            return False
+        _last_clicks[key] = now
+    return True


### PR DESCRIPTION
## Summary
- add a shared debounce helper to filter out rapid duplicate callback presses
- clear residual video wait states before opening menus or switching modes and answer callbacks immediately
- harden video menu callbacks with early acknowledgements, debounce guards, and additional logging

## Testing
- pytest tests/test_video_menu_single_card.py tests/test_video_sora2.py

------
https://chatgpt.com/codex/tasks/task_e_68e96838bea08322a135a993af5cb6a0