### PR TITLE
Add Redis cleanup command and harden connection pools

### DIFF
--- a/db/postgres.py
+++ b/db/postgres.py
@@ -264,9 +264,11 @@ def connect_with_retry(dsn: str, attempts: int = 6, backoff: float = 1.5) -> Eng
                 engine_url,
                 future=True,
                 pool_pre_ping=True,
+                pool_recycle=1800,
                 pool_size=5,
                 max_overflow=5,
                 pool_timeout=15,
+                connect_args={"sslmode": "require"},
             )
             _test_connection(engine)
             log.info("postgres.connected | driver=postgresql+psycopg")


### PR DESCRIPTION
## Summary
- add an async helper to purge legacy Redis keys and expose it through a restricted /cleanup_redis command
- tighten Redis and PostgreSQL pooling parameters to reduce stale connections and SSL drops
- extend the /check_db admin report with Redis key counts and clearer ledger status messaging

## Testing
- python -m compileall bot.py scripts/migrate_from_redis.py db/postgres.py

------
https://chatgpt.com/codex/tasks/task_e_68ed12fca84883229ec4f464d3b3cb12