### PR TITLE
Improve DB resilience and Telegram sender

### DIFF
--- a/core/db/__init__.py
+++ b/core/db/__init__.py
@@ -1,0 +1,17 @@
+"""Database helpers for the bot."""
+
+from .postgres import (
+    ResilientConnectionPool,
+    create_connection_pool,
+    ensure_conninfo,
+    mask_dsn,
+    normalize_dsn,
+)
+
+__all__ = [
+    "ResilientConnectionPool",
+    "create_connection_pool",
+    "ensure_conninfo",
+    "mask_dsn",
+    "normalize_dsn",
+]

--- a/core/db/postgres.py
+++ b/core/db/postgres.py
@@ -1,0 +1,120 @@
+"""PostgreSQL connection helpers with resilient pooling."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import psycopg
+from psycopg.conninfo import make_conninfo
+from psycopg_pool import ConnectionPool
+
+from db.postgres import mask_dsn as _mask_dsn
+from db.postgres import normalize_dsn as _normalize_dsn
+
+log = logging.getLogger("core.db.postgres")
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw.strip())
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+_DEFAULT_POOL_MAX = _env_int("PG_POOL_MAX", 10)
+_DEFAULT_POOL_RECYCLE = _env_int("PG_POOL_RECYCLE_SEC", 300)
+_DEFAULT_STATEMENT_TIMEOUT = _env_int("PG_CONN_STATEMENT_TIMEOUT_MS", 15_000)
+_DEFAULT_KEEPALIVES_IDLE = _env_int("PG_KEEPALIVES_IDLE", 30)
+_DEFAULT_KEEPALIVES_INTERVAL = _env_int("PG_KEEPALIVES_INTERVAL", 10)
+_DEFAULT_KEEPALIVES_COUNT = _env_int("PG_KEEPALIVES_COUNT", 3)
+_DEFAULT_TCP_USER_TIMEOUT = _env_int("PG_TCP_USER_TIMEOUT_MS", 15_000)
+
+
+def normalize_dsn(raw: str) -> str:
+    """Expose the shared DSN normaliser."""
+
+    return _normalize_dsn(raw)
+
+
+def mask_dsn(dsn: str) -> str:
+    """Expose the shared DSN masker."""
+
+    return _mask_dsn(dsn)
+
+
+def ensure_conninfo(raw_dsn: str, *, application_name: Optional[str] = None) -> str:
+    """Append keepalive and timeout parameters to a PostgreSQL DSN."""
+
+    base = normalize_dsn(raw_dsn)
+    conn_kwargs: Dict[str, Any] = {
+        "sslmode": "require",
+        "keepalives": 1,
+        "keepalives_idle": _DEFAULT_KEEPALIVES_IDLE,
+        "keepalives_interval": _DEFAULT_KEEPALIVES_INTERVAL,
+        "keepalives_count": _DEFAULT_KEEPALIVES_COUNT,
+        "tcp_user_timeout": _DEFAULT_TCP_USER_TIMEOUT,
+        "options": f"-c statement_timeout={_DEFAULT_STATEMENT_TIMEOUT}",
+    }
+    if application_name:
+        conn_kwargs["application_name"] = application_name
+    return make_conninfo(base, **conn_kwargs)
+
+
+class ResilientConnectionPool(ConnectionPool):
+    """A psycopg connection pool that discards closed connections."""
+
+    def getconn(self, timeout: Optional[float] = None) -> psycopg.Connection[Any]:  # type: ignore[override]
+        while True:
+            conn = super().getconn(timeout=timeout)
+            if getattr(conn, "closed", False):
+                super().putconn(conn, close=True)
+                continue
+            return conn
+
+    def putconn(
+        self, conn: psycopg.Connection[Any], close: bool = False
+    ) -> None:  # type: ignore[override]
+        close = close or getattr(conn, "closed", False)
+        super().putconn(conn, close=close)
+
+
+def create_connection_pool(
+    raw_dsn: str,
+    *,
+    application_name: str = "bot",
+    max_size: Optional[int] = None,
+    timeout: float = 10.0,
+    max_lifetime: Optional[int] = None,
+    reuse_threshold: int = 1000,
+) -> ResilientConnectionPool:
+    """Create a :class:`ResilientConnectionPool` with sensible defaults."""
+
+    conninfo = ensure_conninfo(raw_dsn, application_name=application_name)
+    pool_max = max_size or _DEFAULT_POOL_MAX
+    lifetime = max_lifetime or _DEFAULT_POOL_RECYCLE
+    pool = ResilientConnectionPool(
+        conninfo=conninfo,
+        max_size=pool_max,
+        timeout=timeout,
+        max_lifetime=lifetime,
+        reuse_threshold=reuse_threshold,
+        kwargs={"autocommit": False},
+    )
+    pool.wait()
+    log.info(
+        "DB_READY",
+        extra={
+            "dsn": mask_dsn(conninfo),
+            "pool_max": pool_max,
+            "recycle": lifetime,
+            "timeout": timeout,
+            "reuse_threshold": reuse_threshold,
+        },
+    )
+    return pool

--- a/core/db/retry.py
+++ b/core/db/retry.py
@@ -1,0 +1,67 @@
+"""Retry helpers for transient PostgreSQL errors."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Callable, Dict, Optional
+
+import psycopg
+
+RETRYABLE_MESSAGES = (
+    "SSL connection has been closed unexpectedly",
+    "Connection reset by peer",
+    "server closed the connection unexpectedly",
+    "terminating connection due to administrator command",
+)
+
+
+def is_retryable_db_error(exc: BaseException) -> bool:
+    message = str(exc)
+    return isinstance(exc, psycopg.OperationalError) and any(
+        fragment in message for fragment in RETRYABLE_MESSAGES
+    )
+
+
+def with_db_retries(
+    fn: Callable[[], Any],
+    *,
+    attempts: int = 3,
+    backoff: float = 0.2,
+    logger: Optional[logging.Logger] = None,
+    context: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """Execute ``fn`` retrying on transient PostgreSQL failures."""
+
+    context_meta: Dict[str, Any] = dict(context or {})
+    last_exc: Optional[BaseException] = None
+    for attempt in range(1, attempts + 1):
+        try:
+            result = fn()
+            if logger and attempt > 1:
+                logger.info("DB_RETRY_OK", extra={"attempt": attempt, **context_meta})
+            return result
+        except Exception as exc:  # noqa: BLE001 - deliberate broad catch for retry logic
+            last_exc = exc
+            if not is_retryable_db_error(exc):
+                if logger:
+                    logger.error(
+                        "DB_RETRY_GIVEUP",
+                        extra={"err": str(exc), "attempt": attempt, **context_meta},
+                    )
+                raise
+            if attempt == attempts:
+                if logger:
+                    logger.error(
+                        "DB_RETRY_GIVEUP",
+                        extra={"err": str(exc), "attempt": attempt, **context_meta},
+                    )
+                raise
+            if logger:
+                logger.warning(
+                    "DB_RETRY",
+                    extra={"err": str(exc), "attempt": attempt, **context_meta},
+                )
+            time.sleep(backoff * attempt)
+    if last_exc is not None:  # pragma: no cover - defensive, loop should return or raise
+        raise last_exc

--- a/telegram_utils.py
+++ b/telegram_utils.py
@@ -368,12 +368,13 @@ async def _call_telegram(
     else:
         payload.pop("_log_context", None)
     chat_id = _extract_chat_id(payload)
+    payload.pop("chat_id", None)
     sender = get_sender()
     return await sender.submit(
+        chat_id,
         method,
         method_name=method_name,
         kind=kind,
-        chat_id=chat_id,
         log_context=dict(log_context or {}),
         **payload,
     )
@@ -410,7 +411,7 @@ async def safe_send(
             telegram_send_total.labels(kind=kind, result="ok", **_BOT_LABELS).inc()
             if attempt > 1:
                 log.info(
-                    "telegram send succeeded",
+                    "SENDER_RETRY_OK",
                     extra={
                         "meta": {
                             "method": method_name,
@@ -493,7 +494,7 @@ async def safe_send(
             if attempt < max_attempts:
                 telegram_send_total.labels(kind=kind, result="retry", **_BOT_LABELS).inc()
                 log.warning(
-                    "telegram retry",
+                    "SENDER_RATE_LIMIT",
                     extra={
                         "meta": {
                             "method": method_name,

--- a/tests/test_db_retry.py
+++ b/tests/test_db_retry.py
@@ -1,0 +1,38 @@
+import logging
+import sys
+from pathlib import Path
+
+import psycopg
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.db.retry import with_db_retries
+
+
+def test_with_db_retries_success_after_retry(caplog):
+    attempts = {"value": 0}
+
+    def flaky() -> str:
+        attempts["value"] += 1
+        if attempts["value"] == 1:
+            raise psycopg.OperationalError("SSL connection has been closed unexpectedly")
+        return "ok"
+
+    logger = logging.getLogger("test.db_retry")
+    caplog.set_level(logging.INFO, logger="test.db_retry")
+
+    result = with_db_retries(
+        flaky,
+        attempts=3,
+        backoff=0.0,
+        logger=logger,
+        context={"op": "test"},
+    )
+
+    assert result == "ok"
+    messages = [record.getMessage() for record in caplog.records if record.name == "test.db_retry"]
+    assert "DB_RETRY" in messages
+    assert "DB_RETRY_OK" in messages
+    assert attempts["value"] == 2

--- a/tests/test_ledger_ensure_user.py
+++ b/tests/test_ledger_ensure_user.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import contextlib
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from ledger import _PostgresLedgerStorage
+
+
+class FakeDB:
+    def __init__(self) -> None:
+        self.users: Dict[int, Dict[str, Any]] = {}
+        self.balances: Dict[int, Dict[str, Any]] = {}
+        self.ledger: Dict[str, Dict[str, Any]] = {}
+        self.transactions: Dict[Tuple[int, str, Optional[str]], Dict[str, Any]] = {}
+        self.transaction_entries: List[Tuple[int, str, int, str]] = []
+
+
+class FakeCursor:
+    def __init__(self, db: FakeDB) -> None:
+        self.db = db
+        self._results: List[Any] = []
+        self.rowcount: int = 0
+
+    def execute(self, sql: str, params: Tuple[Any, ...] | Any = ()) -> None:
+        text = " ".join(sql.split()).lower()
+        self._results = []
+        self.rowcount = 0
+
+        if text.startswith("insert into users"):
+            uid, username, referrer_id = params
+            record = self.db.users.setdefault(uid, {"username": None, "referrer_id": None})
+            if username is not None:
+                record["username"] = username
+            if record.get("referrer_id") is None and referrer_id is not None:
+                record["referrer_id"] = referrer_id
+            self.rowcount = 1
+        elif text.startswith("insert into balances"):
+            uid = params[0]
+            self.db.balances.setdefault(
+                uid, {"tokens": 0, "signup_bonus_granted": False}
+            )
+            self.rowcount = 1
+        elif "select tokens, signup_bonus_granted from balances" in text:
+            uid = params[0]
+            bal = self.db.balances.get(uid, {"tokens": 0, "signup_bonus_granted": False})
+            self._results = [(bal["tokens"], bal.get("signup_bonus_granted", False))]
+        elif text.startswith("select 1 from ledger"):
+            op_id = params[0]
+            self._results = [(1,)] if op_id in self.db.ledger else []
+        elif text.startswith("update balances set signup_bonus_granted = true"):
+            uid = params[0]
+            bal = self.db.balances.setdefault(
+                uid, {"tokens": 0, "signup_bonus_granted": False}
+            )
+            bal["signup_bonus_granted"] = True
+            self.rowcount = 1
+        elif "update balances" in text and "tokens = tokens +" in text:
+            amount, uid = params
+            bal = self.db.balances.setdefault(
+                uid, {"tokens": 0, "signup_bonus_granted": False}
+            )
+            bal["tokens"] += int(amount)
+            bal["signup_bonus_granted"] = True
+            self.rowcount = 1
+            self._results = [(bal["tokens"],)]
+        elif "update balances" in text and "tokens = tokens -" in text:
+            amount, uid = params
+            bal = self.db.balances.setdefault(
+                uid, {"tokens": 0, "signup_bonus_granted": False}
+            )
+            bal["tokens"] -= int(amount)
+            self.rowcount = 1
+            self._results = [(bal["tokens"],)]
+        elif text.startswith("insert into ledger"):
+            uid, amount, reason, op_id, _meta = params
+            if op_id in self.db.ledger:
+                raise RuntimeError("duplicate ledger op")
+            self.db.ledger[op_id] = {
+                "user_id": uid,
+                "amount": int(amount),
+                "reason": reason,
+            }
+            self.rowcount = 1
+        elif text.startswith("insert into transactions"):
+            uid, tx_type, amount, reason, key = params
+            key_tuple = (uid, tx_type, key)
+            if key is not None and key_tuple in self.db.transactions:
+                self.rowcount = 0
+            else:
+                if key is not None:
+                    self.db.transactions[key_tuple] = {
+                        "amount": int(amount),
+                        "reason": reason,
+                    }
+                else:
+                    self.db.transaction_entries.append((uid, tx_type, int(amount), reason))
+                self.rowcount = 1
+        elif "select tokens from balances where user_id=%s for update" in text or (
+            text.startswith("select tokens from balances where user_id=%s")
+            and "for update" not in text
+        ):
+            uid = params[0]
+            bal = self.db.balances.get(uid, {"tokens": 0})
+            self._results = [(bal["tokens"],)]
+        else:  # pragma: no cover - ensure tests keep SQL coverage in sync
+            raise AssertionError(f"Unhandled SQL: {sql}")
+
+    def fetchone(self) -> Any:
+        if self._results:
+            return self._results.pop(0)
+        return None
+
+
+class FakeConnection:
+    def __init__(self, db: FakeDB) -> None:
+        self.db = db
+        self.closed = False
+
+    @contextlib.contextmanager
+    def cursor(self) -> Any:
+        yield FakeCursor(self.db)
+
+    @contextlib.contextmanager
+    def transaction(self) -> Any:
+        yield
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakePool:
+    def __init__(self, db: FakeDB) -> None:
+        self.db = db
+
+    @contextlib.contextmanager
+    def connection(self) -> Any:
+        conn = FakeConnection(self.db)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+
+def make_storage() -> tuple[_PostgresLedgerStorage, FakeDB]:
+    db = FakeDB()
+    storage = object.__new__(_PostgresLedgerStorage)
+    storage.pool = FakePool(db)  # type: ignore[attr-defined]
+    storage.log = logging.getLogger("test.ledger")  # type: ignore[attr-defined]
+    return storage, db
+
+
+def test_ensure_user_idempotent_updates_username_only():
+    storage, db = make_storage()
+
+    storage.ensure_user(1, username="alice", referrer_id=42)
+    storage.ensure_user(1, username="bob", referrer_id=100)
+
+    assert db.users == {1: {"username": "bob", "referrer_id": 42}}
+    assert 1 in db.balances
+
+
+def test_grant_signup_bonus_idempotent():
+    storage, db = make_storage()
+
+    result_first = storage.grant_signup_bonus(5, 100)
+    assert result_first.applied is True
+    assert db.balances[5]["tokens"] == 100
+    assert db.balances[5]["signup_bonus_granted"] is True
+    assert (5, "credit", "signup") in db.transactions
+
+    result_second = storage.grant_signup_bonus(5, 100)
+    assert result_second.applied is False
+    assert result_second.duplicate is True
+    assert db.balances[5]["tokens"] == 100
+    assert len(db.transactions) == 1

--- a/tests/test_sender_signature.py
+++ b/tests/test_sender_signature.py
@@ -1,0 +1,42 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from utils.telegram_sender import TelegramSender
+
+
+def test_sender_submit_rejects_chat_id_kwarg():
+    sender = TelegramSender()
+
+    async def dummy(**kwargs):  # pragma: no cover - should not run
+        return kwargs
+
+    async def runner() -> None:
+        with pytest.raises(TypeError, match="Do not pass 'chat_id' in kwargs"):
+            await sender.submit(123, dummy, method_name="x", kind="y", chat_id=123)
+
+    asyncio.run(runner())
+
+
+def test_sender_submit_injects_chat_id():
+    sender = TelegramSender()
+    received: dict[str, object] = {}
+
+    async def dummy(**kwargs):
+        received.update(kwargs)
+        return "ok"
+
+    async def runner() -> None:
+        result = await sender.submit(987, dummy, method_name="foo", kind="bar", text="hi")
+        assert result == "ok"
+        assert received["chat_id"] == 987
+        assert received["text"] == "hi"
+        await sender.stop()
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- add `core.db` helpers with resilient psycopg pool configuration and retry utilities
- wrap ledger operations in short transactions with automatic retries, keep referrers stable, expose DB diagnostics, and update /diag_slow to report probe timings
- harden Telegram sender submission API, add rate-limit logging, and introduce regression tests for retry behaviour, ledger idempotency, and sender signature

## Testing
- `pytest tests/test_db_retry.py tests/test_ledger_ensure_user.py tests/test_sender_signature.py`


------
https://chatgpt.com/codex/tasks/task_e_68f00b0102e08322a4975fcccf7fd579