### PR TITLE
Improve CI cleanup and patch handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (clean, full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          clean: true
+
+      - name: Ensure clean git working tree
+        run: |
+          git config core.autocrlf input
+          git config apply.whitespace nowarn
+          git config --global --add safe.directory "$GITHUB_WORKSPACE" || true
+          git reset --hard
+          git clean -xfd
+
+      - name: Apply patch via git am (3-way)
+        if: ${{ hashFiles('patches/*.patch') != '' }}
+        run: |
+          git am --3way --whitespace=nowarn patches/*.patch
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install deps
+        run: |
+          python -m pip install -U pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest -q

--- a/ci/setup_and_test.sh
+++ b/ci/setup_and_test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure we are operating from repo root
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# Normalize git workspace
+git config core.autocrlf input
+git config apply.whitespace nowarn
+# Avoid ownership warnings on GitHub-hosted runners
+if command -v git >/dev/null 2>&1; then
+  git config --global --add safe.directory "$(pwd)" || true
+fi
+git reset --hard
+git clean -xfd
+
+# Apply patches via git am if present
+if compgen -G "patches/*.patch" > /dev/null; then
+  git am --3way --whitespace=nowarn patches/*.patch
+fi
+
+# Setup Python environment
+python -m pip install -U pip
+pip install -r requirements.txt
+
+# Run tests
+pytest -q


### PR DESCRIPTION
## Summary
- add CI workflow that cleans the repository before running tests and applies patches with git am if present
- provide helper script to reproduce CI setup locally or in alternative environments

## Testing
- not run (CI only changes)

------
https://chatgpt.com/codex/tasks/task_e_68f51f19d680832288f62aa7f8476eae