### PR TITLE
Improve Redis migration resilience and UTF-8 handling

### DIFF
--- a/redis_utils.py
+++ b/redis_utils.py
@@ -30,7 +30,15 @@ _use_memory_only = bool(_redis_url and _redis_url.startswith("memory://"))
 if _use_memory_only:
     _r = None
 else:
-    _r = redis.from_url(_redis_url) if _redis_url else None
+    _r = (
+        redis.from_url(
+            _redis_url,
+            encoding="utf-8",
+            decode_responses=True,
+        )
+        if _redis_url
+        else None
+    )
 rds = _r
 _PFX = REDIS_PREFIX
 _TTL = 24 * 60 * 60

--- a/suno_web.py
+++ b/suno_web.py
@@ -282,7 +282,7 @@ def root() -> dict[str, bool]:
 def healthz() -> JSONResponse:
     if not REDIS_URL.startswith("memory://"):
         try:
-            redis.from_url(REDIS_URL)
+            redis.from_url(REDIS_URL, encoding="utf-8", decode_responses=True)
         except Exception as exc:  # pragma: no cover - configuration issues
             log.error("health.redis.invalid", extra={"error": str(exc)})
             raise HTTPException(status_code=503, detail="invalid redis configuration") from exc


### PR DESCRIPTION
## Summary
- enforce UTF-8 decoding on Redis clients used across the bot, migration script, and Suno web health checks
- harden the Redis migration pipeline with safe decoding, connection retries, key counting, and explicit skip tracking
- refresh the /migrate_redis admin summary and failure reporting to include remaining keys and full tracebacks

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68ed3c6353048322a04cc31d7ef74777