### PR TITLE
Add log extra sanitization and fix Postgres async pool initialization

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -20669,6 +20669,8 @@ async def run_bot_async() -> None:
 
                     with suppress(Exception):
                         await stop_sender()
+                    with suppress(Exception):
+                        await db_postgres.close_pg_pool()
 
                     SHUTDOWN_EVENT.set()
         except RedisLockBusy:


### PR DESCRIPTION
## Summary
- add helpers in the logging utilities to sanitize reserved LogRecord fields, wrap logger adapters, and expose convenience helpers
- update the async Postgres pool creation to open explicitly, validate connections, and sanitize logging metadata while retrying safely
- close the async Postgres pool during bot shutdown to avoid leaking connections

## Testing
- `pytest tests/test_observability.py` *(fails: missing optional dependency sqlalchemy in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f16fb66afc832284e47f22ccd161f8