### PR TITLE
Centralize UI button handling through registry and router

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6551,33 +6551,51 @@ async def _open_menu_section(
 
 
 async def kb_open(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
-    await _perform_menu_open(
-        "kb",
-        update=update,
-        ctx=ctx,
-        query=update.callback_query,
-        log_click=False,
-    )
+    from ui.buttons.errors import ButtonNotFound
+    from ui.buttons.router import dispatch as dispatch_button
+
+    try:
+        await dispatch_button("kb", update=update, ctx=ctx)
+    except ButtonNotFound:
+        await _perform_menu_open(
+            "kb",
+            update=update,
+            ctx=ctx,
+            query=update.callback_query,
+            log_click=False,
+        )
 
 
 async def photo_open(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
-    await _perform_menu_open(
-        "photo",
-        update=update,
-        ctx=ctx,
-        query=update.callback_query,
-        log_click=False,
-    )
+    from ui.buttons.errors import ButtonNotFound
+    from ui.buttons.router import dispatch as dispatch_button
+
+    try:
+        await dispatch_button("photo", update=update, ctx=ctx)
+    except ButtonNotFound:
+        await _perform_menu_open(
+            "photo",
+            update=update,
+            ctx=ctx,
+            query=update.callback_query,
+            log_click=False,
+        )
 
 
 async def music_open(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
-    await _perform_menu_open(
-        "music",
-        update=update,
-        ctx=ctx,
-        query=update.callback_query,
-        log_click=False,
-    )
+    from ui.buttons.errors import ButtonNotFound
+    from ui.buttons.router import dispatch as dispatch_button
+
+    try:
+        await dispatch_button("music", update=update, ctx=ctx)
+    except ButtonNotFound:
+        await _perform_menu_open(
+            "music",
+            update=update,
+            ctx=ctx,
+            query=update.callback_query,
+            log_click=False,
+        )
 
 
 async def video_open(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
@@ -6585,23 +6603,35 @@ async def video_open(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     if query is not None:
         with suppress(BadRequest):
             await query.answer(cache_time=0)
-    await _perform_menu_open(
-        "video",
-        update=update,
-        ctx=ctx,
-        query=update.callback_query,
-        log_click=False,
-    )
+    from ui.buttons.errors import ButtonNotFound
+    from ui.buttons.router import dispatch as dispatch_button
+
+    try:
+        await dispatch_button("video", update=update, ctx=ctx)
+    except ButtonNotFound:
+        await _perform_menu_open(
+            "video",
+            update=update,
+            ctx=ctx,
+            query=update.callback_query,
+            log_click=False,
+        )
 
 
 async def dialog_open(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
-    await _perform_menu_open(
-        "dialog",
-        update=update,
-        ctx=ctx,
-        query=update.callback_query,
-        log_click=False,
-    )
+    from ui.buttons.errors import ButtonNotFound
+    from ui.buttons.router import dispatch as dispatch_button
+
+    try:
+        await dispatch_button("dialog", update=update, ctx=ctx)
+    except ButtonNotFound:
+        await _perform_menu_open(
+            "dialog",
+            update=update,
+            ctx=ctx,
+            query=update.callback_query,
+            log_click=False,
+        )
 
 
 async def handle_main_menu_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
@@ -6614,7 +6644,13 @@ async def handle_main_menu_callback(update: Update, ctx: ContextTypes.DEFAULT_TY
         return
 
     item = data.split(":", 1)[1]
-    await _perform_menu_open(item, update=update, ctx=ctx, query=query, log_click=True)
+    from ui.buttons.errors import ButtonNotFound
+    from ui.buttons.router import dispatch as dispatch_button
+
+    try:
+        await dispatch_button(item, update=update, ctx=ctx)
+    except ButtonNotFound:
+        await _perform_menu_open(item, update=update, ctx=ctx, query=query, log_click=True)
 
 
 async def handle_hub_open_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
@@ -6628,23 +6664,27 @@ async def handle_hub_open_callback(update: Update, ctx: ContextTypes.DEFAULT_TYP
             await query.answer()
         return
 
-    if data == "hub:open:profile":
-        await profile_open(update, ctx, edit_in_place=True)
-        return
-
-    item = {
+    mapping = {
+        "hub:open:profile": "profile",
         "hub:open:kb": "kb",
         "hub:open:photo": "photo",
         "hub:open:music": "music",
         "hub:open:video": "video",
         "hub:open:dialog": "dialog",
-    }.get(data)
+    }
+    item = mapping.get(data)
     if not item:
         with suppress(BadRequest):
             await query.answer()
         return
 
-    await _perform_menu_open(item, update=update, ctx=ctx, query=query, log_click=True)
+    from ui.buttons.errors import ButtonNotFound
+    from ui.buttons.router import dispatch as dispatch_button
+
+    try:
+        await dispatch_button(item, update=update, ctx=ctx)
+    except ButtonNotFound:
+        await _perform_menu_open(item, update=update, ctx=ctx, query=query, log_click=True)
 
 
 async def show_emoji_hub(

--- a/docs/ui-buttons.md
+++ b/docs/ui-buttons.md
@@ -1,0 +1,51 @@
+# UI Button Architecture
+
+This bot centralises all interactive buttons under the `ui.buttons` package. Each button
+has a declarative contract describing the screen or dialog that must open. Handlers stay
+small and composable, while the router provides idempotency, telemetry and safety rails.
+
+## Key concepts
+
+- **Registry** – `ui.buttons.registry.BUTTONS` is the single source of truth. Every entry
+  includes:
+  - `id` – stable identifier used in callback payloads and metrics.
+  - `title_i18n_key` – localisation key for captions.
+  - `access` – required access tiers (`all`, `paid`, `admin`).
+  - `handler` – async callable returning a `UIResult` contract.
+  - `open_telemetry_event` – event name for distributed traces.
+  - `feature_flag` – optional gate for staged rollouts.
+- **Router** – `ui.buttons.router.dispatch` validates flags, enforces access, applies a
+  Redis-backed idempotency lock (`chat_id + button_id`), emits Prometheus metrics and wraps
+  handler failures into soft, user-facing errors.
+- **Results** – handlers return a `UIResult` describing the expected UI. Tests assert
+  against the result instead of raw Telegram side-effects.
+- **Idempotency** – `ui.buttons.idempotency.with_idempotency` rejects duplicate clicks
+  while the first handler execution is in-flight.
+
+## Adding a new button
+
+1. Implement a handler in `ui/buttons/handlers.py`. Reuse `_open_menu_item` when the button
+   opens a legacy menu card and return the appropriate helper from `ui.buttons.results`
+   (`show_menu`, `show_dialog`, etc.). Document the contract in a docstring.
+2. Register the button in `ui/buttons/registry.py` with the desired access tier and feature
+   flag. This registry is the only place where button metadata lives.
+3. Extend `ui/buttons/guards.py` if the handler needs new access tiers or feature signals.
+4. Add unit tests that call `ui.buttons.router.dispatch` to cover success, feature-flagged
+   and access-denied scenarios. Use the returned `UIResult` for assertions.
+5. Wire existing callback handlers (see `handle_main_menu_callback`) to `dispatch` so every
+   entry point flows through the router.
+
+## Testing matrix
+
+- **Unit tests**: `tests/test_button_router.py` validates registry coverage, access checks
+  and feature flag behaviour.
+- **Integration tests**: exercise real Telegram updates that call `dispatch` and assert the
+  returned contracts.
+- **E2E tests**: cover the `Button × User state` matrix to guarantee the declared contract
+  opens the expected screen and remains idempotent.
+
+## Contracts
+
+The declarative `UIResult` makes button behaviour auditable. When introducing a new button,
+write down the expected UI in the handler docstring and mirror it in tests. Contracts should
+avoid hidden side effects so the CI matrix can reliably detect regressions.

--- a/tests/test_button_router.py
+++ b/tests/test_button_router.py
@@ -1,0 +1,115 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from tests.suno_test_utils import bot_module
+from ui.buttons import BUTTONS
+from ui.buttons import router as button_router
+from ui.buttons.results import UIResult
+
+
+@pytest.fixture(autouse=True)
+def fake_idempotency(monkeypatch):
+    from ui.buttons import idempotency as idemp
+
+    state: set[tuple[object, str]] = set()
+
+    def acquire(owner, key, ttl=5):
+        if owner is None:
+            return True
+        token = (owner, key)
+        if token in state:
+            return False
+        state.add(token)
+        return True
+
+    def release(owner, key):
+        state.discard((owner, key))
+
+    monkeypatch.setattr(idemp, "acquire_action_lock", acquire)
+    monkeypatch.setattr(idemp, "release_action_lock", release)
+
+
+@pytest.mark.parametrize(
+    "button_id",
+    ["profile", "kb", "photo", "music", "video", "dialog", "help", "sora2"],
+)
+def test_registry_contains_expected_buttons(button_id):
+    assert button_id in BUTTONS
+
+
+def _make_update(callback_data: str):
+    async def answer(**kwargs):
+        return None
+
+    message = SimpleNamespace(chat=SimpleNamespace(id=123), chat_id=123)
+    query = SimpleNamespace(
+        data=callback_data,
+        message=message,
+        from_user=SimpleNamespace(id=777),
+        answer=answer,
+    )
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_chat=message.chat,
+        effective_user=query.from_user,
+    )
+    return update
+
+
+async def _fake_perform(item, *, update, ctx, query, log_click):
+    key = bot_module._MENU_CHATDATA_KEYS[item]
+    ctx.chat_data[key] = 100 + len(item)
+    return 100 + len(item)
+
+
+@pytest.fixture(autouse=True)
+def patch_perform(monkeypatch):
+    monkeypatch.setattr(bot_module, "_perform_menu_open", _fake_perform)
+
+    async def fake_help(update, ctx):
+        ctx.user_data["help_called"] = True
+
+    async def fake_sora(update, ctx):
+        ctx.user_data["sora_called"] = True
+
+    monkeypatch.setattr(bot_module, "help_command_entry", fake_help)
+    monkeypatch.setattr(bot_module, "sora2_open_cb", fake_sora)
+
+
+def test_dispatch_profile_updates_chat_data():
+    update = _make_update("menu:profile")
+    ctx = SimpleNamespace(chat_data={}, user_data={}, application=SimpleNamespace(bot_data={}))
+
+    result = asyncio.run(button_router.dispatch("profile", update=update, ctx=ctx))
+    assert isinstance(result, UIResult)
+    assert result.kind == "menu"
+    assert result.screen == "profile"
+    assert ctx.chat_data[bot_module._MENU_CHATDATA_KEYS["profile"]] == 100 + len("profile")
+
+
+def test_dispatch_music_requires_paid():
+    update = _make_update("menu:music")
+    ctx = SimpleNamespace(chat_data={}, user_data={}, application=SimpleNamespace(bot_data={}))
+
+    result = asyncio.run(button_router.dispatch("music", update=update, ctx=ctx))
+    assert result.kind == "error"
+    assert result.details["error_kind"] == "access_denied"
+
+    ctx.user_data["is_paid"] = True
+    result_paid = asyncio.run(button_router.dispatch("music", update=update, ctx=ctx))
+    assert result_paid.kind == "menu"
+
+
+def test_dispatch_sora2_respects_feature_flag():
+    update = _make_update("sora2_open")
+    ctx = SimpleNamespace(chat_data={}, user_data={"is_paid": True}, application=SimpleNamespace(bot_data={}))
+
+    result = asyncio.run(button_router.dispatch("sora2", update=update, ctx=ctx))
+    assert result.kind == "error"
+    assert result.details["error_kind"] == "feature_disabled"
+
+    ctx.application.bot_data = {"feature_flags": {"FEATURE_SORA2_ENABLED": True}}
+    result_enabled = asyncio.run(button_router.dispatch("sora2", update=update, ctx=ctx))
+    assert result_enabled.kind == "dialog"

--- a/tests/test_main_menu_navigation.py
+++ b/tests/test_main_menu_navigation.py
@@ -12,7 +12,7 @@ import handlers.knowledge_base as kb_module  # noqa: E402
 
 
 def test_menu_callbacks_route_ok(monkeypatch):
-    ctx = SimpleNamespace(chat_data={}, user_data={}, application=SimpleNamespace(bot_data={}))
+    ctx = SimpleNamespace(chat_data={}, user_data={"is_paid": True}, application=SimpleNamespace(bot_data={}))
 
     calls: list[tuple[str, tuple, dict]] = []
 
@@ -68,7 +68,7 @@ def test_menu_callbacks_route_ok(monkeypatch):
     monkeypatch.setattr(bot_module, "video_open_menu", fake_video)
     monkeypatch.setattr(bot_module, "dialog_open_menu", fake_dialog)
 
-    async def fake_answer():
+    async def fake_answer(**kwargs):
         return None
 
     tests = [
@@ -123,7 +123,7 @@ def test_menu_open_no_duplicates(monkeypatch):
 
     monkeypatch.setattr(kb_module, "open_root", fake_open_root)
 
-    async def fake_answer():
+    async def fake_answer(**kwargs):
         return None
 
     query = SimpleNamespace(
@@ -158,7 +158,7 @@ def test_menu_suppresses_dialog_notice(monkeypatch):
         assert context.chat_data.get("nav_in_progress") is True
         return 888
 
-    async def fake_answer():
+    async def fake_answer(**kwargs):
         return None
 
     async def fake_ensure(update):

--- a/ui/buttons/__init__.py
+++ b/ui/buttons/__init__.py
@@ -1,0 +1,17 @@
+"""Unified UI button infrastructure."""
+
+from .registry import BUTTONS, ButtonId, ButtonSpec
+from .results import UIResult
+from .router import ButtonRouter, dispatch
+from .types import ButtonContext, ButtonHandler
+
+__all__ = [
+    "BUTTONS",
+    "ButtonId",
+    "ButtonSpec",
+    "ButtonRouter",
+    "ButtonContext",
+    "ButtonHandler",
+    "UIResult",
+    "dispatch",
+]

--- a/ui/buttons/errors.py
+++ b/ui/buttons/errors.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+
+class ButtonError(RuntimeError):
+    """Base class for button router errors."""
+
+
+class ButtonNotFound(ButtonError):
+    pass
+
+
+class ButtonAccessDenied(ButtonError):
+    pass
+
+
+class ButtonFeatureDisabled(ButtonError):
+    pass

--- a/ui/buttons/guards.py
+++ b/ui/buttons/guards.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from telegram.ext import ContextTypes
+
+from .errors import ButtonAccessDenied, ButtonFeatureDisabled
+from .types import ButtonSpec
+
+log = logging.getLogger(__name__)
+
+
+def resolve_user_tier(ctx: ContextTypes.DEFAULT_TYPE, user_id: Optional[int]) -> str:
+    if user_id is not None:
+        try:
+            from bot import ADMIN_IDS  # local import to avoid cycles
+        except Exception:  # pragma: no cover - optional
+            ADMIN_IDS = set()
+        if user_id in ADMIN_IDS:
+            return "admin"
+
+    user_data = getattr(ctx, "user_data", None)
+    if isinstance(user_data, dict):
+        explicit = user_data.get("button_user_tier") or user_data.get("user_tier")
+        if isinstance(explicit, str):
+            return explicit
+        paid_flag = user_data.get("is_paid") or user_data.get("paid")
+        if isinstance(paid_flag, bool) and paid_flag:
+            return "paid"
+
+    return "free"
+
+
+def guard_access(spec: ButtonSpec, ctx: ContextTypes.DEFAULT_TYPE, user_id: Optional[int]) -> str:
+    """Ensure the current user satisfies the required access level."""
+
+    user_tier = resolve_user_tier(ctx, user_id)
+    required = set(spec.access)
+    if not required:
+        return user_tier
+
+    if "admin" in required and user_tier == "admin":
+        return user_tier
+    if "paid" in required:
+        if user_tier in {"paid", "admin"}:
+            return user_tier
+        log.info("ui.button.access_denied", extra={"button": spec.id, "tier": user_tier})
+        raise ButtonAccessDenied(spec.id)
+    if "all" in required:
+        return user_tier
+
+    log.info("ui.button.access_denied", extra={"button": spec.id, "tier": user_tier})
+    raise ButtonAccessDenied(spec.id)
+
+
+def guard_feature(spec: ButtonSpec, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    flag = spec.feature_flag
+    if not flag:
+        return
+
+    application = getattr(ctx, "application", None)
+    containers = []
+    if application is not None:
+        bot_data = getattr(application, "bot_data", None)
+        if isinstance(bot_data, dict):
+            containers.append(bot_data)
+    bot_data = getattr(ctx, "bot_data", None)
+    if isinstance(bot_data, dict):
+        containers.append(bot_data)
+
+    for container in containers:
+        features = container.get("feature_flags") or container.get("features")
+        if isinstance(features, dict) and flag in features:
+            value = features[flag]
+            if isinstance(value, bool):
+                if value:
+                    return
+                raise ButtonFeatureDisabled(flag)
+        value = container.get(flag)
+        if isinstance(value, bool):
+            if value:
+                return
+            raise ButtonFeatureDisabled(flag)
+
+    # default to disabled unless explicitly enabled
+    raise ButtonFeatureDisabled(flag)

--- a/ui/buttons/handlers.py
+++ b/ui/buttons/handlers.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import Optional
+
+from telegram.error import BadRequest
+
+from .results import UIResult, show_dialog, show_menu
+from .types import ButtonContext
+
+
+def _bot():  # pragma: no cover - helper for lazy import
+    import bot as bot_module
+
+    return bot_module
+
+
+async def _open_menu_item(context: ButtonContext, item: str) -> UIResult:
+    bot_module = _bot()
+    ctx = context.app_context
+    chat_data = getattr(ctx, "chat_data", None)
+    fallback_key = bot_module._MENU_CHATDATA_KEYS.get(item)
+    previous: Optional[int] = None
+    if isinstance(chat_data, dict) and fallback_key:
+        raw = chat_data.get(fallback_key)
+        try:
+            previous = int(raw) if raw is not None else None
+        except (TypeError, ValueError):
+            previous = None
+
+    message_id = await bot_module._perform_menu_open(
+        item,
+        update=context.update,
+        ctx=ctx,
+        query=context.query,
+        log_click=False,
+    )
+
+    reused = False
+    if isinstance(chat_data, dict) and fallback_key:
+        raw_after = chat_data.get(fallback_key)
+        try:
+            current = int(raw_after) if raw_after is not None else None
+        except (TypeError, ValueError):
+            current = None
+        else:
+            reused = previous is not None and previous == current
+
+    return show_menu(context.spec.id, screen=item, message_id=message_id, reused=reused)
+
+
+async def open_profile(context: ButtonContext) -> UIResult:
+    return await _open_menu_item(context, "profile")
+
+
+async def open_kb(context: ButtonContext) -> UIResult:
+    return await _open_menu_item(context, "kb")
+
+
+async def open_photo(context: ButtonContext) -> UIResult:
+    return await _open_menu_item(context, "photo")
+
+
+async def open_music(context: ButtonContext) -> UIResult:
+    return await _open_menu_item(context, "music")
+
+
+async def open_video(context: ButtonContext) -> UIResult:
+    query = context.query
+    if query is not None:
+        with suppress(BadRequest):
+            await query.answer(cache_time=0)
+    return await _open_menu_item(context, "video")
+
+
+async def open_dialog(context: ButtonContext) -> UIResult:
+    return await _open_menu_item(context, "dialog")
+
+
+async def open_help(context: ButtonContext) -> UIResult:
+    bot_module = _bot()
+    await bot_module.help_command_entry(context.update, context.app_context)
+    return show_dialog(context.spec.id, "help", message_id=None)
+
+
+async def open_sora2(context: ButtonContext) -> UIResult:
+    handlers = _bot()
+    await handlers.sora2_open_cb(context.update, context.app_context)
+    return show_dialog(context.spec.id, "sora2", message_id=None)

--- a/ui/buttons/idempotency.py
+++ b/ui/buttons/idempotency.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from redis_utils import acquire_action_lock, release_action_lock
+
+from .results import UIResult, acknowledge
+from .types import ButtonContext, ButtonHandler
+
+
+_DEFAULT_TTL = 5
+
+
+def with_idempotency(handler: ButtonHandler, *, ttl: int = _DEFAULT_TTL) -> ButtonHandler:
+    """Wrap ``handler`` with a Redis-backed idempotency guard."""
+
+    async def wrapped(context: ButtonContext) -> UIResult:
+        owner = context.chat_id or context.user_id
+        if owner is None:
+            return await handler(context)
+
+        lock_key = f"ui:btn:{context.spec.id}:{owner}"
+        acquired = acquire_action_lock(owner, lock_key, ttl=ttl)
+        if not acquired:
+            return acknowledge(context.spec.id, message="duplicate_click")
+
+        try:
+            return await handler(context)
+        finally:
+            release_action_lock(owner, lock_key)
+
+    return wrapped

--- a/ui/buttons/registry.py
+++ b/ui/buttons/registry.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from .handlers import (
+    open_dialog,
+    open_help,
+    open_kb,
+    open_music,
+    open_photo,
+    open_profile,
+    open_sora2,
+    open_video,
+)
+from .types import ButtonId, ButtonSpec
+
+
+BUTTONS: Dict[ButtonId, ButtonSpec] = {
+    "profile": ButtonSpec(
+        id="profile",
+        title_i18n_key="button.profile",
+        access=("all",),
+        handler=open_profile,
+        open_telemetry_event="ui.button.open",
+    ),
+    "kb": ButtonSpec(
+        id="kb",
+        title_i18n_key="button.kb",
+        access=("all",),
+        handler=open_kb,
+        open_telemetry_event="ui.button.open",
+    ),
+    "photo": ButtonSpec(
+        id="photo",
+        title_i18n_key="button.photo",
+        access=("all",),
+        handler=open_photo,
+        open_telemetry_event="ui.button.open",
+    ),
+    "music": ButtonSpec(
+        id="music",
+        title_i18n_key="button.music",
+        access=("paid",),
+        handler=open_music,
+        open_telemetry_event="ui.button.open",
+    ),
+    "video": ButtonSpec(
+        id="video",
+        title_i18n_key="button.video",
+        access=("all",),
+        handler=open_video,
+        open_telemetry_event="ui.button.open",
+    ),
+    "dialog": ButtonSpec(
+        id="dialog",
+        title_i18n_key="button.dialog",
+        access=("all",),
+        handler=open_dialog,
+        open_telemetry_event="ui.button.open",
+    ),
+    "help": ButtonSpec(
+        id="help",
+        title_i18n_key="button.help",
+        access=("all",),
+        handler=open_help,
+        open_telemetry_event="ui.button.open",
+    ),
+    "sora2": ButtonSpec(
+        id="sora2",
+        title_i18n_key="button.sora2",
+        access=("paid",),
+        handler=open_sora2,
+        open_telemetry_event="ui.button.open",
+        feature_flag="FEATURE_SORA2_ENABLED",
+    ),
+}

--- a/ui/buttons/results.py
+++ b/ui/buttons/results.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Optional
+
+
+ResultKind = Literal["menu", "dialog", "error", "noop", "ack"]
+
+
+@dataclass(slots=True)
+class UIResult:
+    """Declarative description of what happened after a button click."""
+
+    kind: ResultKind
+    button_id: str
+    screen: Optional[str] = None
+    message: Optional[str] = None
+    details: dict[str, Any] = field(default_factory=dict)
+    changed: bool = True
+
+
+def show_menu(button_id: str, screen: str, *, message_id: Optional[int], reused: bool) -> UIResult:
+    return UIResult(
+        kind="menu",
+        button_id=button_id,
+        screen=screen,
+        details={"message_id": message_id, "reused": reused},
+        changed=not reused,
+    )
+
+
+def show_dialog(button_id: str, screen: str, *, message_id: Optional[int]) -> UIResult:
+    return UIResult(
+        kind="dialog",
+        button_id=button_id,
+        screen=screen,
+        details={"message_id": message_id},
+    )
+
+
+def show_error(button_id: str, message: str, *, error_kind: str) -> UIResult:
+    return UIResult(
+        kind="error",
+        button_id=button_id,
+        message=message,
+        details={"error_kind": error_kind},
+        changed=False,
+    )
+
+
+def noop(button_id: str) -> UIResult:
+    return UIResult(kind="noop", button_id=button_id, changed=False)
+
+
+def acknowledge(button_id: str, *, message: Optional[str] = None) -> UIResult:
+    return UIResult(kind="ack", button_id=button_id, message=message, changed=False)

--- a/ui/buttons/router.py
+++ b/ui/buttons/router.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from .errors import ButtonAccessDenied, ButtonFeatureDisabled, ButtonNotFound
+from .guards import guard_access, guard_feature, resolve_user_tier
+from .idempotency import with_idempotency
+from .results import UIResult, show_error
+from .telemetry import log_click, log_error, log_success, measure_latency
+from .types import ButtonContext, ButtonId, ButtonSpec
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ButtonRouter:
+    """Button dispatcher with access control and telemetry."""
+
+    registry: Mapping[ButtonId, ButtonSpec]
+
+    async def dispatch(
+        self,
+        button_id: ButtonId,
+        *,
+        update: Update,
+        ctx: ContextTypes.DEFAULT_TYPE,
+        request_id: Optional[str] = None,
+    ) -> UIResult:
+        try:
+            spec = self.registry[button_id]
+        except KeyError as exc:
+            log.error("ui.button.unknown", extra={"button": button_id})
+            raise ButtonNotFound(button_id) from exc
+
+        query = getattr(update, "callback_query", None)
+        chat = getattr(update, "effective_chat", None)
+        chat_id = getattr(chat, "id", None)
+        if chat_id is None and query is not None:
+            message = getattr(query, "message", None)
+            chat_id = getattr(getattr(message, "chat", None), "id", None)
+        user = getattr(update, "effective_user", None)
+        user_id = getattr(user, "id", None)
+
+        req_id = request_id or uuid.uuid4().hex
+        context = ButtonContext(
+            update=update,
+            app_context=ctx,
+            spec=spec,
+            request_id=req_id,
+            query=query,
+            chat_id=chat_id,
+            user_id=user_id,
+        )
+
+        user_tier = resolve_user_tier(ctx, user_id)
+        log_click(spec.id, user_tier)
+
+        try:
+            guard_feature(spec, ctx)
+            guard_access(spec, ctx, user_id)
+        except ButtonFeatureDisabled:
+            await context.answer("Скоро", show_alert=True)
+            log_error(spec.id, "feature_disabled")
+            return show_error(spec.id, "feature_disabled", error_kind="feature_disabled")
+        except ButtonAccessDenied:
+            await context.answer("Недоступно", show_alert=True)
+            log_error(spec.id, "access_denied")
+            return show_error(spec.id, "access_denied", error_kind="access_denied")
+
+        handler = spec.handler
+        wrapped_handler = with_idempotency(handler)
+
+        try:
+            with measure_latency(spec.id):
+                result = await wrapped_handler(context)
+        except Exception as exc:  # pragma: no cover - defensive
+            log.exception(
+                "ui.button.failed",
+                extra={"button": spec.id, "ctx": context.as_dict()},
+            )
+            await context.answer("Что-то пошло не так", show_alert=True)
+            log_error(spec.id, "exception")
+            return show_error(spec.id, "exception", error_kind=exc.__class__.__name__)
+
+        if result.kind == "error":
+            error_kind = result.details.get("error_kind", "handler")
+            log_error(spec.id, str(error_kind))
+        else:
+            log_success(spec.id)
+
+        return result
+
+
+_DEFAULT_ROUTER: Optional[ButtonRouter] = None
+
+
+def _get_default_router() -> ButtonRouter:
+    global _DEFAULT_ROUTER
+    if _DEFAULT_ROUTER is None:
+        from .registry import BUTTONS
+
+        _DEFAULT_ROUTER = ButtonRouter(registry=BUTTONS)
+    return _DEFAULT_ROUTER
+
+
+async def dispatch(
+    button_id: ButtonId,
+    *,
+    update: Update,
+    ctx: ContextTypes.DEFAULT_TYPE,
+    request_id: Optional[str] = None,
+) -> UIResult:
+    router = _get_default_router()
+    return await router.dispatch(button_id, update=update, ctx=ctx, request_id=request_id)

--- a/ui/buttons/telemetry.py
+++ b/ui/buttons/telemetry.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from typing import Iterator
+
+from prometheus_client import Counter, Histogram
+
+
+_click_total = Counter(
+    "ui_button_click_total",
+    "Total number of button clicks grouped by id and tier.",
+    labelnames=("button_id", "user_tier"),
+)
+_success_total = Counter(
+    "ui_button_handler_success_total",
+    "Number of successful button handler executions.",
+    labelnames=("button_id",),
+)
+_error_total = Counter(
+    "ui_button_handler_error_total",
+    "Number of button handler errors grouped by kind.",
+    labelnames=("button_id", "error_kind"),
+)
+_latency_seconds = Histogram(
+    "ui_button_latency_seconds",
+    "Execution latency of button handlers in seconds.",
+    labelnames=("button_id",),
+)
+
+
+def log_click(button_id: str, user_tier: str) -> None:
+    _click_total.labels(button_id=button_id, user_tier=user_tier).inc()
+
+
+def log_success(button_id: str) -> None:
+    _success_total.labels(button_id=button_id).inc()
+
+
+def log_error(button_id: str, error_kind: str) -> None:
+    _error_total.labels(button_id=button_id, error_kind=error_kind).inc()
+
+
+@contextmanager
+def measure_latency(button_id: str) -> Iterator[None]:
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        duration = max(time.perf_counter() - start, 0.0)
+        _latency_seconds.labels(button_id=button_id).observe(duration)

--- a/ui/buttons/types.py
+++ b/ui/buttons/types.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Literal, Optional, Protocol, Sequence
+
+from telegram import CallbackQuery, Update
+from telegram.ext import ContextTypes
+
+from .results import UIResult
+
+ButtonId = Literal[
+    "profile",
+    "music",
+    "photo",
+    "video",
+    "sora2",
+    "kb",
+    "help",
+    "dialog",
+]
+
+AccessLevel = Literal["all", "admin", "paid"]
+
+
+class ButtonHandler(Protocol):
+    """Callable protocol for button handlers."""
+
+    async def __call__(self, context: "ButtonContext") -> UIResult:  # pragma: no cover - protocol
+        ...
+
+
+@dataclass(slots=True)
+class ButtonSpec:
+    """Metadata that describes how a button behaves."""
+
+    id: ButtonId
+    title_i18n_key: str
+    access: Sequence[AccessLevel]
+    handler: ButtonHandler
+    open_telemetry_event: str
+    feature_flag: Optional[str] = None
+
+
+@dataclass(slots=True)
+class ButtonContext:
+    """Execution context available to button handlers."""
+
+    update: Update
+    app_context: ContextTypes.DEFAULT_TYPE
+    spec: ButtonSpec
+    request_id: str
+    query: Optional[CallbackQuery]
+    chat_id: Optional[int]
+    user_id: Optional[int]
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a structured representation for logging/debugging."""
+
+        return {
+            "button_id": self.spec.id,
+            "chat_id": self.chat_id,
+            "user_id": self.user_id,
+            "request_id": self.request_id,
+        }
+
+    async def answer(self, text: str, *, show_alert: bool = False) -> None:
+        """Answer the callback query if available."""
+
+        if self.query is None:
+            return
+        try:
+            await self.query.answer(text=text, show_alert=show_alert)
+        except Exception:  # pragma: no cover - network errors are ignored
+            pass
+
+
+ButtonFactory = Callable[[ButtonSpec], ButtonHandler]


### PR DESCRIPTION
## Summary
- add a ui.buttons package with a single registry, router, telemetry, and idempotency helpers
- update existing menu callbacks to dispatch through the new button router and document the workflow
- cover the registry, router behaviour, and updated callbacks with focused tests

## Testing
- pytest tests/test_button_router.py tests/test_main_menu_navigation.py

------
https://chatgpt.com/codex/tasks/task_e_68f65bdbfb948322be836d2d404b2918