### PR TITLE
Normalize PostgreSQL DSN usage and enhance admin commands

### DIFF
--- a/ledger.py
+++ b/ledger.py
@@ -10,6 +10,8 @@ import threading
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
+from db.postgres import normalize_dsn
+
 try:  # psycopg is optional when using the in-memory backend
     import psycopg
     from psycopg.errors import UniqueViolation
@@ -98,6 +100,7 @@ class _PostgresLedgerStorage(_LedgerHelpers):
     def __init__(self, dsn: str):
         if not dsn:
             raise RuntimeError("DATABASE_URL is required for ledger storage")
+        dsn = normalize_dsn(dsn)
         if psycopg is None or ConnectionPool is None:
             raise RuntimeError(
                 "Postgres ledger backend requires psycopg and psycopg_pool to be installed"

--- a/payments/yookassa_callback.py
+++ b/payments/yookassa_callback.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 
 import requests
 
+from db.postgres import normalize_dsn
 from ledger import LedgerStorage
 from texts import common_text
 
@@ -36,6 +37,8 @@ def _ledger() -> LedgerStorage:
     if _ledger_instance is None:
         backend = (os.getenv("LEDGER_BACKEND") or "postgres").lower()
         dsn = os.getenv("DATABASE_URL") or os.getenv("POSTGRES_DSN")
+        if dsn:
+            dsn = normalize_dsn(dsn)
         _ledger_instance = LedgerStorage(dsn, backend=backend)
     return _ledger_instance
 


### PR DESCRIPTION
## Summary
- add normalize_dsn helper that enforces the psycopg driver, SSL defaults, and connection retry/backoff parameters in db/postgres
- expose database overview and balance adjustment utilities for admin tooling and reuse them in /check_db and /add_tokens commands
- reuse the shared engine and add progress-aware retry logic for the Redis migration script while normalizing DSN usage across modules

## Testing
- python -m compileall db/postgres.py ledger.py payments/yookassa_callback.py scripts/migrate_from_redis.py bot.py

------
https://chatgpt.com/codex/tasks/task_e_68ece6ea62e083229b8111bf18853c20