### PR TITLE
Improve Redis migration robustness

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -16362,11 +16362,12 @@ async def migrate_redis_command(update: Update, ctx: ContextTypes.DEFAULT_TYPE) 
         try:
             stats = await run_redis_migration(progress_callback=_progress_callback)
         except Exception as exc:
-            log.exception("admin.migrate_redis.failed | actor=%s err=%s", actor.id, exc)
+            log.error("admin.migrate_redis.failed | actor=%s err=%s", actor.id, exc, exc_info=True)
             try:
                 await status.edit_text(f"❌ Миграция завершилась ошибкой: {exc}")
             except Exception:
-                await message.reply_text("❌ Миграция завершилась ошибкой. Подробности в логах.")
+                pass
+            await message.reply_text(f"❌ Ошибка миграции: {exc}")
             return
         last_progress = None
         lines = stats.as_lines()


### PR DESCRIPTION
## Summary
- add a safe_decode helper and normalize Redis profile parsing to tolerate malformed values
- skip Redis user entries without identity data, log progress every 500 users, and report final migration totals
- adjust the /migrate_redis handler to surface migration errors without crashing the bot

## Testing
- python -m compileall scripts/migrate_from_redis.py bot.py

------
https://chatgpt.com/codex/tasks/task_e_68ed0cc7633483229bb625080d498ef1