### PR TITLE
Improve Postgres connection resilience

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,10 @@ LOG_LEVEL=INFO
 # Redis cache / promo codes (optional)
 REDIS_URL=redis://:password@host:port/0
 REDIS_PREFIX=veo3:prod
+
+# PostgreSQL (Neon / Render)
+DATABASE_URL=postgres://user:password@host:5432/database
+DATABASE_SSLMODE=require
+PG_CONN_KEEPALIVE=1
+PG_CONN_RETRIES=5
+PG_CONN_RETRY_DELAY_SEC=3

--- a/bot.py
+++ b/bot.py
@@ -1547,7 +1547,10 @@ except Exception as exc:
     log.critical("postgres.initialization_failed | err=%s", exc, exc_info=True)
     raise
 
+PG_POOL = None
+
 try:
+    PG_POOL = asyncio.run(db_postgres.create_pg_pool(DATABASE_URL))
     db_postgres.configure_engine(DATABASE_URL)
     db_postgres.ensure_tables()
 except Exception as exc:


### PR DESCRIPTION
## Summary
- add an async Postgres pool initializer with retries, keepalives, and health logging
- wrap critical database helpers with a reconnection decorator to recover after SSL failures
- call the pool bootstrap during bot startup and document the new environment toggles

## Testing
- pytest tests/test_ledger_ensure_user.py

------
https://chatgpt.com/codex/tasks/task_e_68f0f061fe208322a2795fa45710d943