### PR TITLE
Restore stable startup by isolating Codex logger and handling RetryAfter

### DIFF
--- a/logging_utils.py
+++ b/logging_utils.py
@@ -209,6 +209,13 @@ def init_logging(app_name: str, level: str | None = None, *, json_logs: bool | N
         extra={"meta": settings.critical_variables()},
     )
 
+    try:
+        from core.codex_logger import setup_codex_logger
+
+        setup_codex_logger()
+    except Exception as exc:  # pragma: no cover - defensive guard
+        print(f"[INIT] Codex logger disabled: {exc}")
+
 
 __all__ = [
     "JsonFormatter",


### PR DESCRIPTION
## Summary
- replace deprecated FloodWait handling with RetryAfter-only retries and add a startup confirmation log
- expose a setup_codex_logger helper that honours CODEX_LOG_ENABLED so Codex stays disabled without network chatter
- wrap Codex logger setup in bot and logging utilities to fail safe when the handler is unavailable

## Testing
- python -m compileall bot.py core/codex_logger.py logging_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68eea09655448322a04e71ee37b7c484