### PR TITLE
Harden Suno polling and ledger bootstrap

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -64,7 +64,7 @@ from typing import (
     Sequence,
     Iterable,
 )
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from contextlib import suppress
 from urllib.parse import urlparse, urlunparse, urlencode, parse_qsl
 from dataclasses import dataclass
@@ -582,6 +582,7 @@ _SUNO_START_LOCK_TTL = 300
 _SUNO_PENDING_TTL = 20 * 60
 _SUNO_PENDING_LOCK = threading.Lock()
 _SUNO_PENDING_MEMORY: Dict[str, tuple[float, str]] = {}
+_SUNO_RECONCILE_ATTEMPTS: Dict[str, float] = {}
 
 _SUNO_REFUND_PENDING_LOCK = threading.Lock()
 _SUNO_REFUND_PENDING_MEMORY: Dict[str, tuple[float, str]] = {}
@@ -854,8 +855,10 @@ def _utcnow_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _parse_iso8601(value: Optional[str]) -> Optional[datetime]:
-    if not value:
+def _parse_iso8601(value: Any) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        return value
+    if not isinstance(value, str):
         return None
     text = value.strip()
     if not text:
@@ -1126,6 +1129,9 @@ SUNO_POLL_BACKGROUND_LIMIT = max(
     SUNO_POLL_NOTIFY_AFTER,
     _env_float("SUNO_POLL_BACKGROUND_LIMIT", 600.0),
 )
+SUNO_RECONCILE_INTERVAL = max(30.0, _env_float("SUNO_RECONCILE_INTERVAL_SEC", 180.0))
+SUNO_RECONCILE_MAX_AGE = max(60.0, _env_float("SUNO_RECONCILE_MAX_AGE_SEC", 24 * 3600.0))
+SUNO_RECONCILE_BATCH = max(1, _env_int("SUNO_RECONCILE_BATCH", 40))
 ENV_NAME            = _env("ENV_NAME", "prod") or "prod"
 BOT_SINGLETON_DISABLED = bool(SETTINGS_BOT_SINGLETON_DISABLED)
 BOT_LEADER_TTL_MS   = 30_000
@@ -11259,6 +11265,161 @@ async def _suno_poll_record_info(
             return result
 
 
+def _suno_deliver_record_info_payload(
+    task_id: str,
+    payload: Mapping[str, Any],
+    *,
+    req_id: Optional[str],
+    delivery_via: str = "poll",
+    tracks: Optional[List[Dict[str, Any]]] = None,
+) -> bool:
+    try:
+        tracks_payload = tracks if tracks is not None else _poll_tracks(payload)
+        if not tracks_payload:
+            return False
+        envelope_payload = {
+            "code": payload.get("code") or 200,
+            "msg": payload.get("message") or payload.get("msg"),
+            "data": {
+                "taskId": task_id,
+                "callbackType": "complete",
+                "response": {"tracks": tracks_payload},
+            },
+        }
+        callback_task = SunoTask.from_envelope(CallbackEnvelope.model_validate(envelope_payload))
+        callback_task = callback_task.model_copy(
+            update={"code": envelope_payload["code"], "msg": envelope_payload.get("msg")}
+        )
+        SUNO_SERVICE.handle_callback(callback_task, req_id=req_id, delivery_via=delivery_via)
+        return True
+    except Exception:
+        log.exception("[SUNO] deliver failed | task_id=%s via=%s", task_id, delivery_via)
+        return False
+
+
+def _suno_reconcile_should_attempt(task_id: str, now: float) -> bool:
+    if not task_id:
+        return False
+    min_gap = max(30.0, min(SUNO_RECONCILE_INTERVAL, 300.0))
+    last_attempt = _SUNO_RECONCILE_ATTEMPTS.get(task_id)
+    if last_attempt is not None and now - last_attempt < min_gap:
+        return False
+    _SUNO_RECONCILE_ATTEMPTS[task_id] = now
+    stale_threshold = now - max(SUNO_RECONCILE_MAX_AGE, 3600.0)
+    for key, ts in list(_SUNO_RECONCILE_ATTEMPTS.items()):
+        if ts < stale_threshold:
+            _SUNO_RECONCILE_ATTEMPTS.pop(key, None)
+    return True
+
+
+async def _suno_reconcile_once() -> None:
+    if SUNO_RECONCILE_BATCH <= 0:
+        return
+    try:
+        records = await asyncio.to_thread(
+            SUNO_SERVICE.list_last_tasks,
+            max(SUNO_RECONCILE_BATCH * 2, SUNO_RECONCILE_BATCH),
+        )
+    except Exception as exc:
+        log.warning("[SUNO] reconcile fetch failed | err=%s", exc)
+        return
+    now_dt = datetime.now(timezone.utc)
+    cutoff = now_dt - timedelta(seconds=SUNO_RECONCILE_MAX_AGE)
+    now_monotonic = time.monotonic()
+    processed = 0
+    for record in records:
+        if processed >= SUNO_RECONCILE_BATCH:
+            break
+        if not isinstance(record, Mapping):
+            continue
+        task_id = str(record.get("task_id") or record.get("taskId") or "").strip()
+        if not task_id:
+            continue
+        tracks = record.get("tracks")
+        if isinstance(tracks, list) and tracks:
+            continue
+        if SUNO_SERVICE._recently_delivered(task_id):  # type: ignore[attr-defined]
+            continue
+        updated_at = _parse_iso8601(record.get("updated_at"))
+        created_at = _parse_iso8601(record.get("created_at"))
+        reference_time = updated_at or created_at or now_dt
+        if reference_time < cutoff:
+            continue
+        if not _suno_reconcile_should_attempt(task_id, now_monotonic):
+            continue
+        try:
+            user_id_raw = record.get("user_id")
+            user_id_value = int(user_id_raw) if user_id_raw not in (None, "") else None
+        except (TypeError, ValueError):
+            user_id_value = None
+        processed += 1
+        try:
+            poll_result = await asyncio.to_thread(
+                SUNO_SERVICE.poll_record_info_once,
+                task_id,
+                user_id=user_id_value,
+            )
+        except Exception as exc:
+            log.warning("[SUNO] reconcile poll failed | task_id=%s err=%s", task_id, exc)
+            continue
+        state = poll_result.state
+        if state == "ready":
+            payload = poll_result.payload if isinstance(poll_result.payload, Mapping) else {}
+            req_id_value = record.get("req_id") or SUNO_SERVICE.get_request_id(task_id)
+            durations = SunoService._durations_from_tracks(  # type: ignore[attr-defined]
+                SunoService._tracks_from_payload(payload)  # type: ignore[attr-defined]
+            )
+            log.info(
+                "[SUNO] reconcile ready | task_id=%s attempts=%s elapsed=%.1f durations=%s",
+                task_id,
+                poll_result.attempts,
+                poll_result.elapsed,
+                durations,
+            )
+            delivered = await asyncio.to_thread(
+                _suno_deliver_record_info_payload,
+                task_id,
+                payload,
+                req_id=req_id_value,
+                delivery_via="reconcile",
+            )
+            if not delivered:
+                log.warning("[SUNO] reconcile delivery skipped | task_id=%s", task_id)
+        elif state == "hard_error":
+            log.warning(
+                "[SUNO] reconcile hard error | task_id=%s status=%s http=%s",
+                task_id,
+                poll_result.message or poll_result.error or state,
+                poll_result.status_code,
+            )
+
+
+async def _suno_reconcile_worker(stop_event: asyncio.Event) -> None:
+    if SUNO_RECONCILE_INTERVAL <= 0:
+        return
+    log.info(
+        "[SUNO] reconciliation worker started | interval=%.1fs batch=%d max_age=%.0fs",
+        SUNO_RECONCILE_INTERVAL,
+        SUNO_RECONCILE_BATCH,
+        SUNO_RECONCILE_MAX_AGE,
+    )
+    try:
+        while not stop_event.is_set():
+            try:
+                await _suno_reconcile_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log.exception("[SUNO] reconcile iteration failed")
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=SUNO_RECONCILE_INTERVAL)
+                break
+            except asyncio.TimeoutError:
+                continue
+    finally:
+        log.info("[SUNO] reconciliation worker stopped")
+
+
 async def _poll_suno_and_send(
     chat_id: int,
     ctx: ContextTypes.DEFAULT_TYPE,
@@ -11411,16 +11572,6 @@ async def _poll_suno_and_send(
             await _notify_timeout_once()
             return
 
-        envelope_payload = {
-            "code": details.get("code") or 200,
-            "msg": details.get("message") or details.get("msg"),
-            "data": {
-                "taskId": task_id,
-                "callbackType": "complete",
-                "response": {"tracks": tracks_payload},
-            },
-        }
-
         duration_value = _poll_duration(details)
         audio_url_preview = ""
         if tracks_payload:
@@ -11443,19 +11594,16 @@ async def _poll_suno_and_send(
             },
         )
 
-        try:
-            callback_task = SunoTask.from_envelope(CallbackEnvelope.model_validate(envelope_payload))
-            callback_task = callback_task.model_copy(
-                update={"code": envelope_payload["code"], "msg": envelope_payload.get("msg")}
-            )
-            await asyncio.to_thread(
-                SUNO_SERVICE.handle_callback,
-                callback_task,
-                req_id=req_id_value,
-                delivery_via="poll",
-            )
-        except Exception as exc:
-            log.exception("[SUNO] poll delivery failed | task_id=%s err=%s", task_id, exc)
+        delivered = await asyncio.to_thread(
+            _suno_deliver_record_info_payload,
+            task_id,
+            details,
+            req_id=req_id_value,
+            delivery_via="poll",
+            tracks=tracks_payload,
+        )
+        if not delivered:
+            log.warning("[SUNO] poll delivery skipped | task_id=%s", task_id)
         return
 
     except asyncio.CancelledError:
@@ -12603,7 +12751,6 @@ def _poll_duration(payload: Mapping[str, Any]) -> Optional[float]:
                 except ValueError:
                     continue
     return None
-
 def _kie_request_with_endpoint(
     service: str,
     kind: str,
@@ -20566,6 +20713,12 @@ async def run_bot_async() -> None:
         background_tasks.append(asyncio.create_task(db_postgres.db_health_check()))
     except Exception as exc:
         log.error("DB health check startup failed: %s", exc, exc_info=True)
+
+    if SUNO_CONFIG.enabled:
+        try:
+            background_tasks.append(asyncio.create_task(_suno_reconcile_worker(stop_event)))
+        except Exception as exc:
+            log.error("[SUNO] reconcile worker start failed: %s", exc, exc_info=True)
 
     def request_shutdown(sig: Optional[signal.Signals]) -> None:
         signal_name = getattr(sig, "name", None) or (str(sig) if sig else "external")

--- a/db/postgres.py
+++ b/db/postgres.py
@@ -327,6 +327,7 @@ async def create_pg_pool(dsn: Optional[str] = None) -> AsyncConnectionPool:
                 min_size=1,
                 max_size=8,
                 timeout=10,
+                open=False,
                 kwargs={
                     "keepalives": _CONN_KEEPALIVE,
                     "keepalives_idle": _KEEPALIVE_IDLE,

--- a/docs/runbook_suno.md
+++ b/docs/runbook_suno.md
@@ -1,0 +1,64 @@
+# Suno Music Generation Runbook
+
+This runbook summarises the operational flow of the Suno integration in the bot and
+highlights the moving parts that now guarantee late deliveries.
+
+## Startup & Database
+
+* The ledger backend connects to PostgreSQL during startup (`ledger._prepare`).
+  All DDL statements are idempotent and safe to re-run on PG14/PG15.
+* Postgres connection pools are opened explicitly (`psycopg_pool.AsyncConnectionPool.open`),
+  eliminating the deprecated implicit open warning.
+
+## Generation Lifecycle
+
+1. **Enqueue** – `_poll_suno_and_send` stores task metadata through `SunoService`.
+2. **Polling** – `SunoService.poll_record_info_once` uses the configured
+   `SUNO_TASK_STATUS_PATH`. A `404` response is treated as `pending`.
+3. **Timeout** – After `SUNO_POLL_TIMEOUT_SEC` the poller emits a timeout,
+   notifies the user once, and issues a refund (`suno:refund:timeout`).
+4. **Delivery** – When tracks are ready, `_suno_deliver_record_info_payload` forwards
+   them through `SunoService.handle_callback` (via webhook, poll, or reconciliation).
+
+## Reconciliation Worker
+
+* Controlled by environment variables:
+  * `SUNO_RECONCILE_INTERVAL_SEC` (default `180s`)
+  * `SUNO_RECONCILE_MAX_AGE_SEC` (default `24h`)
+  * `SUNO_RECONCILE_BATCH` (default `40`)
+* Runs in the background once the bot is up (`_suno_reconcile_worker`).
+* Scans recent task records (Redis/in-memory) and re-queries the status endpoint.
+* Uses `_SUNO_RECONCILE_ATTEMPTS` to throttle per-task checks and avoids hammering
+  tasks still in progress.
+* Late successes are delivered with `delivery_via="reconcile"` so Telegram users
+  still receive their tracks even after a timeout refund.
+
+## Refund Policy
+
+* Refunds are issued only for terminal API states (FAILED/ERROR/EXPIRED) or when
+  the poller times out. `404`/`pending` states do **not** trigger refunds.
+* Reconciliation does not attempt to refund; it only handles deliveries.
+
+## Troubleshooting Checklist
+
+1. **No delivery & no refund** – Inspect Redis keys `suno:pending:*` and
+   `_SUNO_RECONCILE_ATTEMPTS` to ensure reconciliation is running.
+2. **Repeated refunds** – Confirm the task status is actually terminal by
+   checking the recorded payload in `SUNO_SERVICE.get_task_record`.
+3. **Status endpoint mismatch** – Validate `SUNO_TASK_STATUS_PATH` in the
+   deployment environment; logs now print the resolved path at startup.
+
+## Useful Commands
+
+* Run focused tests:
+
+  ```bash
+  pytest tests/test_suno_poll_pending.py tests/test_suno_reconcile.py
+  ```
+
+* Inspect last stored tasks (within a REPL):
+
+  ```python
+  import bot
+  bot.SUNO_SERVICE.list_last_tasks(limit=5)
+  ```

--- a/ledger.py
+++ b/ledger.py
@@ -309,7 +309,20 @@ class _PostgresLedgerStorage(_LedgerHelpers):
             "ALTER TABLE transactions ALTER COLUMN created_at SET DEFAULT now()",
             "ALTER TABLE transactions ALTER COLUMN created_at SET NOT NULL",
             "ALTER TABLE transactions ADD COLUMN IF NOT EXISTS key TEXT",
-            "ALTER TABLE transactions ADD CONSTRAINT IF NOT EXISTS transactions_user_type_key_key UNIQUE (user_id, type, key)",
+            """
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1
+                      FROM pg_constraint
+                     WHERE conname = 'transactions_user_type_key_key'
+                ) THEN
+                    ALTER TABLE transactions
+                        ADD CONSTRAINT transactions_user_type_key_key UNIQUE (user_id, type, key);
+                END IF;
+            END;
+            $$;
+            """,
             """
             UPDATE transactions
                SET amount = CASE

--- a/suno/service.py
+++ b/suno/service.py
@@ -31,12 +31,14 @@ from stickers import pop_wait_sticker_id
 from settings import (
     HTTP_POOL_CONNECTIONS,
     HTTP_POOL_PER_HOST,
+    KIE_BASE_URL,
     REDIS_PREFIX,
     SUNO_API_BASE,
     SUNO_API_TOKEN,
     SUNO_CALLBACK_SECRET,
     SUNO_CALLBACK_URL,
     SUNO_ENABLED,
+    SUNO_TASK_STATUS_PATH,
 )
 from telegram_utils import mask_tokens
 from utils.audio_post import prepare_audio_file_sync
@@ -53,7 +55,35 @@ except Exception:  # pragma: no cover - optional import
 
 log = logging.getLogger("suno.service")
 
-API_BASE = SUNO_API_BASE
+_DEFAULT_API_BASE = "https://api.kie.ai"
+
+
+def _resolve_api_base() -> str:
+    raw = (SUNO_API_BASE or KIE_BASE_URL or _DEFAULT_API_BASE) or _DEFAULT_API_BASE
+    text = str(raw).strip()
+    if not text:
+        text = _DEFAULT_API_BASE
+    return text.rstrip("/")
+
+
+def _normalize_status_path(raw: Optional[str]) -> str:
+    candidate = (raw or "").strip()
+    if not candidate:
+        candidate = "/api/v1/generate/record-info"
+    if candidate.startswith("http://") or candidate.startswith("https://"):
+        return candidate
+    if not candidate.startswith("/"):
+        candidate = "/" + candidate
+    return candidate
+
+
+API_BASE = _resolve_api_base()
+_STATUS_PATH = _normalize_status_path(SUNO_TASK_STATUS_PATH)
+_STATUS_URL = (
+    _STATUS_PATH
+    if _STATUS_PATH.startswith(("http://", "https://"))
+    else f"{API_BASE}{_STATUS_PATH}"
+)
 API_KEY = SUNO_API_TOKEN
 CALLBACK_URL = SUNO_CALLBACK_URL
 
@@ -147,8 +177,9 @@ def _post(path: str, payload: Dict[str, Any]) -> ApiEnvelope:
 
 
 def _get(path: str, params: Dict[str, Any]) -> ApiEnvelope:
+    url = path if path.startswith(("http://", "https://")) else f"{API_BASE}{path}"
     response = requests.get(
-        f"{API_BASE}{path}",
+        url,
         headers={"Authorization": f"Bearer {API_KEY}"} if API_KEY else None,
         params=params,
         timeout=15,
@@ -243,7 +274,7 @@ def suno_add_vocals(
 
 
 def suno_record_info(task_id: str) -> Dict[str, Any]:
-    envelope = _get("/api/v1/generate/record-info", {"taskId": task_id})
+    envelope = _get(_STATUS_URL, {"taskId": task_id})
     data = envelope.data or {}
     if isinstance(data, Mapping):
         return dict(data)
@@ -381,9 +412,13 @@ class SunoService:
             self._poll_first_delay,
             _env_float("SUNO_POLL_TIMEOUT_SEC", _POLL_DEFAULT_TIMEOUT),
         )
+        self._api_base = API_BASE
+        self._status_path = _STATUS_PATH
+        self._status_url = _STATUS_URL
         summary = {
             "suno_enabled": bool(SUNO_ENABLED),
-            "api_base": SUNO_API_BASE,
+            "api_base": self._api_base,
+            "status_path": self._status_path,
             "callback_configured": bool(SUNO_CALLBACK_URL and SUNO_CALLBACK_SECRET),
         }
         log.info("configuration summary", extra={"meta": summary})
@@ -538,7 +573,7 @@ class SunoService:
         headers: Dict[str, str] = {}
         if API_KEY:
             headers["Authorization"] = f"Bearer {API_KEY}"
-        url = f"{API_BASE}/api/v1/generate/record-info"
+        url = self._status_url
         try:
             response = self._api_session.get(url, params=params, headers=headers or None, timeout=20)
         except requests.RequestException as exc:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,153 @@ from __future__ import annotations
 
 from typing import Generator
 
+import os
+import sys
+import types
 import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
+os.environ.setdefault("LEDGER_BACKEND", "memory")
+os.environ.setdefault("TELEGRAM_TOKEN", "dummy-token")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("KIE_API_KEY", "dummy-key")
+os.environ.setdefault("SUNO_CALLBACK_URL", "https://example.com/callback")
+os.environ.setdefault("LOG_LEVEL", "ERROR")
+os.environ.setdefault("LOG_JSON", "false")
+
+if "sqlalchemy" not in sys.modules:
+    sqlalchemy_stub = types.ModuleType("sqlalchemy")
+
+    def _noop(*args, **kwargs):
+        return None
+
+    sqlalchemy_stub.create_engine = _noop  # type: ignore[attr-defined]
+    sqlalchemy_stub.text = lambda value: value  # type: ignore[attr-defined]
+    sys.modules["sqlalchemy"] = sqlalchemy_stub
+
+    sqlalchemy_engine_stub = types.ModuleType("sqlalchemy.engine")
+
+    from urllib.parse import parse_qsl, quote, urlparse, urlencode, urlunparse
+
+    class _DummyURL:
+        def __init__(self, raw: str):
+            parsed = urlparse(str(raw))
+            self.drivername = parsed.scheme or ""
+            self.username = parsed.username
+            self.password = parsed.password
+            self.host = parsed.hostname or ""
+            self.port = parsed.port
+            self.database = parsed.path[1:] if parsed.path.startswith("/") else parsed.path
+            self.query = dict(parse_qsl(parsed.query))
+            self._raw = self._compose(hide_password=False)
+
+        def _compose(self, hide_password: bool) -> str:
+            netloc = ""
+            if self.username:
+                user = quote(self.username, safe="")
+                netloc += user
+                if self.password is not None:
+                    password = "***" if hide_password else quote(self.password, safe="")
+                    netloc += f":{password}"
+                netloc += "@"
+            netloc += self.host or ""
+            if self.port is not None:
+                netloc += f":{self.port}"
+            path = f"/{self.database}" if self.database else ""
+            query = urlencode(self.query)
+            return urlunparse((self.drivername, netloc, path, "", query, ""))
+
+        def set(self, **kwargs):
+            if "drivername" in kwargs:
+                self.drivername = kwargs["drivername"]
+            if "username" in kwargs:
+                self.username = kwargs["username"]
+            if "password" in kwargs:
+                self.password = kwargs["password"]
+            if "host" in kwargs:
+                self.host = kwargs["host"] or ""
+            if "port" in kwargs:
+                self.port = kwargs["port"]
+            if "database" in kwargs:
+                self.database = kwargs["database"] or ""
+            if "query" in kwargs and kwargs["query"] is not None:
+                self.query = dict(kwargs["query"])
+            self._raw = self._compose(hide_password=False)
+            return self
+
+        def __str__(self) -> str:
+            return self._raw
+
+        def render_as_string(self, hide_password: bool = True) -> str:
+            return self._compose(hide_password=hide_password)
+
+    sqlalchemy_engine_stub.Engine = object  # type: ignore[attr-defined]
+    sqlalchemy_engine_stub.URL = _DummyURL  # type: ignore[attr-defined]
+    sqlalchemy_engine_stub.make_url = lambda value: _DummyURL(str(value))  # type: ignore[attr-defined]
+    sys.modules["sqlalchemy.engine"] = sqlalchemy_engine_stub
+
+    sqlalchemy_exc_stub = types.ModuleType("sqlalchemy.exc")
+
+    class _SqlAlchemyStubError(Exception):
+        pass
+
+    sqlalchemy_exc_stub.OperationalError = _SqlAlchemyStubError  # type: ignore[attr-defined]
+    sqlalchemy_exc_stub.SQLAlchemyError = _SqlAlchemyStubError  # type: ignore[attr-defined]
+    sys.modules["sqlalchemy.exc"] = sqlalchemy_exc_stub
+
+import importlib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_postgres_module = importlib.import_module("db.postgres")
+
+
+class _DummyCursor:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, *args, **kwargs):
+        return None
+
+    async def fetchone(self):
+        return (1,)
+
+
+class _DummyConnection:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self):
+        return _DummyCursor()
+
+
+class _DummyPool:
+    def connection(self):
+        return _DummyConnection()
+
+    async def close(self):
+        return None
+
+
+async def _fake_create_pg_pool(dsn: str | None = None):
+    return _DummyPool()
+
+
+def _fake_configure_engine(dsn: str | None = None):
+    return None
+
+
+setattr(_postgres_module, "create_pg_pool", _fake_create_pg_pool)
+setattr(_postgres_module, "configure_engine", _fake_configure_engine)
 
 
 @pytest.fixture

--- a/tests/test_ledger_prepare.py
+++ b/tests/test_ledger_prepare.py
@@ -1,0 +1,67 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+class _DummyTransaction:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _DummyCursor:
+    def __init__(self, statements: list[str]):
+        self._statements = statements
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, statement: str) -> None:
+        self._statements.append(statement)
+
+
+class _DummyConnection:
+    def __init__(self, statements: list[str]):
+        self._statements = statements
+
+    def transaction(self) -> _DummyTransaction:
+        return _DummyTransaction()
+
+    def cursor(self) -> _DummyCursor:
+        return _DummyCursor(self._statements)
+
+
+def test_prepare_is_idempotent(monkeypatch):
+    postgres_stub = types.ModuleType("core.db.postgres")
+    postgres_stub.normalize_dsn = lambda value: value  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "core", types.ModuleType("core"))
+    monkeypatch.setitem(sys.modules, "core.db", types.ModuleType("core.db"))
+    monkeypatch.setitem(sys.modules, "core.db.postgres", postgres_stub)
+
+    ledger_module = importlib.import_module("ledger")
+    storage = ledger_module._PostgresLedgerStorage("postgresql://user:pass@localhost/db")
+    executed: list[str] = []
+    dummy_conn = _DummyConnection(executed)
+
+    def fake_with_connection(fn, *, op, retries=None, **ctx):
+        fn(dummy_conn)
+
+    monkeypatch.setattr(storage, "_with_connection", fake_with_connection)
+
+    storage._prepare()
+    storage._prepare()
+
+    guard_statements = [stmt for stmt in executed if "transactions_user_type_key_key" in stmt]
+    assert guard_statements, "constraint guard must execute"
+    assert any("DO $$" in stmt for stmt in guard_statements)

--- a/tests/test_suno_poll_pending.py
+++ b/tests/test_suno_poll_pending.py
@@ -1,0 +1,29 @@
+import os
+import sys
+from pathlib import Path
+
+import requests
+
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
+os.environ.setdefault("LEDGER_BACKEND", "memory")
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import bot  # noqa: E402
+
+
+def test_poll_404_is_pending(monkeypatch):
+    response = requests.Response()
+    response.status_code = 404
+    response._content = b'{"code": 404, "msg": "Not ready"}'
+
+    def fake_get(*args, **kwargs):
+        return response
+
+    monkeypatch.setattr(bot.SUNO_SERVICE._api_session, "get", fake_get, raising=False)
+
+    result = bot.SUNO_SERVICE.poll_record_info_once("task-404")
+    assert result.state == "pending"
+    assert result.status_code == 404

--- a/tests/test_suno_reconcile.py
+++ b/tests/test_suno_reconcile.py
@@ -1,0 +1,141 @@
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from suno.service import RecordInfoPollResult
+
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
+os.environ.setdefault("LEDGER_BACKEND", "memory")
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import bot  # noqa: E402
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_reconcile_delivers_late_result(monkeypatch):
+    monkeypatch.setattr(bot, "SUNO_POLL_FIRST_DELAY", 0.0, raising=False)
+    monkeypatch.setattr(bot, "SUNO_POLL_BACKOFF_SERIES", [0.0], raising=False)
+    monkeypatch.setattr(bot, "SUNO_POLL_TIMEOUT", 0.0, raising=False)
+
+    pending_result = RecordInfoPollResult(
+        state="pending",
+        status_code=404,
+        payload={"data": {}},
+        message="pending",
+    )
+
+    monkeypatch.setattr(
+        bot.SUNO_SERVICE,
+        "poll_record_info_once",
+        lambda *args, **kwargs: pending_result,
+        raising=False,
+    )
+    monkeypatch.setattr(bot.SUNO_SERVICE, "_recently_delivered", lambda *_: False, raising=False)
+    monkeypatch.setattr(bot.SUNO_SERVICE, "get_task_record", lambda *_: {}, raising=False)
+
+    refunds: list[str] = []
+
+    async def fake_issue_refund(*args, **kwargs):
+        refunds.append(kwargs.get("reason", ""))
+
+    async def async_noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(bot, "_suno_issue_refund", fake_issue_refund, raising=False)
+    monkeypatch.setattr(bot, "_suno_notify", async_noop, raising=False)
+    monkeypatch.setattr(bot, "refresh_suno_card", async_noop, raising=False)
+    monkeypatch.setattr(bot, "refresh_balance_card_if_open", async_noop, raising=False)
+    monkeypatch.setattr(bot, "_reset_suno_card_cache", lambda *_: None, raising=False)
+
+    ctx = SimpleNamespace(bot=SimpleNamespace(), user_data={})
+
+    await bot._poll_suno_and_send(
+        chat_id=555,
+        ctx=ctx,
+        user_id=42,
+        task_id="task-timeout",
+        params={"title": "Song", "style": "Pop", "lyrics": "", "instrumental": True},
+        meta={"req_id": "req-timeout"},
+        req_id="req-timeout",
+        reply_to=None,
+    )
+
+    assert refunds == ["suno:refund:timeout"]
+
+    ready_payload = {
+        "data": {
+            "response": {
+                "tracks": [
+                    {
+                        "audioUrl": "https://example.com/track.mp3",
+                        "imageUrl": "https://example.com/cover.jpg",
+                        "title": "Song",
+                    }
+                ]
+            }
+        }
+    }
+
+    ready_result = RecordInfoPollResult(
+        state="ready",
+        status_code=200,
+        payload=ready_payload,
+        message=None,
+    )
+
+    monkeypatch.setattr(
+        bot.SUNO_SERVICE,
+        "poll_record_info_once",
+        lambda *args, **kwargs: ready_result,
+        raising=False,
+    )
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    record = {
+        "task_id": "task-timeout",
+        "status": "started",
+        "tracks": [],
+        "req_id": "req-timeout",
+        "created_at": now_iso,
+        "updated_at": now_iso,
+        "user_id": 42,
+    }
+
+    monkeypatch.setattr(
+        bot.SUNO_SERVICE,
+        "list_last_tasks",
+        lambda limit=5: [record],
+        raising=False,
+    )
+    monkeypatch.setattr(bot.SUNO_SERVICE, "get_request_id", lambda *_: "req-timeout", raising=False)
+    monkeypatch.setattr(bot.SUNO_SERVICE, "_recently_delivered", lambda *_: False, raising=False)
+
+    delivered: list[dict[str, object]] = []
+
+    def fake_handle_callback(task, req_id=None, *, delivery_via="webhook"):
+        delivered.append({
+            "task_id": task.task_id,
+            "via": delivery_via,
+            "tracks": len(getattr(task, "items", [])),
+        })
+
+    monkeypatch.setattr(bot.SUNO_SERVICE, "handle_callback", fake_handle_callback, raising=False)
+    bot._SUNO_RECONCILE_ATTEMPTS.clear()
+
+    await bot._suno_reconcile_once()
+
+    assert len(delivered) == 1
+    assert delivered[0]["via"] == "reconcile"
+    assert len(refunds) == 1


### PR DESCRIPTION
## Summary
- guard the ledger transactions constraint with an idempotent DO block and open async pools explicitly
- improve Suno polling: normalize the status endpoint, treat 404 as pending, add a reconciliation worker, and refactor delivery helpers
- provide lightweight test scaffolding, new Suno/ledger tests, and an operations runbook

## Testing
- `pytest tests/test_ledger_prepare.py`
- `pytest tests/test_suno_poll_pending.py`
- `pytest tests/test_suno_reconcile.py`


------
https://chatgpt.com/codex/tasks/task_e_68f550e1591c8322ad722d5342e45e34