### PR TITLE
Implement Suno job persistence and polling safeguards

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -64,6 +64,7 @@ from typing import (
     MutableMapping,
     Sequence,
     Iterable,
+    Mapping,
 )
 from datetime import datetime, timedelta, timezone
 from contextlib import suppress
@@ -455,6 +456,7 @@ from suno.cover_source import (
     upload_url as upload_cover_url,
     validate_audio_file as validate_cover_audio_file,
 )
+from suno.jobs_store import jobs_store as SUNO_JOB_STORE
 from suno.service import SunoService, SunoAPIError, RecordInfoPollResult
 from sora2_client import (
     CreateTaskResponse,
@@ -11315,6 +11317,19 @@ async def _launch_suno_generation(
         meta["task_id"] = task_id
         _suno_update_last_debit_meta(user_id, {"task_id": task_id})
 
+        try:
+            job_user_id = int(user_id)
+        except (TypeError, ValueError):
+            job_user_id = None
+        SUNO_JOB_STORE.record_enqueue(
+            task_id,
+            user_id=job_user_id,
+            chat_id=int(chat_id),
+            request_id=req_id,
+            title=title,
+            payload={"params": params, "meta": meta},
+        )
+
         pending_meta.update(
             {
                 "task_id": task_id,
@@ -11442,6 +11457,26 @@ async def _suno_poll_record_info(
         if result.message:
             meta["message"] = result.message
 
+        payload_mapping = result.payload if isinstance(result.payload, Mapping) else None
+        if result.state in {"pending", "retry"}:
+            SUNO_JOB_STORE.mark_pending(
+                task_id,
+                payload=payload_mapping,
+                status=normalized_status,
+            )
+        elif result.state == "ready":
+            SUNO_JOB_STORE.mark_ready(task_id, payload=payload_mapping)
+        elif result.state == "hard_error":
+            SUNO_JOB_STORE.mark_failed(
+                task_id,
+                message=result.message or result.error,
+                payload=payload_mapping,
+            )
+        elif result.state == "timeout":
+            SUNO_JOB_STORE.mark_timeout(task_id)
+        elif result.state == "delivered":
+            SUNO_JOB_STORE.mark_delivered(task_id, delivery_key=f"suno:{task_id}")
+
         should_log_retry = False
         if result.status_code == 404 and result.state in {"pending", "retry"}:
             should_log_retry = True
@@ -11556,6 +11591,69 @@ def _suno_reconcile_should_attempt(task_id: str, now: float) -> bool:
 async def _suno_reconcile_once() -> None:
     if SUNO_RECONCILE_BATCH <= 0:
         return
+    now_dt = datetime.now(timezone.utc)
+    cutoff = now_dt - timedelta(seconds=SUNO_RECONCILE_MAX_AGE)
+    now_monotonic = time.monotonic()
+    processed = 0
+    processed_ids: set[str] = set()
+    jobs_candidates = SUNO_JOB_STORE.iter_reconcilable(since=cutoff, limit=SUNO_RECONCILE_BATCH)
+    if jobs_candidates:
+        for job in jobs_candidates:
+            if processed >= SUNO_RECONCILE_BATCH:
+                break
+            task_id = job.job_id
+            if not task_id:
+                continue
+            if task_id in processed_ids:
+                continue
+            processed += 1
+            processed_ids.add(task_id)
+            try:
+                poll_result = await asyncio.to_thread(
+                    SUNO_SERVICE.poll_record_info_once,
+                    task_id,
+                    user_id=job.user_id,
+                )
+            except Exception as exc:
+                log.warning("[SUNO] reconcile poll failed | task_id=%s err=%s", task_id, exc)
+                continue
+            payload = poll_result.payload if isinstance(poll_result.payload, Mapping) else {}
+            status_value = None
+            if isinstance(payload, Mapping):
+                status_value = SunoService._status_from_payload(payload)
+            normalized_status = status_value.upper() if isinstance(status_value, str) else None
+            if poll_result.state == "ready":
+                SUNO_JOB_STORE.mark_ready(task_id, payload=payload)
+                req_id_value = job.request_id or SUNO_SERVICE.get_request_id(task_id)
+                delivered = await asyncio.to_thread(
+                    _suno_deliver_record_info_payload,
+                    task_id,
+                    payload,
+                    req_id=req_id_value,
+                    delivery_via="reconcile",
+                )
+                if delivered:
+                    SUNO_JOB_STORE.mark_delivered(task_id, delivery_key=f"suno:{task_id}")
+                else:
+                    log.warning("[SUNO] reconcile delivery skipped | task_id=%s", task_id)
+                continue
+            if poll_result.state == "hard_error" and normalized_status in {"FAILED", "ERROR", "CANCELLED", "CANCELED", "EXPIRED"}:
+                SUNO_JOB_STORE.mark_failed(
+                    task_id,
+                    message=poll_result.message or poll_result.error or normalized_status,
+                    payload=payload,
+                    final=True,
+                )
+                continue
+            SUNO_JOB_STORE.mark_pending(
+                task_id,
+                payload=payload,
+                status=normalized_status,
+            )
+
+    if processed >= SUNO_RECONCILE_BATCH:
+        return
+
     try:
         records = await asyncio.to_thread(
             SUNO_SERVICE.list_last_tasks,
@@ -11564,10 +11662,6 @@ async def _suno_reconcile_once() -> None:
     except Exception as exc:
         log.warning("[SUNO] reconcile fetch failed | err=%s", exc)
         return
-    now_dt = datetime.now(timezone.utc)
-    cutoff = now_dt - timedelta(seconds=SUNO_RECONCILE_MAX_AGE)
-    now_monotonic = time.monotonic()
-    processed = 0
     for record in records:
         if processed >= SUNO_RECONCILE_BATCH:
             break
@@ -11575,6 +11669,8 @@ async def _suno_reconcile_once() -> None:
             continue
         task_id = str(record.get("task_id") or record.get("taskId") or "").strip()
         if not task_id:
+            continue
+        if task_id in processed_ids:
             continue
         tracks = record.get("tracks")
         if isinstance(tracks, list) and tracks:
@@ -11606,6 +11702,7 @@ async def _suno_reconcile_once() -> None:
         state = poll_result.state
         if state == "ready":
             payload = poll_result.payload if isinstance(poll_result.payload, Mapping) else {}
+            SUNO_JOB_STORE.mark_ready(task_id, payload=payload)
             req_id_value = record.get("req_id") or SUNO_SERVICE.get_request_id(task_id)
             durations = SunoService._durations_from_tracks(  # type: ignore[attr-defined]
                 SunoService._tracks_from_payload(payload)  # type: ignore[attr-defined]
@@ -11626,12 +11723,20 @@ async def _suno_reconcile_once() -> None:
             )
             if not delivered:
                 log.warning("[SUNO] reconcile delivery skipped | task_id=%s", task_id)
+            else:
+                SUNO_JOB_STORE.mark_delivered(task_id, delivery_key=f"suno:{task_id}")
         elif state == "hard_error":
             log.warning(
                 "[SUNO] reconcile hard error | task_id=%s status=%s http=%s",
                 task_id,
                 poll_result.message or poll_result.error or state,
                 poll_result.status_code,
+            )
+            SUNO_JOB_STORE.mark_failed(
+                task_id,
+                message=poll_result.message or poll_result.error or state,
+                payload=payload,
+                final=True,
             )
 
 
@@ -11850,39 +11955,82 @@ async def _poll_suno_and_send(
         if not should_schedule:
             return
 
+        SUNO_JOB_STORE.mark_reconciling(task_id)
+
         async def _follow_up() -> None:
+            failure_states = {"FAILED", "EXPIRED", "TIMEOUT", "ERROR", "CANCELLED", "CANCELED"}
+            deadline = time.monotonic() + max(SUNO_TIMEOUT_RECHECK_TTL, SUNO_TIMEOUT_RECHECK_DELAY)
+            attempt = 0
             try:
-                await asyncio.sleep(SUNO_TIMEOUT_RECHECK_DELAY)
-                follow_result = await _suno_poll_record_info(task_id, user_id=user_id)
-                payload = dict(follow_result.payload) if isinstance(follow_result.payload, Mapping) else {}
-                if follow_result.state == "ready":
-                    log.info(
-                        "[SUNO] timeout follow-up ready | task_id=%s attempts=%s elapsed=%.1f",
+                while True:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    await asyncio.sleep(min(SUNO_TIMEOUT_RECHECK_DELAY, max(0.0, remaining)))
+                    attempt += 1
+                    poll_result = await asyncio.to_thread(
+                        SUNO_SERVICE.poll_record_info_once,
                         task_id,
-                        follow_result.attempts,
-                        follow_result.elapsed,
+                        user_id=user_id,
                     )
-                    delivered = await _deliver_ready_payload(payload, via="timeout_followup")
-                    if delivered:
-                        await _clear_wait()
-                    return
-                if follow_result.state == "hard_error":
-                    reason_text = _clean_reason(follow_result.message or follow_result.error)
-                    message = _suno_error_message(follow_result.status_code, reason_text)
-                    await _issue_refund(message, reason="suno:refund:timeout_final")
-                    return
-                if follow_result.state == "timeout":
-                    await _issue_refund(_suno_timeout_text(), reason="suno:refund:timeout_final")
-                    return
-                # Pending or other non-terminal state after grace window
-                await _issue_refund(
-                    _suno_timeout_text(),
-                    reason="suno:refund:timeout_final",
+                    payload = (
+                        dict(poll_result.payload)
+                        if isinstance(poll_result.payload, Mapping)
+                        else {}
+                    )
+                    status_value = None
+                    if isinstance(payload, Mapping):
+                        status_value = SunoService._status_from_payload(payload)
+                    normalized_follow_status = status_value.upper() if isinstance(status_value, str) else None
+                    if poll_result.state == "ready":
+                        log.info(
+                            "[SUNO] timeout follow-up ready | task_id=%s attempts=%s",
+                            task_id,
+                            attempt,
+                        )
+                        delivered = await _deliver_ready_payload(payload, via="timeout_followup")
+                        if delivered:
+                            SUNO_JOB_STORE.mark_delivered(task_id, delivery_key=f"suno:{task_id}")
+                            await _clear_wait()
+                        return
+                    if poll_result.state == "hard_error":
+                        reason_text = _clean_reason(poll_result.message or poll_result.error)
+                        message = _suno_error_message(poll_result.status_code, reason_text)
+                        should_refund = normalized_follow_status in failure_states
+                        SUNO_JOB_STORE.mark_failed(
+                            task_id,
+                            message=message,
+                            payload=payload,
+                            final=True,
+                            refunded=should_refund,
+                        )
+                        if should_refund:
+                            await _issue_refund(message, reason="suno:refund:timeout_final")
+                        return
+                    if poll_result.state == "timeout":
+                        SUNO_JOB_STORE.mark_timeout(task_id)
+                    else:
+                        SUNO_JOB_STORE.mark_pending(
+                            task_id,
+                            payload=payload,
+                            status=normalized_follow_status,
+                        )
+                SUNO_JOB_STORE.mark_failed(
+                    task_id,
+                    message="timeout",
+                    final=True,
+                    refunded=True,
                 )
+                await _issue_refund(_suno_timeout_text(), reason="suno:refund:timeout_final")
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
                 log.exception("[SUNO] timeout follow-up failed | task_id=%s err=%s", task_id, exc)
+                SUNO_JOB_STORE.mark_failed(
+                    task_id,
+                    message=str(exc),
+                    final=True,
+                )
                 await _issue_refund(
                     _suno_error_message(None, _clean_reason(str(exc))),
                     reason="suno:refund:timeout_followup_err",
@@ -11961,15 +12109,28 @@ async def _poll_suno_and_send(
                     task_id,
                     notify_exc,
                 )
-            refund_states = {"FAILED", "EXPIRED", "TIMEOUT"}
+            refund_states = {"FAILED", "EXPIRED", "TIMEOUT", "ERROR"}
             if normalized_status in refund_states:
                 await _issue_refund(message, reason="suno:refund:status_err")
+                SUNO_JOB_STORE.mark_failed(
+                    task_id,
+                    message=message,
+                    payload=details,
+                    final=True,
+                    refunded=True,
+                )
                 await _clear_wait()
             else:
                 log.info(
                     "[SUNO] poll hard error without refund | task_id=%s status=%s",
                     task_id,
                     normalized_status,
+                )
+                SUNO_JOB_STORE.mark_failed(
+                    task_id,
+                    message=message,
+                    payload=details,
+                    final=True,
                 )
                 await _clear_wait()
             return
@@ -12017,6 +12178,7 @@ async def _poll_suno_and_send(
 
         delivered = await _deliver_ready_payload(details, via="poll", tracks=tracks_payload)
         if delivered:
+            SUNO_JOB_STORE.mark_delivered(task_id, delivery_key=f"suno:{task_id}")
             await _clear_wait()
         return
 
@@ -12026,6 +12188,13 @@ async def _poll_suno_and_send(
     except Exception as exc:
         log.exception("[SUNO] poll unexpected failure | task_id=%s err=%s", task_id, exc)
         await _issue_refund(_suno_error_message(None, _clean_reason(str(exc))), reason="suno:refund:poll_err")
+        SUNO_JOB_STORE.mark_failed(
+            task_id,
+            message=str(exc),
+            payload=details,
+            final=True,
+            refunded=True,
+        )
         await _clear_wait()
     finally:
         s = state(ctx)

--- a/db/postgres.py
+++ b/db/postgres.py
@@ -282,6 +282,33 @@ _TRANSACTIONS_MIGRATIONS = [
     """,
 ]
 
+_SUNO_JOBS_DDL = """
+CREATE TABLE IF NOT EXISTS suno_jobs (
+    id TEXT PRIMARY KEY,
+    user_id BIGINT,
+    chat_id BIGINT,
+    request_id TEXT,
+    title TEXT,
+    state TEXT NOT NULL DEFAULT 'ENQUEUED',
+    refund_state TEXT NOT NULL DEFAULT 'ESCROW',
+    last_error TEXT,
+    ledger_txn_id TEXT,
+    payload JSONB DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    delivered_at TIMESTAMPTZ,
+    webhook_seen_at TIMESTAMPTZ,
+    last_polled_at TIMESTAMPTZ,
+    retries INTEGER NOT NULL DEFAULT 0,
+    delivery_key TEXT
+);
+"""
+
+_SUNO_JOBS_INDEX_DDL = """
+CREATE INDEX IF NOT EXISTS idx_suno_jobs_state_updated
+    ON suno_jobs (state, updated_at DESC);
+"""
+
 
 def _render_postgres_url(url: URL) -> str:
     rendered = url.render_as_string(hide_password=False)
@@ -697,6 +724,8 @@ def _ensure_tables_once() -> None:
         conn.execute(text(_TRANSACTIONS_INDEX_DDL))
         for statement in _TRANSACTIONS_MIGRATIONS:
             conn.execute(text(statement))
+        conn.execute(text(_SUNO_JOBS_DDL))
+        conn.execute(text(_SUNO_JOBS_INDEX_DDL))
 
 
 async def ensure_tables_with_retries(

--- a/handlers/faq_handler.py
+++ b/handlers/faq_handler.py
@@ -8,6 +8,7 @@ from typing import Awaitable, Callable, Optional
 from telegram import Update
 from telegram.constants import ParseMode
 from telegram.ext import ContextTypes
+from telegram.error import BadRequest
 
 from keyboards import CB_FAQ_PREFIX, faq_keyboard
 from texts import FAQ_INTRO, FAQ_SECTIONS
@@ -73,11 +74,16 @@ async def faq_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     user_id = update.effective_user.id if update.effective_user else None
     logger.info("faq.callback | user_id=%s data=%s", user_id, query.data)
 
+    try:
+        await query.answer()
+    except BadRequest as exc:
+        if "Query is too old" not in str(exc):
+            raise
+
     data = query.data
     key = data.removeprefix(CB_FAQ_PREFIX)
 
     if key == "back":
-        await query.answer()
         if callable(_show_main_menu):
             await _show_main_menu(update, context)
             return
@@ -101,7 +107,6 @@ async def faq_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         except Exception:  # pragma: no cover - metrics should not break flow
             logger.exception("faq.section_metric_failed | section=%s", key)
 
-    await query.answer()
     message = query.message
     if message is None:
         return

--- a/suno/jobs_store.py
+++ b/suno/jobs_store.py
@@ -1,0 +1,445 @@
+"""Persistent Suno job tracking with Postgres fallback."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+import json
+import logging
+import threading
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+try:  # SQLAlchemy is optional in tests
+    from sqlalchemy import text
+    from sqlalchemy.exc import SQLAlchemyError
+except Exception:  # pragma: no cover - fallback for environments without SQLAlchemy
+    text = None  # type: ignore
+
+    class SQLAlchemyError(Exception):  # type: ignore
+        pass
+
+from db import postgres as db_postgres
+
+log = logging.getLogger("suno.jobs_store")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class SunoJobState(str, Enum):
+    """Finite states for the Suno job lifecycle."""
+
+    ENQUEUED = "ENQUEUED"
+    PENDING = "PENDING"
+    READY = "READY"
+    DELIVERED = "DELIVERED"
+    FAILED = "FAILED"
+    FAILED_FINAL = "FAILED_FINAL"
+    TIMEOUT = "TIMEOUT"
+    RECONCILING = "RECONCILING"
+
+
+class RefundState(str, Enum):
+    ESCROW = "ESCROW"
+    CAPTURED = "CAPTURED"
+    REFUNDED = "REFUNDED"
+
+
+@dataclass
+class SunoJobRecord:
+    """In-memory representation of a persisted Suno job."""
+
+    job_id: str
+    user_id: Optional[int] = None
+    chat_id: Optional[int] = None
+    request_id: Optional[str] = None
+    title: Optional[str] = None
+    state: SunoJobState = SunoJobState.ENQUEUED
+    refund_state: RefundState = RefundState.ESCROW
+    last_error: Optional[str] = None
+    ledger_txn_id: Optional[str] = None
+    payload: Optional[Dict[str, Any]] = None
+    created_at: datetime = field(default_factory=_utcnow)
+    updated_at: datetime = field(default_factory=_utcnow)
+    delivered_at: Optional[datetime] = None
+    webhook_seen_at: Optional[datetime] = None
+    last_polled_at: Optional[datetime] = None
+    retries: int = 0
+    delivery_key: Optional[str] = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.job_id,
+            "user_id": self.user_id,
+            "chat_id": self.chat_id,
+            "request_id": self.request_id,
+            "title": self.title,
+            "state": self.state.value,
+            "refund_state": self.refund_state.value,
+            "last_error": self.last_error,
+            "ledger_txn_id": self.ledger_txn_id,
+            "payload": self.payload or {},
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "delivered_at": self.delivered_at.isoformat() if self.delivered_at else None,
+            "webhook_seen_at": self.webhook_seen_at.isoformat() if self.webhook_seen_at else None,
+            "last_polled_at": self.last_polled_at.isoformat() if self.last_polled_at else None,
+            "retries": self.retries,
+            "delivery_key": self.delivery_key,
+        }
+
+
+class SunoJobStore:
+    """Persist Suno job state in Postgres with an in-memory fallback."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._memory: Dict[str, SunoJobRecord] = {}
+        self._engine = self._try_get_engine()
+
+    # ------------------------------------------------------------------
+    #   Engine helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _try_get_engine():
+        try:
+            return db_postgres.get_engine()
+        except Exception:  # pragma: no cover - optional in tests
+            return None
+
+    def _with_lock(self, fn, *args, **kwargs):
+        with self._lock:
+            return fn(*args, **kwargs)
+
+    def _persist(self, sql: str, params: Mapping[str, Any]) -> None:
+        engine = self._engine
+        if engine is None or text is None:
+            return
+        try:
+            with engine.begin() as conn:
+                conn.execute(text(sql), params)
+        except SQLAlchemyError as exc:  # pragma: no cover - best effort logging
+            log.warning("suno.jobs_store.sql_failed", extra={"error": str(exc)})
+
+    def _load_memory(self, job_id: str) -> Optional[SunoJobRecord]:
+        return self._memory.get(job_id)
+
+    def _save_memory(self, record: SunoJobRecord) -> None:
+        self._memory[record.job_id] = record
+
+    def _get_or_create(self, job_id: str) -> SunoJobRecord:
+        record = self._memory.get(job_id)
+        if record is None:
+            record = SunoJobRecord(job_id=job_id)
+            self._memory[job_id] = record
+        return record
+
+    # ------------------------------------------------------------------
+    #   Public API
+    # ------------------------------------------------------------------
+    def record_enqueue(
+        self,
+        job_id: str,
+        *,
+        user_id: Optional[int],
+        chat_id: Optional[int],
+        request_id: Optional[str],
+        title: Optional[str],
+        payload: Optional[Mapping[str, Any]] = None,
+    ) -> SunoJobRecord:
+        def _update() -> SunoJobRecord:
+            record = self._get_or_create(job_id)
+            now = _utcnow()
+            record.user_id = user_id
+            record.chat_id = chat_id
+            record.request_id = request_id
+            record.title = title
+            record.payload = dict(payload or {})
+            record.state = SunoJobState.ENQUEUED
+            record.refund_state = RefundState.ESCROW
+            record.last_error = None
+            record.created_at = record.created_at or now
+            record.updated_at = now
+            self._save_memory(record)
+            return record
+
+        record = self._with_lock(_update)
+        self._persist(
+            """
+            INSERT INTO suno_jobs (id, user_id, chat_id, request_id, title, state, refund_state, payload)
+            VALUES (:id, :user_id, :chat_id, :request_id, :title, :state, :refund_state, :payload)
+            ON CONFLICT (id) DO UPDATE
+               SET user_id = EXCLUDED.user_id,
+                   chat_id = EXCLUDED.chat_id,
+                   request_id = EXCLUDED.request_id,
+                   title = EXCLUDED.title,
+                   state = EXCLUDED.state,
+                   refund_state = EXCLUDED.refund_state,
+                   payload = EXCLUDED.payload,
+                   updated_at = NOW()
+            """,
+            {
+                "id": job_id,
+                "user_id": user_id,
+                "chat_id": chat_id,
+                "request_id": request_id,
+                "title": title,
+                "state": record.state.value,
+                "refund_state": record.refund_state.value,
+                "payload": json.dumps(record.payload or {}, ensure_ascii=False),
+            },
+        )
+        return record
+
+    def mark_pending(
+        self,
+        job_id: str,
+        *,
+        payload: Optional[Mapping[str, Any]] = None,
+        status: Optional[str] = None,
+    ) -> None:
+        def _update() -> SunoJobRecord:
+            record = self._get_or_create(job_id)
+            record.state = SunoJobState.PENDING
+            record.updated_at = _utcnow()
+            record.last_polled_at = record.updated_at
+            if payload is not None:
+                record.payload = dict(payload)
+            if status:
+                record.payload = dict(record.payload or {})
+                record.payload["status_label"] = status
+            self._save_memory(record)
+            return record
+
+        record = self._with_lock(_update)
+        self._persist(
+            """
+            UPDATE suno_jobs
+               SET state = :state,
+                   payload = COALESCE(:payload, payload),
+                   last_polled_at = NOW(),
+                   updated_at = NOW()
+             WHERE id = :id
+            """,
+            {
+                "id": job_id,
+                "state": record.state.value,
+                "payload": json.dumps(record.payload or {}, ensure_ascii=False)
+                if payload is not None or status
+                else None,
+            },
+        )
+
+    def mark_ready(
+        self,
+        job_id: str,
+        *,
+        payload: Optional[Mapping[str, Any]],
+    ) -> None:
+        def _update() -> SunoJobRecord:
+            record = self._get_or_create(job_id)
+            record.state = SunoJobState.READY
+            record.refund_state = RefundState.CAPTURED
+            record.payload = dict(payload or {})
+            record.updated_at = _utcnow()
+            record.last_polled_at = record.updated_at
+            self._save_memory(record)
+            return record
+
+        record = self._with_lock(_update)
+        self._persist(
+            """
+            UPDATE suno_jobs
+               SET state = :state,
+                   refund_state = :refund_state,
+                   payload = :payload,
+                   last_polled_at = NOW(),
+                   updated_at = NOW()
+             WHERE id = :id
+            """,
+            {
+                "id": job_id,
+                "state": record.state.value,
+                "refund_state": record.refund_state.value,
+                "payload": json.dumps(record.payload or {}, ensure_ascii=False),
+            },
+        )
+
+    def mark_failed(
+        self,
+        job_id: str,
+        *,
+        message: Optional[str],
+        payload: Optional[Mapping[str, Any]] = None,
+        final: bool = False,
+        refunded: bool = False,
+    ) -> None:
+        state = SunoJobState.FAILED_FINAL if final else SunoJobState.FAILED
+        refund_state = RefundState.REFUNDED if refunded else RefundState.ESCROW
+
+        def _update() -> SunoJobRecord:
+            record = self._get_or_create(job_id)
+            record.state = state
+            record.last_error = message
+            if payload is not None:
+                record.payload = dict(payload)
+            record.updated_at = _utcnow()
+            record.refund_state = refund_state
+            self._save_memory(record)
+            return record
+
+        record = self._with_lock(_update)
+        self._persist(
+            """
+            UPDATE suno_jobs
+               SET state = :state,
+                   last_error = :last_error,
+                   refund_state = :refund_state,
+                   payload = COALESCE(:payload, payload),
+                   updated_at = NOW()
+             WHERE id = :id
+            """,
+            {
+                "id": job_id,
+                "state": record.state.value,
+                "last_error": message,
+                "refund_state": record.refund_state.value,
+                "payload": json.dumps(record.payload or {}, ensure_ascii=False)
+                if payload is not None
+                else None,
+            },
+        )
+
+    def mark_timeout(self, job_id: str) -> None:
+        def _update() -> SunoJobRecord:
+            record = self._get_or_create(job_id)
+            record.state = SunoJobState.TIMEOUT
+            record.updated_at = _utcnow()
+            self._save_memory(record)
+            return record
+
+        record = self._with_lock(_update)
+        self._persist(
+            """
+            UPDATE suno_jobs
+               SET state = :state,
+                   updated_at = NOW()
+             WHERE id = :id
+            """,
+            {"id": job_id, "state": record.state.value},
+        )
+
+    def mark_reconciling(self, job_id: str) -> None:
+        def _update() -> SunoJobRecord:
+            record = self._get_or_create(job_id)
+            record.state = SunoJobState.RECONCILING
+            record.retries += 1
+            record.updated_at = _utcnow()
+            self._save_memory(record)
+            return record
+
+        record = self._with_lock(_update)
+        self._persist(
+            """
+            UPDATE suno_jobs
+               SET state = :state,
+                   retries = retries + 1,
+                   updated_at = NOW()
+             WHERE id = :id
+            """,
+            {"id": job_id, "state": record.state.value},
+        )
+
+    def mark_delivered(self, job_id: str, *, delivery_key: Optional[str] = None) -> None:
+        def _update() -> SunoJobRecord:
+            record = self._get_or_create(job_id)
+            record.state = SunoJobState.DELIVERED
+            record.delivered_at = _utcnow()
+            record.updated_at = record.delivered_at
+            record.refund_state = RefundState.CAPTURED
+            if delivery_key:
+                record.delivery_key = delivery_key
+            self._save_memory(record)
+            return record
+
+        record = self._with_lock(_update)
+        self._persist(
+            """
+            UPDATE suno_jobs
+               SET state = :state,
+                   delivered_at = NOW(),
+                   refund_state = :refund_state,
+                   delivery_key = COALESCE(:delivery_key, delivery_key),
+                   updated_at = NOW()
+             WHERE id = :id
+            """,
+            {
+                "id": job_id,
+                "state": record.state.value,
+                "refund_state": record.refund_state.value,
+                "delivery_key": delivery_key,
+            },
+        )
+
+    def mark_webhook_seen(self, job_id: str) -> None:
+        def _update() -> SunoJobRecord:
+            record = self._get_or_create(job_id)
+            record.webhook_seen_at = _utcnow()
+            self._save_memory(record)
+            return record
+
+        self._with_lock(_update)
+        self._persist(
+            """
+            UPDATE suno_jobs
+               SET webhook_seen_at = NOW(),
+                   updated_at = NOW()
+             WHERE id = :id
+            """,
+            {"id": job_id},
+        )
+
+    def should_deliver(self, job_id: str, *, delivery_key: str) -> bool:
+        def _check() -> bool:
+            record = self._get_or_create(job_id)
+            if record.delivery_key and record.delivery_key == delivery_key:
+                return False
+            if record.state == SunoJobState.DELIVERED:
+                return False
+            return True
+
+        return self._with_lock(_check)
+
+    def get(self, job_id: str) -> Optional[SunoJobRecord]:
+        return self._with_lock(lambda: self._load_memory(job_id))
+
+    def iter_reconcilable(
+        self,
+        *,
+        since: datetime,
+        limit: int,
+        states: Iterable[SunoJobState] = (
+            SunoJobState.TIMEOUT,
+            SunoJobState.PENDING,
+            SunoJobState.RECONCILING,
+        ),
+    ) -> List[SunoJobRecord]:
+        def _collect() -> List[SunoJobRecord]:
+            target_states = {state for state in states}
+            result: List[SunoJobRecord] = []
+            for record in self._memory.values():
+                if record.state not in target_states:
+                    continue
+                if record.updated_at < since:
+                    continue
+                result.append(record)
+            result.sort(key=lambda rec: rec.updated_at, reverse=True)
+            return result[:limit]
+
+        return self._with_lock(_collect)
+
+
+jobs_store = SunoJobStore()
+
+__all__ = ["SunoJobState", "RefundState", "SunoJobRecord", "SunoJobStore", "jobs_store"]

--- a/suno/service.py
+++ b/suno/service.py
@@ -28,6 +28,7 @@ from suno.client import (
 )
 from suno.schemas import ApiEnvelope, CallbackEnvelope, SunoTask, SunoTrack
 from suno.tempfiles import cleanup_old_directories, schedule_unlink, task_directory
+from suno.jobs_store import jobs_store
 from stickers import pop_wait_sticker_id
 from settings import (
     HTTP_POOL_CONNECTIONS,
@@ -2367,6 +2368,23 @@ class SunoService:
         incoming_status = (task.callback_type or "").lower()
         existing_status = str(existing_record.get("status") or "").lower()
         final_states = {"complete", "error", "failed", "success"}
+        try:
+            jobs_store.mark_webhook_seen(task.task_id)
+        except Exception:
+            log.debug("SunoService webhook state update failed", exc_info=True)
+
+        normalized_callback = incoming_status.upper()
+        if normalized_callback in {"COMPLETE", "SUCCESS", "SUCCEEDED", "READY"}:
+            with suppress(Exception):
+                jobs_store.mark_ready(task.task_id, payload=task.model_dump(exclude_none=True))
+        elif normalized_callback in {"FAILED", "ERROR"}:
+            with suppress(Exception):
+                jobs_store.mark_failed(
+                    task.task_id,
+                    message=task.msg or incoming_status,
+                    payload=task.model_dump(exclude_none=True),
+                    final=True,
+                )
         if incoming_status in final_states:
             self._delete_wait_sticker(int(chat_id))
         if incoming_status in final_states and self._recently_delivered(task.task_id):
@@ -2710,6 +2728,11 @@ class SunoService:
             self._save_task_record(task.task_id, record)
             if incoming_status in final_states:
                 self._mark_delivered(task.task_id)
+                with suppress(Exception):
+                    jobs_store.mark_delivered(
+                        task.task_id,
+                        delivery_key=f"suno:{task.task_id}",
+                    )
                 log.info(
                     "Suno ready",
                     extra={


### PR DESCRIPTION
## Summary
- persist Suno job lifecycle data in Postgres via a new jobs_store helper
- update polling, timeout follow-up, and reconciliation to use the stored state and avoid premature refunds
- rely on webhook updates for delivery accounting and harden FAQ callback handling

## Testing
- pytest tests/test_suno_poll_timeout.py
- pytest tests/test_suno_poll_error.py
- pytest tests/test_suno_poll_success.py
- pytest tests/test_suno_reconcile.py

------
https://chatgpt.com/codex/tasks/task_e_68f6322bd6148322bf45a6e4edc3fee7