### PR TITLE
Align Postgres users table with Redis migration expectations

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -513,6 +513,7 @@ from telegram_utils import (
     safe_send_photo,
     safe_send_text,
     safe_send_placeholder,
+    safe_edit_long_message,
     safe_edit_markdown_v2,
     safe_send_sticker,
     run_ffmpeg,
@@ -16934,7 +16935,14 @@ async def migrate_redis_command(update: Update, ctx: ContextTypes.DEFAULT_TYPE) 
             )
         summary = "\n".join(summary_lines)
         try:
-            await status.edit_text(summary)
+            await safe_edit_long_message(
+                bot=ctx.bot,
+                message=status,
+                chat_id=message.chat_id if message else None,
+                text=summary,
+                caption="Redis migration summary",
+                filename="redis_migration_summary.txt",
+            )
         except Exception:
             await message.reply_text(summary)
         log.info(

--- a/ci/setup_and_test.sh
+++ b/ci/setup_and_test.sh
@@ -23,5 +23,6 @@ fi
 python -m pip install -U pip
 pip install -r requirements.txt
 
-# Run tests
+# Run lint and tests
+ruff check --select F821 handlers scripts tests
 pytest -q

--- a/db/postgres.py
+++ b/db/postgres.py
@@ -111,10 +111,91 @@ CREATE TABLE IF NOT EXISTS users (
     username TEXT,
     referrer_id BIGINT,
     joined_at TIMESTAMPTZ DEFAULT NOW(),
-    updated_at TIMESTAMPTZ DEFAULT NOW(),
-    referral_earned_total BIGINT NOT NULL DEFAULT 0
+    referral_earned_total BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 """
+
+_USERS_MIGRATIONS = [
+    """
+    DO $$
+    BEGIN
+        IF NOT EXISTS (
+            SELECT 1
+              FROM information_schema.columns
+             WHERE table_schema = current_schema()
+               AND table_name = 'users'
+               AND column_name = 'joined_at'
+        ) THEN
+            ALTER TABLE users ADD COLUMN joined_at TIMESTAMPTZ;
+        END IF;
+
+        IF NOT EXISTS (
+            SELECT 1
+              FROM information_schema.columns
+             WHERE table_schema = current_schema()
+               AND table_name = 'users'
+               AND column_name = 'updated_at'
+        ) THEN
+            ALTER TABLE users ADD COLUMN updated_at TIMESTAMPTZ;
+        END IF;
+
+        IF NOT EXISTS (
+            SELECT 1
+              FROM information_schema.columns
+             WHERE table_schema = current_schema()
+               AND table_name = 'users'
+               AND column_name = 'referral_earned_total'
+        ) THEN
+            ALTER TABLE users ADD COLUMN referral_earned_total BIGINT;
+        END IF;
+
+        ALTER TABLE users ALTER COLUMN joined_at SET DEFAULT NOW();
+        BEGIN
+            ALTER TABLE users ALTER COLUMN joined_at DROP NOT NULL;
+        EXCEPTION
+            WHEN undefined_column THEN NULL;
+        END;
+
+        ALTER TABLE users ALTER COLUMN updated_at SET DEFAULT NOW();
+        IF EXISTS (
+            SELECT 1
+              FROM information_schema.columns
+             WHERE table_schema = current_schema()
+               AND table_name = 'users'
+               AND column_name = 'updated_at'
+        ) THEN
+            UPDATE users
+               SET updated_at = NOW()
+             WHERE updated_at IS NULL;
+            BEGIN
+                ALTER TABLE users ALTER COLUMN updated_at SET NOT NULL;
+            EXCEPTION
+                WHEN undefined_column THEN NULL;
+            END;
+        END IF;
+
+        ALTER TABLE users ALTER COLUMN referral_earned_total SET DEFAULT 0;
+        IF EXISTS (
+            SELECT 1
+              FROM information_schema.columns
+             WHERE table_schema = current_schema()
+               AND table_name = 'users'
+               AND column_name = 'referral_earned_total'
+        ) THEN
+            UPDATE users
+               SET referral_earned_total = 0
+             WHERE referral_earned_total IS NULL;
+            BEGIN
+                ALTER TABLE users ALTER COLUMN referral_earned_total SET NOT NULL;
+            EXCEPTION
+                WHEN undefined_column THEN NULL;
+            END;
+        END IF;
+    END;
+    $$;
+    """,
+]
 
 _BALANCES_DDL = """
 CREATE TABLE IF NOT EXISTS balances (
@@ -607,6 +688,8 @@ def _ensure_tables_once() -> None:
                 """
             )
         )
+        for statement in _USERS_MIGRATIONS:
+            conn.execute(text(statement))
         conn.execute(text(_BALANCES_DDL))
         conn.execute(text(_REFERRALS_DDL))
         conn.execute(text(_AUDIT_DDL))

--- a/handlers/profile.py
+++ b/handlers/profile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 import os

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ psycopg[binary,pool]>=3.1,<4.0
 # Вспомогательные пакеты для сборки
 wheel>=0.43
 setuptools>=69
+ruff>=0.4,<0.5

--- a/scripts/migrate_from_redis.py
+++ b/scripts/migrate_from_redis.py
@@ -681,19 +681,22 @@ async def migrate_from_redis(
         for user_id, record in user_records.items():
             username_candidate = _sanitize_text(record.get("username"))
             normalized_referrer = _normalize_referrer(record.get("referrer_id"))
-            if username_candidate is None and normalized_referrer is None:
-                source_keys = sorted(user_sources.get(user_id, []))
-                key_info = ", ".join(source_keys) if source_keys else f"user:{user_id}"
-                log.warning("redis-migration.users.skip | reason=missing_identity key=%s", key_info)
-                skipped.append(f"malformed user record: {key_info}")
-                stats.redis_profiles_skipped += 1
-                continue
             row = dict(record)
             row["username"] = username_candidate
             row["referrer_id"] = normalized_referrer
             source_keys = sorted(user_sources.get(user_id, []))
             if source_keys:
                 row["_source"] = ", ".join(source_keys)
+            if username_candidate is None and normalized_referrer is None:
+                joined_value = row.get("joined_at")
+                if not isinstance(joined_value, datetime):
+                    joined_value = datetime.now(timezone.utc)
+                row["joined_at"] = joined_value
+                log.info(
+                    "redis-migration.user.stubbed | user_id=%s sources=%s",
+                    user_id,
+                    row.get("_source", "unknown"),
+                )
             user_batches.append(row)
             stats.redis_profiles_processed += 1
         balance_batch = [

--- a/telegram_utils.py
+++ b/telegram_utils.py
@@ -26,7 +26,7 @@ from PIL import Image
 import requests
 from requests import Response
 
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup, InputFile, Message
+from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup, InputFile, Message
 from telegram.constants import ParseMode
 from telegram.error import BadRequest, Forbidden, NetworkError, RetryAfter, TelegramError, TimedOut
 
@@ -1051,6 +1051,47 @@ async def safe_send_sticker(
     )
 
 
+async def safe_edit_long_message(
+    *,
+    bot: Bot | Any,
+    message: Message | None,
+    chat_id: int | None,
+    text: str,
+    caption: Optional[str] = None,
+    filename: str = "migration_summary.txt",
+    limit: int = 3500,
+) -> Message:
+    """Edit ``message`` with ``text`` falling back to a document when too long."""
+
+    payload = text or ""
+    max_length = max(1, int(limit))
+    target_chat = chat_id or (message.chat_id if message is not None else None)
+    if target_chat is None:
+        raise ValueError("chat_id or message must be provided")
+
+    if len(payload) <= max_length:
+        if message is not None:
+            try:
+                return await message.edit_text(payload)
+            except BadRequest as exc:
+                description = (exc.message or str(exc) or "").lower()
+                if "message is not modified" in description:
+                    return message
+                if "message is too long" not in description:
+                    raise
+        return await bot.send_message(target_chat, payload)
+
+    buffer = io.BytesIO(payload.encode("utf-8"))
+    buffer.name = filename or "message.txt"
+    buffer.seek(0)
+    caption_text = caption or "Migration summary"
+    log.info(
+        "tg.message.long.fallback | strategy=document | size=%s",
+        len(payload),
+    )
+    return await bot.send_document(target_chat, document=buffer, caption=caption_text)
+
+
 async def run_ffmpeg(input_bytes: bytes, args: list[str], timeout: float = 40.0) -> bytes:
     ffmpeg_bin = (os.getenv("FFMPEG_BIN") or "ffmpeg").strip() or "ffmpeg"
     cmd = [ffmpeg_bin, *args]
@@ -1178,6 +1219,7 @@ __all__ = [
     "safe_send_media_group",
     "safe_send_placeholder",
     "safe_send_sticker",
+    "safe_edit_long_message",
     "safe_edit_text",
     "safe_edit_markdown_v2",
     "run_ffmpeg",

--- a/tests/test_redis_migration_workflow.py
+++ b/tests/test_redis_migration_workflow.py
@@ -1,0 +1,130 @@
+import asyncio
+from typing import Any
+
+from telegram.error import BadRequest
+
+from db import postgres as db_postgres
+from scripts import migrate_from_redis
+from telegram_utils import safe_edit_long_message
+
+
+def test_users_schema_idempotent(monkeypatch):
+    executed: list[str] = []
+
+    class _Connection:
+        def execute(self, statement: Any) -> None:
+            executed.append(str(statement))
+
+    class _Begin:
+        def __enter__(self) -> _Connection:
+            return _Connection()
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    class _Engine:
+        def begin(self) -> _Begin:
+            return _Begin()
+
+    monkeypatch.setattr(db_postgres, "_ensure_engine", lambda: _Engine())
+
+    db_postgres._ensure_tables_once()
+    db_postgres._ensure_tables_once()
+
+    user_statements = [
+        stmt for stmt in executed if "CREATE TABLE IF NOT EXISTS users" in stmt
+    ]
+    assert len(user_statements) == 2
+    assert any("referral_earned_total" in stmt for stmt in executed)
+    assert any("DO $$" in stmt for stmt in executed)
+
+
+def test_execute_users_import(monkeypatch):
+    captured: list[list[dict[str, Any]]] = []
+
+    async def _fake_execute(engine, stmt, rows, stage):  # noqa: ANN001
+        captured.append(list(rows))
+        return len(rows)
+
+    monkeypatch.setattr(migrate_from_redis, "_execute_with_retry", _fake_execute)
+
+    sample_rows = [
+        {
+            "id": 7377603294,
+            "username": "ghavcsh",
+            "referrer_id": None,
+            "joined_at": None,
+            "referral_earned_total": None,
+        },
+        {
+            "id": 5254733138,
+            "username": "NioSkittle",
+            "referrer_id": 123,
+            "joined_at": "2024-10-01T10:00:00+00:00",
+            "referral_earned_total": "5",
+        },
+        {
+            "id": 878622103,
+            "username": None,
+            "referrer_id": None,
+            "joined_at": None,
+            "referral_earned_total": None,
+        },
+    ]
+
+    first = asyncio.run(migrate_from_redis._execute_users(object(), sample_rows))
+    second = asyncio.run(migrate_from_redis._execute_users(object(), sample_rows))
+
+    assert first == len(sample_rows)
+    assert second == len(sample_rows)
+    assert captured
+    flattened = [item for batch in captured for item in batch]
+    ids = {row["id"] for row in flattened}
+    assert ids == {row["id"] for row in sample_rows}
+
+
+def test_safe_edit_long_message_document_fallback():
+    class _Message:
+        chat_id = 42
+
+        async def edit_text(self, text: str) -> None:  # noqa: D401
+            raise BadRequest("Message is too long")
+
+    class _Bot:
+        def __init__(self) -> None:
+            self.sent_document = None
+            self.sent_message = None
+
+        async def send_message(self, chat_id: int, text: str):
+            self.sent_message = (chat_id, text)
+            return {"ok": True}
+
+        async def send_document(self, chat_id: int, document, caption: str | None = None):
+            document.seek(0)
+            payload = document.read()
+            self.sent_document = (chat_id, payload, caption, getattr(document, "name", None))
+            return {"ok": True}
+
+    bot = _Bot()
+    message = _Message()
+    long_text = "x" * 5000
+
+    result = asyncio.run(
+        safe_edit_long_message(
+            bot=bot,
+            message=message,
+            chat_id=None,
+            text=long_text,
+            caption="Migration summary",
+            filename="redis_summary.txt",
+        )
+    )
+
+    assert bot.sent_document is not None
+    chat_id, payload, caption, name = bot.sent_document
+    assert chat_id == message.chat_id
+    assert payload == long_text.encode("utf-8")
+    assert caption == "Migration summary"
+    assert name == "redis_summary.txt"
+    assert result == {"ok": True}
+


### PR DESCRIPTION
## Summary
- add the missing asyncio import to the profile handler and route Redis migration summaries through a long-message safe helper
- update the Postgres users DDL/migrations so joined_at, referral_earned_total, and updated_at match Redis migration writes and stub empty user records during import
- wire in a focused ruff F821 lint check, add tests for schema/idempotent import/reporting, and ship a Telegram helper for oversized summaries

## Testing
- ruff check --select F821 handlers scripts tests
- pytest tests/test_redis_migration_workflow.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f5fa5588fc8322be88d96b33192528