### PR TITLE
Fix Sora2 task creation endpoint and improve video callbacks

### DIFF
--- a/sora2_client.py
+++ b/sora2_client.py
@@ -573,7 +573,7 @@ async def kie_create_sora2_task(
     aspect_ratio: Optional[str] = None,
     quality: Optional[str] = None,
     callback_url: Optional[str] = None,
-) -> str:
+) -> Optional[str]:
     input_payload: Dict[str, Any] = {"prompt": prompt}
     aspect = (aspect_ratio or "").strip() or "16:9"
     quality_value = (quality or "").strip() or "standard"
@@ -590,6 +590,12 @@ async def kie_create_sora2_task(
     headers = _kie_headers(json_payload=True)
     async with httpx.AsyncClient(timeout=60.0) as client:
         response = await client.post(endpoint, json=payload, headers=headers)
+    if response.status_code == 404:
+        logger.error(
+            "sora2.fail_404",
+            extra={"url": endpoint, "payload": _sanitize_payload_for_log(payload)},
+        )
+        return None
     logger.info(
         "kie.http.create",
         extra={


### PR DESCRIPTION
## Summary
- update the Sora2 client to hit the new /api/v1/createTask endpoint and report 404s cleanly
- improve Sora2 prompt handling by using the wait-state text, refunding on failures, and logging errors with stack traces
- answer video and Sora2 callback buttons immediately to prevent sticky loading indicators

## Testing
- pytest tests/test_video_sora2.py

------
https://chatgpt.com/codex/tasks/task_e_68e9e8f4465483229178c2ecefa137d7