### PR TITLE
Make patch application optional in CI and deployment pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
-  push:
-    branches: ["**"]
+  push: { branches: ["**"] }
   pull_request:
 
 jobs:
@@ -14,28 +13,35 @@ jobs:
           fetch-depth: 0
           clean: true
 
-      - name: Ensure clean git working tree
+      - name: Ensure clean working tree
         run: |
           git config core.autocrlf input
           git config apply.whitespace nowarn
-          git config --global --add safe.directory "$GITHUB_WORKSPACE" || true
           git reset --hard
           git clean -xfd
 
-      - name: Apply patch via git am (3-way)
-        if: ${{ hashFiles('patches/*.patch') != '' }}
+      - name: Apply patch via git am --3way (optional)
+        if: ${{ secrets.PATCH_B64 != '' }}
         run: |
-          git am --3way --whitespace=nowarn patches/*.patch
+          echo "$PATCH_B64" | base64 -d > /tmp/change.patch
+          if ! git am --3way /tmp/change.patch; then
+            git am --abort || true
+            echo "::error::git am failed. See logs."
+            exit 1
+          fi
+        env:
+          PATCH_B64: ${{ secrets.PATCH_B64 }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install deps
         run: |
-          python -m pip install -U pip
-          pip install -r requirements.txt
+          pip install -U pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Run tests
-        run: pytest -q
+        run: |
+          if [ -d tests ] || [ -f pytest.ini ]; then pytest -q; else echo "No tests"; fi

--- a/ci/setup_and_test.sh
+++ b/ci/setup_and_test.sh
@@ -7,16 +7,19 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 # Normalize git workspace
 git config core.autocrlf input
 git config apply.whitespace nowarn
-# Avoid ownership warnings on GitHub-hosted runners
-if command -v git >/dev/null 2>&1; then
-  git config --global --add safe.directory "$(pwd)" || true
-fi
 git reset --hard
 git clean -xfd
 
-# Apply patches via git am if present
-if compgen -G "patches/*.patch" > /dev/null; then
-  git am --3way --whitespace=nowarn patches/*.patch
+# Optionally apply a patch from base64-encoded content
+if [[ -n "${PATCH_B64:-}" ]]; then
+  tmp_patch="$(mktemp)"
+  echo "$PATCH_B64" | base64 -d > "$tmp_patch"
+  if ! git am --3way "$tmp_patch"; then
+    git am --abort || true
+    echo "Patch application failed" >&2
+    exit 1
+  fi
+  rm -f "$tmp_patch"
 fi
 
 # Setup Python environment

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,13 @@ services:
     name: shubinfilms-best-veo3-bot
     env: python
     region: frankfurt
-    buildCommand: pip install -r requirements.txt
+    buildCommand: |
+      git reset --hard && git clean -xfd
+      if [ -n "$PATCH_B64" ]; then
+        echo "$PATCH_B64" | base64 -d > /tmp/change.patch
+        git am --3way /tmp/change.patch || { git am --abort; exit 1; }
+      fi
+      pip install -r requirements.txt
     startCommand: >
       uvicorn suno_web:app
       --host 0.0.0.0
@@ -15,7 +21,13 @@ services:
     name: best-veo3-bot
     env: python
     pythonVersion: 3.11.9
-    buildCommand: pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
+    buildCommand: |
+      git reset --hard && git clean -xfd
+      if [ -n "$PATCH_B64" ]; then
+        echo "$PATCH_B64" | base64 -d > /tmp/change.patch
+        git am --3way /tmp/change.patch || { git am --abort; exit 1; }
+      fi
+      pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
     startCommand: python -u bot.py
     plan: starter
     region: frankfurt

--- a/scripts/clean-clone-apply-and-test.sh
+++ b/scripts/clean-clone-apply-and-test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_URL="${REPO_URL:-git@github.com:org/project.git}"
+WORKDIR="${WORKDIR:-/tmp/project-clean}"
+PATCH_FILE="${PATCH_FILE:-/tmp/change.patch}"
+
+rm -rf "$WORKDIR" && mkdir -p "$WORKDIR" && cd "$WORKDIR"
+git clone "$REPO_URL" .
+git config core.autocrlf input
+git config apply.whitespace nowarn
+
+[ -f "$PATCH_FILE" ] && git am --3way "$PATCH_FILE" || true
+
+if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+if [ -d tests ] || [ -f pytest.ini ]; then pytest -q; else echo "No tests"; fi


### PR DESCRIPTION
## Summary
- run CI on a guaranteed clean checkout and gate optional patches on a PATCH_B64 secret
- update shared CI script to allow optional base64 patches and drop implicit patch directory usage
- ensure Render builds reset the tree, optionally apply PATCH_B64 patches, and add a helper script for clean local clones

## Testing
- pytest -q *(fails: missing dependency sqlalchemy and REDIS_URL configuration requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68f539e64df0832286240a0b095d0713