### PR TITLE
Harden PostgreSQL connectivity and admin tooling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,11 +19,10 @@ mutagen>=1.47.0
 Pillow>=10.0
 
 # Database toolkit for admin features
-SQLAlchemy>=2.0,<3.0
+SQLAlchemy>=2.0.30,<3.0
 
 # PostgreSQL + пул соединений
-psycopg[binary]>=3.2,<3.3
-psycopg-pool>=3.2,<3.3
+psycopg[binary,pool]>=3.1,<4.0
 
 # Вспомогательные пакеты для сборки
 wheel>=0.43


### PR DESCRIPTION
## Summary
- update dependencies to ship psycopg with pooling extras and tighten the SQLAlchemy requirement
- add resilient PostgreSQL engine bootstrap with schema setup, transaction logging, health checks, and backup helpers
- expose admin commands for DB health/backup, log token adjustments, and harden the Redis→Postgres migration with retries

## Testing
- python -m compileall bot.py db/postgres.py scripts/migrate_from_redis.py

------
https://chatgpt.com/codex/tasks/task_e_68ece11077348322b9712cd0b07ac6e8