### PR TITLE
Stabilize runner lock and Codex logging flush

### DIFF
--- a/core/codex_logger.py
+++ b/core/codex_logger.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import os
+import threading
 import time
 import traceback
 from typing import Any, Dict, List, Optional
@@ -17,6 +18,8 @@ class AsyncCodexHandler(logging.Handler):
     """A logging handler that ships structured logs to Codex asynchronously."""
 
     _TELEGRAM_API_TEMPLATE = "https://api.telegram.org/bot{token}/sendMessage"
+    _STOP_SENTINEL: object = object()
+    _FLUSH_SENTINEL: object = object()
 
     def __init__(self) -> None:
         super().__init__()
@@ -26,25 +29,60 @@ class AsyncCodexHandler(logging.Handler):
         self.app_name = os.getenv("APP_NAME", "veo3-bot")
         self.app_env = os.getenv("APP_ENV", "prod")
         self.min_level = os.getenv("CODEX_LOG_MIN_LEVEL", "INFO")
-        self.batch_size = int(os.getenv("CODEX_LOG_BATCH_SIZE", "20"))
-        self.flush_sec = float(os.getenv("CODEX_LOG_FLUSH_SEC", "2"))
-        self.queue: "asyncio.Queue[Dict[str, Any]]" = asyncio.Queue(
-            maxsize=int(os.getenv("CODEX_LOG_MAX_QUEUE", "1000"))
-        )
+        self.batch_size = max(1, int(os.getenv("CODEX_LOG_BATCH_SIZE", "20")))
+        self.flush_sec = max(0.5, float(os.getenv("CODEX_LOG_FLUSH_SEC", "2")))
+        self.max_queue = max(1, int(os.getenv("CODEX_LOG_MAX_QUEUE", "1000")))
+
+        self.queue: Optional[asyncio.Queue[Dict[str, Any]]] = None
         self.session: Optional[aiohttp.ClientSession] = None
-        self._loop_task: Optional[asyncio.Task[None]] = None
-        self._flush_lock = asyncio.Lock()
-        self._telegram_chat_id = os.getenv("TG_LOG_CHAT_ID")
-        self._telegram_token = os.getenv("TELEGRAM_TOKEN")
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._worker_done: Optional[asyncio.Event] = None
+        self._thread: Optional[threading.Thread] = None
+        self._queue_ready = threading.Event()
+        self._closing = False
         self._failure_streak = 0
         self._last_fallback_ts = 0.0
+        self._telegram_chat_id = os.getenv("TG_LOG_CHAT_ID")
+        self._telegram_token = os.getenv("TELEGRAM_TOKEN")
 
         if self.enabled and self.endpoint and self.api_key:
-            try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                loop = asyncio.get_event_loop()
-            self._loop_task = loop.create_task(self._loop())
+            self._start_worker()
+
+    # ------------------------------------------------------------------
+    # Worker lifecycle
+    # ------------------------------------------------------------------
+    def _start_worker(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            name="codex-logger",
+            daemon=True,
+        )
+        self._thread.start()
+        self._queue_ready.wait(timeout=5)
+
+    def _run_loop(self) -> None:
+        try:
+            asyncio.run(self._worker_main())
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logging.getLogger("codex").warning("worker loop crashed: %s", exc)
+
+    async def _worker_main(self) -> None:
+        self._loop = asyncio.get_running_loop()
+        self.queue = asyncio.Queue(maxsize=self.max_queue)
+        self._worker_done = asyncio.Event()
+        self._queue_ready.set()
+        try:
+            await self._worker()
+        finally:
+            if self.session and not self.session.closed:
+                await self.session.close()
+            self.session = None
+            self.queue = None
+            self._loop = None
+            self._worker_done.set()
+            self._queue_ready.clear()
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
         if self.session is None or self.session.closed:
@@ -52,26 +90,18 @@ class AsyncCodexHandler(logging.Handler):
             self.session = aiohttp.ClientSession(timeout=timeout)
         return self.session
 
-    async def _loop(self) -> None:
-        """Background loop flushing queued records to Codex."""
-
-        try:
-            await self._ensure_session()
-        except Exception as exc:  # pragma: no cover - defensive
-            logging.getLogger("codex").warning("session init failed: %s", exc)
+    # ------------------------------------------------------------------
+    # Logging.Handler API
+    # ------------------------------------------------------------------
+    def emit(self, record: logging.LogRecord) -> None:  # noqa: D401
+        if (
+            not self.enabled
+            or not self.endpoint
+            or not self.api_key
+            or record.name == "codex"
+        ):
             return
-
-        try:
-            while True:
-                await asyncio.sleep(self.flush_sec)
-                await self.flush()
-        except asyncio.CancelledError:  # pragma: no cover - graceful shutdown
-            raise
-        except Exception as exc:  # pragma: no cover - defensive logging
-            logging.getLogger("codex").warning("flush loop crashed: %s", exc)
-
-    async def emit_async(self, record: logging.LogRecord) -> None:
-        if not self.enabled or not self.endpoint:
+        if not self._queue_ready.is_set() or self.queue is None or self._loop is None:
             return
 
         message = self.format(record)
@@ -88,69 +118,147 @@ class AsyncCodexHandler(logging.Handler):
             },
         }
 
+        def _put() -> None:
+            if self.queue is None or self._closing:
+                return
+            try:
+                self.queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                pass
+
+        self._loop.call_soon_threadsafe(_put)
+
+    def flush(self) -> None:  # noqa: D401
+        if not self.enabled or not self._queue_ready.is_set() or not self._loop:
+            return
         try:
-            self.queue.put_nowait(payload)
-        except asyncio.QueueFull:
-            # Drop the message silently to avoid blocking the application.
+            future = asyncio.run_coroutine_threadsafe(self._flush_async(), self._loop)
+            future.result()
+        except Exception as exc:
+            logging.getLogger("codex").warning("flush failed: %s", exc)
+
+    def close(self) -> None:
+        try:
+            self.flush()
+        except Exception:
             pass
-
-    def emit(self, record: logging.LogRecord) -> None:  # noqa: D401
-        if not self.enabled or not self.endpoint:
-            return
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
+        if self.enabled and self._loop:
             try:
-                loop = asyncio.get_event_loop()
-            except RuntimeError:
-                return
-        try:
-            loop.create_task(self.emit_async(record))
-        except RuntimeError:
-            # The loop is not running (application shutdown) — drop the log silently.
-            return
-
-    async def flush(self) -> None:  # noqa: D401
-        if not self.enabled or not self.endpoint:
-            return
-        if self.queue.empty():
-            return
-
-        async with self._flush_lock:
-            if self.queue.empty():
-                return
-
-            batch: List[Dict[str, Any]] = []
-            while not self.queue.empty() and len(batch) < self.batch_size:
-                try:
-                    batch.append(self.queue.get_nowait())
-                except asyncio.QueueEmpty:
-                    break
-
-            if not batch:
-                return
-
-            session = await self._ensure_session()
-            headers = {
-                "Authorization": f"Bearer {self.api_key}",
-                "Content-Type": "application/json",
-            }
-
-            try:
-                async with session.post(self.endpoint, data=json.dumps(batch), headers=headers) as resp:
-                    if resp.status >= 400:
-                        raise RuntimeError(f"Codex returned {resp.status}")
+                future = asyncio.run_coroutine_threadsafe(self._shutdown_async(), self._loop)
+                future.result()
             except Exception as exc:
-                logging.getLogger("codex").warning("flush error: %s", exc)
-                # Attempt to requeue the batch for future delivery.
-                for item in batch:
-                    try:
-                        self.queue.put_nowait(item)
-                    except asyncio.QueueFull:
+                logging.getLogger("codex").warning("shutdown failed: %s", exc)
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5)
+        self._thread = None
+        super().close()
+
+    # ------------------------------------------------------------------
+    # Flush & shutdown helpers
+    # ------------------------------------------------------------------
+    async def _flush_async(self) -> None:
+        if not self.enabled or self.queue is None or self._closing:
+            return
+        await self.queue.put(self._FLUSH_SENTINEL)
+        await self.queue.join()
+
+    async def _shutdown_async(self) -> None:
+        if self.queue is None or self._closing:
+            return
+        self._closing = True
+        await self.queue.put(self._STOP_SENTINEL)
+        await self.queue.join()
+        if self._worker_done is not None:
+            await self._worker_done.wait()
+
+    # ------------------------------------------------------------------
+    # Worker implementation
+    # ------------------------------------------------------------------
+    async def _worker(self) -> None:
+        if self.queue is None:
+            return
+        pending: List[Dict[str, Any]] = []
+        loop = asyncio.get_running_loop()
+        next_flush: Optional[float] = None
+
+        try:
+            while True:
+                timeout: Optional[float] = None
+                if pending:
+                    timeout = max(0.0, next_flush - loop.time()) if next_flush else 0.0
+                try:
+                    item = await asyncio.wait_for(self.queue.get(), timeout=timeout)
+                    got_item = True
+                except asyncio.TimeoutError:
+                    item = None
+                    got_item = False
+
+                if got_item:
+                    if item is self._STOP_SENTINEL:
+                        await self._flush_pending(pending)
+                        self.queue.task_done()
                         break
-                await self._handle_flush_failure(batch, str(exc))
-            else:
-                self._failure_streak = 0
+                    if item is self._FLUSH_SENTINEL:
+                        await self._flush_pending(pending)
+                        self.queue.task_done()
+                        next_flush = None
+                        continue
+
+                    pending.append(item)
+                    if len(pending) == 1:
+                        next_flush = loop.time() + self.flush_sec
+                    if len(pending) >= self.batch_size:
+                        await self._flush_pending(pending)
+                        next_flush = None
+                    continue
+
+                if pending:
+                    await self._flush_pending(pending)
+                    next_flush = None
+        finally:
+            await self._flush_pending(pending)
+
+    async def _flush_pending(self, pending: List[Dict[str, Any]]) -> None:
+        if not pending or self.queue is None:
+            return
+        batch = list(pending)
+        success = await self._send_batch(batch)
+        if not success:
+            for item in batch:
+                try:
+                    self.queue.put_nowait(item)
+                except asyncio.QueueFull:
+                    break
+        for _ in batch:
+            self.queue.task_done()
+        pending.clear()
+
+    async def _send_batch(self, batch: List[Dict[str, Any]]) -> bool:
+        if not batch or not self.endpoint or not self.api_key:
+            return True
+        try:
+            session = await self._ensure_session()
+        except Exception as exc:  # pragma: no cover - defensive
+            logging.getLogger("codex").warning("session init failed: %s", exc)
+            return False
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = json.dumps(batch, ensure_ascii=False)
+
+        try:
+            async with session.post(self.endpoint, data=payload, headers=headers) as resp:
+                if resp.status >= 400:
+                    raise RuntimeError(f"Codex returned {resp.status}")
+        except Exception as exc:
+            logging.getLogger("codex").warning("flush error: %s", exc)
+            await self._handle_flush_failure(batch, str(exc))
+            return False
+
+        self._failure_streak = 0
+        return True
 
     async def _handle_flush_failure(self, batch: List[Dict[str, Any]], reason: str) -> None:
         self._failure_streak += 1
@@ -165,7 +273,11 @@ class AsyncCodexHandler(logging.Handler):
         if now - self._last_fallback_ts < 60:
             return
 
-        session = await self._ensure_session()
+        try:
+            session = await self._ensure_session()
+        except Exception:  # pragma: no cover - defensive
+            return
+
         sample = batch[0] if batch else {}
         sample_message = sample.get("msg", "") if isinstance(sample, dict) else ""
         text_lines = [
@@ -191,8 +303,7 @@ class AsyncCodexHandler(logging.Handler):
             async with session.post(url, json=payload) as resp:
                 if resp.status < 400:
                     self._last_fallback_ts = now
-        except Exception:
-            # Ignore Telegram errors entirely — we don't want cascading failures.
+        except Exception:  # pragma: no cover - best effort fallback
             return
 
 
@@ -200,6 +311,8 @@ def attach_codex_handler() -> None:
     handler = AsyncCodexHandler()
     if not handler.enabled:
         return
+
+    handler.setLevel(getattr(logging, handler.min_level.upper(), logging.INFO))
 
     root = logging.getLogger()
     root.addHandler(handler)

--- a/tests/test_codex_logger.py
+++ b/tests/test_codex_logger.py
@@ -1,0 +1,83 @@
+import asyncio
+import logging
+import sys
+import warnings
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import unused_port
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.codex_logger import AsyncCodexHandler
+
+
+def test_codex_handler_flush_shutdown(monkeypatch: pytest.MonkeyPatch) -> None:
+    asyncio.run(_exercise(monkeypatch))
+
+
+async def _exercise(monkeypatch: pytest.MonkeyPatch) -> None:
+    messages: List[Any] = []
+    event = asyncio.Event()
+
+    async def codex_endpoint(request: web.Request) -> web.Response:
+        data = await request.json()
+        if isinstance(data, list):
+            messages.extend(data)
+        else:
+            messages.append(data)
+        if not event.is_set():
+            event.set()
+        return web.Response(text="ok")
+
+    app = web.Application()
+    app.router.add_post("/", codex_endpoint)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    port = unused_port()
+    site = web.TCPSite(runner, "127.0.0.1", port)
+    await site.start()
+
+    endpoint = f"http://127.0.0.1:{port}/"
+
+    monkeypatch.setenv("CODEX_LOG_ENABLED", "true")
+    monkeypatch.setenv("CODEX_LOG_ENDPOINT", endpoint)
+    monkeypatch.setenv("CODEX_LOG_API_KEY", "test-key")
+    monkeypatch.setenv("APP_NAME", "test-app")
+    monkeypatch.setenv("APP_ENV", "test")
+    monkeypatch.setenv("CODEX_LOG_BATCH_SIZE", "2")
+    monkeypatch.setenv("CODEX_LOG_FLUSH_SEC", "0.5")
+    monkeypatch.delenv("TG_LOG_CHAT_ID", raising=False)
+    monkeypatch.delenv("TELEGRAM_TOKEN", raising=False)
+
+    logger = logging.getLogger("codex-test")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+
+    handler = AsyncCodexHandler()
+    handler.setLevel(logging.INFO)
+    logger.addHandler(handler)
+    logger.propagate = False
+
+    try:
+        logger.info("first codex message")
+        logger.info("second codex message")
+
+        await asyncio.to_thread(handler.flush)
+        await asyncio.wait_for(event.wait(), timeout=5)
+
+        with warnings.catch_warnings(record=True) as caught:
+            await asyncio.to_thread(logging.shutdown)
+        assert not [w for w in caught if "flush" in str(w.message)]
+
+        assert len(messages) >= 1
+        sample = messages[0]
+        assert isinstance(sample, dict)
+        assert sample.get("logger") == "codex-test"
+    finally:
+        await runner.cleanup()
+        logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- harden the Redis runner lock with configurable TTL/heartbeat settings, cooperative takeover, and safe reacquire/release paths
- extend /cleanup_redis to report lock diagnostics and optionally clear stale locks while leaving healthy locks untouched during cleanup
- reimplement the Codex logging handler around a background worker with synchronous flush/close semantics and add a regression test

## Testing
- pytest tests/test_codex_logger.py


------
https://chatgpt.com/codex/tasks/task_e_68ed57dd4e38832294c84d4b508d48c0