### PR TITLE
Improve profile callbacks logging and harden Suno delivery

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -503,11 +503,13 @@ from metrics import (
     suno_notify_ok,
     suno_notify_total,
     suno_refund_total,
+    suno_delivery_total,
     suno_poll_status_total,
     suno_ready_latency_seconds,
     suno_late_delivery_total,
     suno_timeout_total,
     suno_refund_trigger_total,
+    suno_refund_outcome_total,
     chat_messages_total,
     chat_latency_ms,
     chat_context_tokens,
@@ -11962,6 +11964,7 @@ async def _poll_suno_and_send(
             user_message=refund_text,
         )
         await _clear_wait()
+        suno_refund_outcome_total.labels(result="executed", **_METRIC_LABELS).inc()
 
     async def _clear_wait() -> None:
         try:
@@ -11986,10 +11989,14 @@ async def _poll_suno_and_send(
             delivery_via=via,
             tracks=prepared_tracks,
         )
-        if not delivered:
-            log.warning("[SUNO] %s delivery skipped | task_id=%s", via, task_id)
-            return False
-        return True
+        if delivered:
+            outcome = "late" if via not in {"poll", "webhook"} else "sent"
+            suno_delivery_total.labels(result=outcome, **_METRIC_LABELS).inc()
+            return True
+
+        log.warning("[SUNO] %s delivery skipped | task_id=%s", via, task_id)
+        suno_delivery_total.labels(result="failed", **_METRIC_LABELS).inc()
+        return False
 
     def _schedule_failure_follow_up(
         *,
@@ -12047,6 +12054,7 @@ async def _poll_suno_and_send(
             final=False,
             refunded=False,
         )
+        suno_refund_outcome_total.labels(result="scheduled", **_METRIC_LABELS).inc()
 
         async def _follow_up_failure() -> None:
             try:
@@ -12073,6 +12081,7 @@ async def _poll_suno_and_send(
                         SUNO_JOB_STORE.mark_delivered(
                             task_id, delivery_key=f"suno:{task_id}"
                         )
+                        suno_refund_outcome_total.labels(result="canceled", **_METRIC_LABELS).inc()
                         await _clear_wait()
                         return
                 if poll_result.state == "retry" or poll_result.state == "pending":
@@ -12144,6 +12153,7 @@ async def _poll_suno_and_send(
         pending = _SUNO_FAILURE_FOLLOWUPS.pop(task_id, None)
         if pending and not pending.done():
             pending.cancel()
+            suno_refund_outcome_total.labels(result="canceled", **_METRIC_LABELS).inc()
         if rds is not None:
             try:
                 rds.delete(_suno_failure_followup_key(task_id))
@@ -12384,6 +12394,15 @@ async def _poll_suno_and_send(
         if delivered:
             SUNO_JOB_STORE.mark_delivered(task_id, delivery_key=f"suno:{task_id}")
             await _clear_wait()
+            return
+
+        failure_message = _suno_error_message(None, "delivery failed")
+        _schedule_failure_follow_up(
+            message=failure_message,
+            reason="suno:refund:delivery_failed",
+            payload=details,
+            stage="delivery",
+        )
         return
 
     except asyncio.CancelledError:
@@ -22015,6 +22034,15 @@ def register_handlers(application: Any) -> None:
             application.add_handler(CallbackQueryHandler(callback))
         else:
             application.add_handler(CallbackQueryHandler(callback, pattern=pattern))
+
+    try:
+        from ui.buttons.router import handle_unmatched_callback  # local import to avoid cycles
+
+        unmatched_handler = CallbackQueryHandler(handle_unmatched_callback, pattern=r".*")
+        unmatched_handler.block = False
+        application.add_handler(unmatched_handler, group=1)
+    except Exception as exc:  # pragma: no cover - defensive registration
+        log.warning("handlers.unmatched_registration_failed", extra={"error": str(exc)})
 
     application.add_handler(PreCheckoutQueryHandler(precheckout_callback))
     application.add_handler(MessageHandler(filters.SUCCESSFUL_PAYMENT, successful_payment_handler))

--- a/keyboards.py
+++ b/keyboards.py
@@ -1,3 +1,4 @@
+import logging
 from functools import lru_cache
 import re
 from typing import Dict, Iterable, List, Optional, Tuple
@@ -11,6 +12,9 @@ from telegram import (
 )
 
 from utils.text_normalizer import normalize_btn_text
+
+
+log = logging.getLogger(__name__)
 
 
 
@@ -285,6 +289,7 @@ def _row(*buttons: InlineKeyboardButton) -> list[list[InlineKeyboardButton]]:
 def kb_btn(text: str, callback: str) -> InlineKeyboardButton:
     """Единая фабрика кнопок для инлайн-клавиатуры."""
 
+    log.debug('[UI] render button %s data="%s"', text, callback)
     return InlineKeyboardButton(text=text, callback_data=callback)
 
 

--- a/metrics.py
+++ b/metrics.py
@@ -86,6 +86,13 @@ ui_callback_dedup_total = Counter(
     registry=REGISTRY,
 )
 
+ui_callback_unmatched_total = Counter(
+    "ui_callback_unmatched_total",
+    "Callback queries that did not match any UI handler grouped by source.",
+    labelnames=("source", "env", "service"),
+    registry=REGISTRY,
+)
+
 faq_root_views_total = Counter(
     "faq_root_views_total",
     "Total number of FAQ root menu views",
@@ -231,6 +238,13 @@ suno_late_delivery_total = Counter(
     registry=REGISTRY,
 )
 
+suno_delivery_total = Counter(
+    "suno_delivery_total",
+    "Suno delivery attempts grouped by result",
+    labelnames=("result", "env", "service"),
+    registry=REGISTRY,
+)
+
 suno_timeout_total = Counter(
     "suno_timeout_total",
     "Suno polling timeouts grouped by stage",
@@ -242,6 +256,13 @@ suno_refund_trigger_total = Counter(
     "suno_refund_trigger_total",
     "Suno refund triggers grouped by stage",
     labelnames=("stage", "env", "service"),
+    registry=REGISTRY,
+)
+
+suno_refund_outcome_total = Counter(
+    "suno_refund_outcome_total",
+    "Suno refund outcomes grouped by result",
+    labelnames=("result", "env", "service"),
     registry=REGISTRY,
 )
 

--- a/tests/test_button_registry_completeness.py
+++ b/tests/test_button_registry_completeness.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from ui.buttons import registry as buttons_registry  # noqa: E402
+
+
+def test_all_keyboard_actions_in_registry():
+    buttons_registry.assert_registry_matches_keyboard()
+
+
+def test_home_button_callbacks_match_ids():
+    mappings = buttons_registry.iter_home_button_mappings()
+    assert mappings, "expected home button mappings"
+    for button_id, callback in mappings.items():
+        assert button_id in buttons_registry.BUTTONS
+        assert button_id in callback
+        assert isinstance(callback, str)

--- a/tests/test_button_router.py
+++ b/tests/test_button_router.py
@@ -8,7 +8,7 @@ from ui.buttons import BUTTONS
 from ui.buttons.idempotency import _RECENT_CLICKS
 from ui.buttons import idempotency as idemp
 from ui.buttons.results import UIResult, acknowledge
-from ui.buttons.router import ButtonRouter
+from ui.buttons.router import ButtonRouter, handle_unmatched_callback
 from ui.buttons.types import ButtonSpec
 
 
@@ -242,3 +242,27 @@ def test_debounce_same_button_quickly(monkeypatch):
     assert first.kind == "menu"
     assert second == acknowledge("test", message="duplicate_click")
     assert len(executions) == 1
+
+
+def test_unmatched_callback_logged_but_not_crash(caplog):
+    async def answer(**kwargs):
+        setattr(query, "answered", True)
+        return None
+
+    message = SimpleNamespace(chat=SimpleNamespace(id=55), chat_id=55, message_id=777)
+    query = SimpleNamespace(
+        data="menu:missing", answer=answer, message=message, from_user=SimpleNamespace(id=42)
+    )
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_chat=message.chat,
+        effective_user=query.from_user,
+    )
+
+    ctx = SimpleNamespace()
+
+    with caplog.at_level("INFO"):
+        asyncio.run(handle_unmatched_callback(update, ctx))
+
+    assert getattr(query, "answered", False) is True
+    assert any(record.message == "ui.callback.unmatched" for record in caplog.records)

--- a/tests/test_main_menu_navigation.py
+++ b/tests/test_main_menu_navigation.py
@@ -10,6 +10,18 @@ if str(ROOT) not in sys.path:
 from tests.suno_test_utils import FakeBot, bot_module
 from telegram_utils import safe_answer
 import handlers.knowledge_base as kb_module  # noqa: E402
+import keyboards as keyboards_module  # noqa: E402
+
+
+def test_profile_button_present_with_correct_data():
+    markup = keyboards_module.kb_main()
+    profile_callbacks = [
+        button.callback_data
+        for row in markup.inline_keyboard
+        for button in row
+        if getattr(button, "callback_data", None) == keyboards_module.HOME_CB_PROFILE
+    ]
+    assert profile_callbacks == [keyboards_module.HOME_CB_PROFILE]
 
 
 def test_menu_callbacks_route_ok(monkeypatch):

--- a/ui/buttons/idempotency.py
+++ b/ui/buttons/idempotency.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import threading
 import time
@@ -11,6 +12,8 @@ from .results import UIResult, acknowledge
 from .types import ButtonContext, ButtonHandler
 from runtime_metrics import increment_ui_callback_counter
 
+
+log = logging.getLogger(__name__)
 
 _DEFAULT_TTL = max(int(os.getenv("UI_BUTTONS_LOCK_TTL", "1") or "1"), 1)
 _DEBOUNCE_MS = float(os.getenv("UI_BUTTONS_DEBOUNCE_WINDOW_MS", "450") or "450")
@@ -37,6 +40,13 @@ def should_process(user_id: Optional[int], callback_data: Optional[str]) -> bool
     with _DEBOUNCE_LOCK:
         expires = _RECENT_CLICKS.get(key, 0.0)
         if expires and expires > current:
+            log.debug(
+                "ui.click.coalesced",
+                extra={
+                    "user_id": int(user_id),
+                    "callback_data": normalized,
+                },
+            )
             return False
         _RECENT_CLICKS[key] = current + _DEBOUNCE_WINDOW
 

--- a/ui/buttons/registry.py
+++ b/ui/buttons/registry.py
@@ -2,6 +2,15 @@ from __future__ import annotations
 
 from typing import Dict
 
+from keyboards import (
+    HOME_CB_DIALOG,
+    HOME_CB_KB,
+    HOME_CB_MUSIC,
+    HOME_CB_PHOTO,
+    HOME_CB_PROFILE,
+    HOME_CB_VIDEO,
+)
+
 from .handlers import (
     open_dialog,
     open_help,
@@ -74,3 +83,46 @@ BUTTONS: Dict[ButtonId, ButtonSpec] = {
         feature_flag="FEATURE_SORA2_ENABLED",
     ),
 }
+
+
+_HOME_BUTTON_CALLBACKS: Dict[str, str] = {
+    "profile": HOME_CB_PROFILE,
+    "kb": HOME_CB_KB,
+    "photo": HOME_CB_PHOTO,
+    "music": HOME_CB_MUSIC,
+    "video": HOME_CB_VIDEO,
+    "dialog": HOME_CB_DIALOG,
+}
+
+
+def iter_home_button_mappings() -> Dict[str, str]:
+    """Return the mapping of registry ids to home keyboard payloads."""
+
+    return dict(_HOME_BUTTON_CALLBACKS)
+
+
+def registry_keyboard_inconsistencies() -> Dict[str, str]:
+    """Return buttons whose keyboard payload does not align with the registry."""
+
+    inconsistencies: Dict[str, str] = {}
+    for button_id, callback in _HOME_BUTTON_CALLBACKS.items():
+        spec = BUTTONS.get(button_id)
+        if spec is None:
+            inconsistencies[button_id] = "<missing-spec>"
+            continue
+        payload = str(callback)
+        if not payload:
+            inconsistencies[button_id] = "<empty>"
+            continue
+        if button_id not in payload:
+            inconsistencies[button_id] = payload
+    return inconsistencies
+
+
+def assert_registry_matches_keyboard() -> None:
+    mismatches = registry_keyboard_inconsistencies()
+    if mismatches:
+        raise AssertionError(
+            "Keyboard callback payloads do not match registry ids: "
+            + ", ".join(f"{key} -> {value}" for key, value in sorted(mismatches.items()))
+        )

--- a/ui/buttons/router.py
+++ b/ui/buttons/router.py
@@ -6,7 +6,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Mapping, Optional
 
-from metrics import ui_callback_dedup_total
+from metrics import ui_callback_dedup_total, ui_callback_unmatched_total
 from runtime_metrics import increment_ui_callback_counter
 from telegram import Update
 from telegram.ext import ContextTypes
@@ -67,6 +67,11 @@ class ButtonRouter:
         if query is not None:
             ack_result = await safe_answer(query, cache_time=0)
             context.mark_acknowledged(ack_result)
+            try:
+                setattr(update, "_ui_button_handled", True)
+                setattr(query, "_ui_button_handled", True)
+            except Exception:  # pragma: no cover - best effort attribute assignment
+                pass
 
             callback_data = getattr(query, "data", None)
             if not should_process(user_id, callback_data):
@@ -144,3 +149,50 @@ async def dispatch(
 ) -> UIResult:
     router = _get_default_router()
     return await router.dispatch(button_id, update=update, ctx=ctx, request_id=request_id)
+
+
+async def handle_unmatched_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    del ctx  # context is unused but part of PTB signature
+
+    query = getattr(update, "callback_query", None)
+    if query is None:
+        return
+
+    if getattr(query, "_ui_button_handled", False) or getattr(update, "_ui_button_handled", False):
+        return
+
+    data = getattr(query, "data", None)
+    if not data:
+        return
+
+    if not isinstance(data, str):
+        return
+
+    if not (
+        data.startswith("menu:")
+        or data.startswith("hub:open:")
+        or data.startswith("kb_open")
+        or data.startswith("dialog:")
+    ):
+        return
+
+    user = getattr(update, "effective_user", None)
+    message = getattr(query, "message", None)
+    message_id = getattr(message, "message_id", None)
+    user_id = getattr(user, "id", None)
+
+    ack_result = await safe_answer(query, cache_time=0)
+
+    log.info(
+        "ui.callback.unmatched",
+        extra={
+            "data": data,
+            "user_id": user_id,
+            "message_id": message_id,
+            "ack_result": ack_result,
+        },
+    )
+    try:
+        ui_callback_unmatched_total.labels(source="telegram", **_BOT_LABELS).inc()
+    except Exception:  # pragma: no cover - defensive metrics guard
+        log.debug("ui.callback.unmatched.metric_failed", exc_info=True)


### PR DESCRIPTION
## Summary
- add telemetry for unmatched home callbacks, tighten debouncing logs, and validate registry mappings with dedicated tests
- surface keyboard render diagnostics for the profile button and ensure it is present via new navigation coverage
- harden Suno delivery by tracking delivery/refund outcomes, retrying failed deliveries, and exposing the new counters

## Testing
- pytest tests/test_button_registry_completeness.py -q
- pytest tests/test_button_router.py::test_unmatched_callback_logged_but_not_crash -q
- pytest tests/test_main_menu_navigation.py::test_profile_button_present_with_correct_data -q
- pytest tests/test_suno_poll_pending.py::test_poll_404_is_pending -q


------
https://chatgpt.com/codex/tasks/task_e_68f6bad358c8832284303abefb70d04a