### PR TITLE
Improve Postgres initialization resilience

### DIFF
--- a/scripts/migrate_from_redis.py
+++ b/scripts/migrate_from_redis.py
@@ -484,7 +484,7 @@ async def migrate_from_redis(
 
     db_postgres.configure_engine(database_url)
     try:
-        await asyncio.to_thread(db_postgres.ensure_tables)
+        await db_postgres.ensure_tables_with_retries()
     except Exception as exc:
         log.error("redis-migration.ensure_tables_failed | err=%s", exc, exc_info=True)
         raise RuntimeError("Failed to prepare PostgreSQL tables") from exc


### PR DESCRIPTION
## Summary
- add SSL-aware retry helper for ensuring tables and expose a background DB health check
- add a reconnect_pool helper and configure SQLAlchemy with keepalive-friendly defaults
- update bot startup and migration script to use the resilient ensure_tables coroutine

## Testing
- ⚠️ `pytest` *(fails: waiting for external Postgres connection, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68f283cd179c832280709f49dde853a6