### PR TITLE
Force profile UI refresh and handle legacy callbacks

### DIFF
--- a/handlers/profile.py
+++ b/handlers/profile.py
@@ -26,10 +26,12 @@ from utils.input_state import (
     WaitInputState,
     WaitKind,
     clear_wait_state,
+    force_clear_user_state,
     get_wait_state,
     input_state,
     set_wait_state,
 )
+from metrics import profile_open_total, profile_render_ms
 import settings as app_settings
 log = logging.getLogger(__name__)
 
@@ -787,6 +789,7 @@ async def open_profile(
     *,
     source: str,
     suppress_nav: bool = True,
+    force_refresh: bool = False,
 ) -> None:
     if _simple_profile_enabled():
         from . import profile_simple
@@ -818,18 +821,43 @@ async def open_profile(
             chat_data[NAV_UNTIL] = max(previous_deadline, now + 2.0)
             chat_data["suppress_dialog_notice"] = True
 
-        result = await open_profile_card(
-            update,
-            ctx,
-            source=source,
-            suppress_nav=suppress_nav,
-        )
-
-        reused = bool(result.reused) if isinstance(result, OpenedProfile) else False
-        log.debug(
-            "profile.open",
-            extra={"source": source, "reused_msg": reused},
-        )
+        started = time.perf_counter()
+        metrics_result = "ok"
+        reused = False
+        try:
+            result = await open_profile_card(
+                update,
+                ctx,
+                source=source,
+                suppress_nav=suppress_nav,
+                force_refresh=force_refresh,
+            )
+            reused = bool(result.reused) if isinstance(result, OpenedProfile) else False
+            log.debug(
+                "profile.open",
+                extra={"source": source, "reused_msg": reused, "force_refresh": force_refresh},
+            )
+        except Exception:
+            metrics_result = "error"
+            raise
+        finally:
+            elapsed_ms = max((time.perf_counter() - started) * 1000.0, 0.0)
+            try:
+                profile_render_ms.labels(
+                    force_refresh="true" if force_refresh else "false",
+                    source=(source or "unknown").strip() or "unknown",
+                ).observe(elapsed_ms)
+            except Exception:
+                log.debug("profile.metrics.render_failed", exc_info=True)
+            try:
+                profile_open_total.labels(
+                    force_refresh="true" if force_refresh else "false",
+                    reused="true" if reused else "false",
+                    source=(source or "unknown").strip() or "unknown",
+                    result=metrics_result,
+                ).inc()
+            except Exception:
+                log.debug("profile.metrics.open_failed", exc_info=True)
     finally:
         _clear_nav_event(chat_data, flag, ctx, previous_nav)
 
@@ -841,6 +869,7 @@ async def open(
     *,
     suppress_nav: bool = True,
     reuse: bool = True,
+    force_refresh: bool | None = None,
 ) -> None:
     payload = payload or {}
     source = str(payload.get("source", "button") or "button")
@@ -850,6 +879,16 @@ async def open(
     reuse_override = payload.get("reuse")
     if reuse_override is not None:
         reuse = bool(reuse_override)
+    if force_refresh is None:
+        default_force = source in {"button", "quick", "menu"}
+        force_refresh = bool(payload.get("force_refresh", default_force))
+    else:
+        force_refresh = bool(force_refresh)
+    if force_refresh:
+        reuse = False
+
+    if source in {"button", "quick"} and suppress_override is None:
+        suppress_nav = False
 
     chat = getattr(update, "effective_chat", None)
     user = getattr(update, "effective_user", None)
@@ -857,18 +896,35 @@ async def open(
     user_id = getattr(user, "id", None)
 
     log.info(
-        "profile.open(chat_id=%s, user_id=%s, suppress_nav=%s)",
+        "profile.open(chat_id=%s, user_id=%s, suppress_nav=%s, force_refresh=%s)",
         chat_id,
         user_id,
         suppress_nav,
+        force_refresh,
     )
+
+    if user_id is not None:
+        try:
+            await force_clear_user_state(user_id, reason="profile_open")
+        except Exception:
+            log.debug(
+                "profile.force_clear_failed",
+                exc_info=True,
+                extra={"user_id": user_id},
+            )
 
     if not reuse:
         chat_data = _chat_data(ctx)
         if isinstance(chat_data, MutableMapping):
             chat_data.pop(PROFILE_MSG_ID, None)
 
-    await open_profile(update, ctx, source=source, suppress_nav=suppress_nav)
+    await open_profile(
+        update,
+        ctx,
+        source=source,
+        suppress_nav=suppress_nav,
+        force_refresh=bool(force_refresh),
+    )
 
 
 async def _open_profile_card_impl(
@@ -879,6 +935,7 @@ async def _open_profile_card_impl(
     ctx: ContextTypes.DEFAULT_TYPE,
     suppress_nav: bool = True,
     source: str = "menu",
+    force_refresh: bool = False,
 ) -> OpenedProfile:
     log.debug(
         "profile.open(chat_id=%s, user_id=%s, source=%s, suppress_nav=%s)",
@@ -908,7 +965,7 @@ async def _open_profile_card_impl(
 
     chat_data = _chat_data(ctx)
     previous_mid = _get_profile_msg_id(chat_data)
-    reuse_existing = previous_mid is not None
+    reuse_existing = previous_mid is not None and not force_refresh
 
     if isinstance(chat_data, MutableMapping):
         chat_data["nav_event"] = True
@@ -958,6 +1015,7 @@ async def open_profile_card(
     *,
     source: str = "menu",
     suppress_nav: bool = True,
+    force_refresh: bool = False,
 ) -> OpenedProfile:
     chat = getattr(update, "effective_chat", None)
     message = getattr(update, "effective_message", None)
@@ -977,6 +1035,7 @@ async def open_profile_card(
         ctx=ctx,
         suppress_nav=suppress_nav,
         source=source,
+        force_refresh=force_refresh,
     )
 
 

--- a/helpers/debounce.py
+++ b/helpers/debounce.py
@@ -4,7 +4,7 @@ import time
 from threading import RLock
 from typing import Hashable
 
-__all__ = ["debounce"]
+__all__ = ["debounce", "reset"]
 
 
 _last_clicks: dict[tuple[Hashable, Hashable], float] = {}
@@ -28,3 +28,21 @@ def debounce(user_id: Hashable, action: Hashable, *, delay: float = 1.0) -> bool
             return False
         _last_clicks[key] = now
     return True
+
+
+def reset(user_id: Hashable | None = None, action: Hashable | None = None) -> None:
+    """Clear stored debounce entries matching ``user_id``/``action`` filters."""
+
+    with _lock:
+        if user_id is None and action is None:
+            _last_clicks.clear()
+            return
+
+        keys = [
+            key
+            for key in _last_clicks
+            if (user_id is None or key[0] == user_id)
+            and (action is None or key[1] == action)
+        ]
+        for key in keys:
+            _last_clicks.pop(key, None)

--- a/keyboards.py
+++ b/keyboards.py
@@ -472,7 +472,7 @@ def menu_main_like() -> InlineKeyboardMarkup:
     return build_menu(
         [
             [
-                (f"{EMOJI['profile']} Профиль", "profile"),
+                (f"{EMOJI['profile']} Профиль", "btn:profile|src=hub"),
                 ("📚 База знаний", "kb_docs"),
             ],
             [
@@ -497,7 +497,7 @@ def menu_bottom_unified() -> InlineKeyboardMarkup:
             [(f"{EMOJI['music']} Генерация музыки", "nav_music")],
             [(f"{EMOJI['prompt']} Prompt-Master", "nav_prompt")],
             [(f"{EMOJI['chat']} Обычный чат", "nav_chat")],
-            [(f"{EMOJI['profile']} Профиль", "profile")],
+            [(f"{EMOJI['profile']} Профиль", "btn:profile|src=nav")],
         ]
     )
 

--- a/metrics.py
+++ b/metrics.py
@@ -126,7 +126,36 @@ ui_callback_dedup_total = Counter(
 ui_callback_unmatched_total = Counter(
     "ui_callback_unmatched_total",
     "Callback queries that did not match any UI handler grouped by source.",
-    labelnames=("source", "env", "service"),
+    labelnames=("source", "legacy", "env", "service"),
+    registry=REGISTRY,
+)
+
+ui_callback_legacy_forwarded_total = Counter(
+    "ui_callback_legacy_forwarded_total",
+    "Legacy callback payloads forwarded to registered actions.",
+    labelnames=("target", "env", "service"),
+    registry=REGISTRY,
+)
+
+profile_open_total = Counter(
+    "profile_open_total",
+    "Profile open attempts grouped by force refresh, reuse decision and result.",
+    labelnames=("force_refresh", "reused", "source", "result", "env", "service"),
+    registry=REGISTRY,
+)
+
+profile_render_ms = Histogram(
+    "profile_render_ms",
+    "Latency of rendering the profile screen in milliseconds.",
+    labelnames=("force_refresh", "source", "env", "service"),
+    registry=REGISTRY,
+    buckets=(25, 50, 100, 150, 200, 300, 400, 600, 1000, 1500),
+)
+
+ui_wait_clear_all_total = Counter(
+    "ui_wait_clear_all_total",
+    "Forced wait/input state clears grouped by reason.",
+    labelnames=("reason", "env", "service"),
     registry=REGISTRY,
 )
 

--- a/tests/test_profile_clears_waits.py
+++ b/tests/test_profile_clears_waits.py
@@ -1,0 +1,63 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import utils.input_state as input_state
+from helpers import debounce as debounce_helper
+import redis_utils
+
+
+def test_waits_are_cleared_on_profile_open(monkeypatch):
+    wait_calls: list[tuple[str, int, str]] = []
+
+    def fake_clear_wait_state(user_id: int, *, reason: str = "manual") -> None:
+        wait_calls.append(("wait_state", int(user_id), reason))
+
+    registry_calls: list[tuple[int, str]] = []
+
+    class RegistryStub:
+        def clear(self, chat_id: int, *, reason: str = "manual") -> None:
+            registry_calls.append((int(chat_id), reason))
+
+    release_calls: list[tuple[int, str]] = []
+
+    def fake_release_user_lock(user_id: int, key: str) -> None:
+        release_calls.append((int(user_id), key))
+
+    mode_calls: list[int] = []
+
+    async def fake_clear_mode_state(user_id: int) -> None:
+        mode_calls.append(int(user_id))
+
+    debounce_calls: list[int] = []
+
+    def fake_debounce_reset(user_id: int) -> None:
+        debounce_calls.append(int(user_id))
+
+    metric_calls: list[tuple[str, dict | None]] = []
+
+    def fake_metrics_inc(metric_name: str, *, value: float = 1.0, tags=None, service: str = "bot") -> None:
+        metric_calls.append((metric_name, dict(tags or {})))
+
+    monkeypatch.setattr(input_state, "clear_wait_state", fake_clear_wait_state)
+    monkeypatch.setattr(input_state, "input_state", RegistryStub())
+    monkeypatch.setattr(redis_utils, "release_user_lock", fake_release_user_lock)
+    monkeypatch.setattr(redis_utils, "clear_mode_state", fake_clear_mode_state)
+    monkeypatch.setattr(debounce_helper, "reset", fake_debounce_reset)
+    monkeypatch.setattr(input_state, "metrics_inc", fake_metrics_inc)
+
+    asyncio.run(input_state.force_clear_user_state(404, reason="profile_open"))
+
+    assert wait_calls == [("wait_state", 404, "profile_open")]
+    assert registry_calls == [(404, "profile_open")]
+    assert mode_calls == [404]
+    assert debounce_calls == [404]
+    assert metric_calls == [("ui_wait_clear_all_total", {"reason": "profile_open"})]
+    released_keys = {key for _, key in release_calls}
+    assert released_keys == {"video_menu", "reply-nav", "dialog", "kb", "mode_reset"}

--- a/tests/test_profile_debounce.py
+++ b/tests/test_profile_debounce.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import ui.buttons.idempotency as idempotency
+
+
+def test_profile_debounce_window(monkeypatch):
+    idempotency._RECENT_CLICKS.clear()
+    times = iter([0.0, 0.1, 0.31])
+
+    def fake_now():
+        return next(times)
+
+    monkeypatch.setattr(idempotency, "_now", fake_now)
+
+    assert idempotency.should_process(42, "btn:profile|src=video") is True
+    assert idempotency.should_process(42, "btn:profile|src=hub") is False
+    assert idempotency.should_process(42, "btn:profile") is True

--- a/tests/test_profile_force_refresh.py
+++ b/tests/test_profile_force_refresh.py
@@ -1,0 +1,58 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import bot as bot_module
+import handlers.profile as profile_handlers
+from tests.test_profile_views import DummyBot, _make_ctx
+
+
+def test_profile_button_always_rerenders(monkeypatch):
+    ctx = _make_ctx(DummyBot())
+    ctx.chat_data[profile_handlers.PROFILE_MSG_ID] = 31345
+
+    force_clear_calls: list[tuple[int, str]] = []
+
+    async def fake_force_clear(user_id, *, reason="profile_open"):
+        force_clear_calls.append((int(user_id), reason))
+
+    monkeypatch.setattr(profile_handlers, "force_clear_user_state", fake_force_clear)
+
+    open_calls: list[dict[str, object]] = []
+
+    async def fake_open_profile_card(
+        update,
+        ctx,
+        *,
+        edit: bool = True,
+        suppress_nav: bool = True,
+        force_new: bool = False,
+    ) -> int:
+        open_calls.append(
+            {"edit": edit, "force_new": force_new, "suppress_nav": suppress_nav}
+        )
+        return 777
+
+    monkeypatch.setattr(bot_module, "open_profile_card", fake_open_profile_card)
+
+    update = SimpleNamespace(
+        effective_chat=SimpleNamespace(id=100),
+        effective_message=SimpleNamespace(chat_id=100),
+        effective_user=SimpleNamespace(id=555),
+    )
+
+    async def scenario() -> None:
+        await profile_handlers.open(update, ctx, payload={"source": "button"})
+
+    asyncio.run(scenario())
+
+    assert force_clear_calls == [(555, "profile_open")]
+    assert open_calls == [{"edit": False, "force_new": True, "suppress_nav": False}]
+    assert ctx.chat_data.get(profile_handlers.PROFILE_MSG_ID) == 777

--- a/tests/test_router_ack_timing.py
+++ b/tests/test_router_ack_timing.py
@@ -1,0 +1,38 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import ui.buttons.router as router
+
+
+def test_ack_precedes_dispatch(monkeypatch):
+    order: list[str] = []
+
+    async def fake_safe_answer(query, cache_time=0):
+        order.append("ack")
+        return "ok"
+
+    async def fake_dispatch(action, update, ctx, *, raw_data, payload=None, legacy=False):
+        order.append("dispatch")
+
+    monkeypatch.setattr(router, "safe_answer", fake_safe_answer)
+    monkeypatch.setattr(router, "dispatch_via_registry", fake_dispatch)
+
+    query = SimpleNamespace(data="btn:profile", _ui_button_handled=False)
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_chat=SimpleNamespace(id=1),
+        effective_user=SimpleNamespace(id=2),
+    )
+    ctx = SimpleNamespace()
+
+    asyncio.run(router.on_callback(update, ctx))
+
+    assert order[:2] == ["ack", "dispatch"]

--- a/tests/test_router_legacy_bridge.py
+++ b/tests/test_router_legacy_bridge.py
@@ -1,0 +1,71 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import ui.buttons.router as router
+
+
+class _DummyCounter:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def labels(self, **labels):
+        self.calls.append(labels)
+        return self
+
+    def inc(self):
+        return None
+
+
+@pytest.mark.parametrize(
+    "raw,expected_source",
+    [
+        ("profile", "button"),
+        ("profile.open", "button"),
+        ("open:profile", "menu"),
+        ("quick:profile", "quick"),
+    ],
+)
+def test_legacy_payloads_route_to_profile(raw, expected_source, monkeypatch):
+    ack_calls: list[int] = []
+
+    async def fake_safe_answer(query, cache_time=0):
+        ack_calls.append(cache_time)
+        return "ok"
+
+    dispatched: list[tuple] = []
+
+    async def fake_dispatch(action, update, ctx, *, raw_data, payload=None, legacy=False):
+        dispatched.append((action, raw_data, payload, legacy))
+
+    legacy_counter = _DummyCounter()
+
+    monkeypatch.setattr(router, "safe_answer", fake_safe_answer)
+    monkeypatch.setattr(router, "dispatch_via_registry", fake_dispatch)
+    monkeypatch.setattr(router, "ui_callback_legacy_forwarded_total", legacy_counter)
+
+    query = SimpleNamespace(data=raw)
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_chat=SimpleNamespace(id=1),
+        effective_user=SimpleNamespace(id=2),
+    )
+    ctx = SimpleNamespace()
+
+    asyncio.run(router.on_callback(update, ctx))
+
+    assert ack_calls, "callback should be acknowledged"
+    assert dispatched and dispatched[0][0] == "profile"
+    assert dispatched[0][1] == "btn:profile"
+    assert dispatched[0][3] is True
+    payload = dispatched[0][2] or {}
+    assert payload.get("legacy") is True
+    assert payload.get("source") == expected_source
+    assert legacy_counter.calls and legacy_counter.calls[0]["target"] == "profile"

--- a/ui/buttons/idempotency.py
+++ b/ui/buttons/idempotency.py
@@ -19,6 +19,7 @@ _DEFAULT_TTL = max(int(os.getenv("UI_BUTTONS_LOCK_TTL", "1") or "1"), 1)
 _DEBOUNCE_MS = float(os.getenv("UI_BUTTONS_DEBOUNCE_WINDOW_MS", "500") or "500")
 _DEBOUNCE_MS = max(_DEBOUNCE_MS, 0.0)
 _DEBOUNCE_WINDOW = _DEBOUNCE_MS / 1000.0 if _DEBOUNCE_MS else 0.0
+_PROFILE_DEBOUNCE_WINDOW = 0.3
 _DEBOUNCE_LOCK = threading.Lock()
 _RECENT_CLICKS: dict[tuple[int, str], float] = {}
 
@@ -28,14 +29,26 @@ def _now() -> float:
 
 
 def should_process(user_id: Optional[int], callback_data: Optional[str]) -> bool:
-    if user_id is None or not callback_data or _DEBOUNCE_WINDOW <= 0:
+    if user_id is None or not callback_data:
         return True
 
     normalized = callback_data.strip()
     if not normalized:
         return True
 
-    key = (int(user_id), normalized)
+    base = normalized
+    window = _DEBOUNCE_WINDOW
+    if normalized.startswith("btn:"):
+        base = normalized.split("|", 1)[0]
+    if base == "btn:profile":
+        window = _PROFILE_DEBOUNCE_WINDOW
+        key = (int(user_id), base)
+    else:
+        key = (int(user_id), normalized)
+
+    if window <= 0:
+        return True
+
     current = _now()
     with _DEBOUNCE_LOCK:
         expires = _RECENT_CLICKS.get(key, 0.0)
@@ -48,10 +61,11 @@ def should_process(user_id: Optional[int], callback_data: Optional[str]) -> bool
                 },
             )
             return False
-        _RECENT_CLICKS[key] = current + _DEBOUNCE_WINDOW
+        _RECENT_CLICKS[key] = current + window
 
         # Garbage collect stale entries lazily.
-        cutoff = current - (_DEBOUNCE_WINDOW * 4)
+        cleanup_window = max(window, _DEBOUNCE_WINDOW)
+        cutoff = current - (cleanup_window * 4)
         if cutoff > 0:
             stale = [item for item, exp in _RECENT_CLICKS.items() if exp <= cutoff]
             for item in stale:

--- a/ui/buttons/router.py
+++ b/ui/buttons/router.py
@@ -13,6 +13,7 @@ from metrics import (
     ui_callback_ack_latency_ms,
     ui_callback_ack_total,
     ui_callback_dedup_total,
+    ui_callback_legacy_forwarded_total,
     ui_callback_total,
 )
 from runtime_metrics import increment_ui_callback_counter
@@ -31,6 +32,81 @@ from telegram_utils import safe_answer
 log = logging.getLogger(__name__)
 _ENV = (os.getenv("APP_ENV") or "prod").strip() or "prod"
 _BOT_LABELS = {"env": _ENV, "service": "bot"}
+
+
+@dataclass(slots=True)
+class NormalizedCallback:
+    raw: str
+    normalized: str | None
+    action: str | None
+    payload: dict[str, object]
+    legacy: bool
+    dedupe_key: str
+
+
+_LEGACY_PROFILE_ALIASES: dict[str, tuple[str, str]] = {
+    "profile": ("profile", "button"),
+    "profile.open": ("profile", "button"),
+    "open:profile": ("profile", "menu"),
+    "quick:profile": ("profile", "quick"),
+    "stars:profile": ("profile", "button"),
+}
+
+
+def _parse_params(parts: list[str]) -> dict[str, str]:
+    params: dict[str, str] = {}
+    for part in parts:
+        chunk = (part or "").strip()
+        if not chunk:
+            continue
+        if "=" not in chunk:
+            continue
+        key, value = chunk.split("=", 1)
+        params[key] = value
+    return params
+
+
+def normalize_callback_data(data: str) -> NormalizedCallback:
+    stripped = (data or "").strip()
+    payload: dict[str, object] = {}
+    if not stripped:
+        return NormalizedCallback(stripped, None, None, payload, False, stripped)
+
+    lowered = stripped.lower()
+    if stripped.startswith("btn:"):
+        base, *extra = stripped.split("|")
+        params = _parse_params(extra)
+        src = params.pop("src", None)
+        if src:
+            payload["source"] = src
+        for key, value in params.items():
+            payload.setdefault(key, value)
+        action = base.split(":", 1)[1].strip() if ":" in base else None
+        return NormalizedCallback(
+            raw=stripped,
+            normalized=base,
+            action=action,
+            payload=payload,
+            legacy=False,
+            dedupe_key=base,
+        )
+
+    legacy_payload = _LEGACY_PROFILE_ALIASES.get(lowered)
+    if legacy_payload:
+        action, source = legacy_payload
+        payload = {"source": source, "legacy": True}
+        normalized = f"btn:{action}"
+        return NormalizedCallback(
+            raw=stripped,
+            normalized=normalized,
+            action=action,
+            payload=payload,
+            legacy=True,
+            dedupe_key=normalized,
+        )
+
+    legacy = ":" in stripped and not stripped.startswith("btn:")
+    return NormalizedCallback(stripped, None, None, payload, legacy, stripped)
 
 
 @dataclass(slots=True)
@@ -166,6 +242,8 @@ async def dispatch_via_registry(
     ctx: ContextTypes.DEFAULT_TYPE,
     *,
     raw_data: str,
+    payload: dict[str, object] | None = None,
+    legacy: bool = False,
 ) -> None:
     query = getattr(update, "callback_query", None)
     user = getattr(update, "effective_user", None)
@@ -175,7 +253,7 @@ async def dispatch_via_registry(
 
     entry = REGISTRY.get(action)
     if entry is None:
-        await _log_unmatched(raw_data, update)
+        await _log_unmatched(raw_data, update, legacy=legacy)
         return
 
     if not should_process(user_id, raw_data):
@@ -202,11 +280,12 @@ async def dispatch_via_registry(
             "user_id": user_id,
             "chat_id": chat_id,
             "data": raw_data,
+            "legacy": legacy,
         },
     )
 
     try:
-        await handler(update, ctx, payload=None)
+        await handler(update, ctx, payload=payload)
     except Exception:
         try:
             ui_callback_total.labels(action=action, result="error", **_BOT_LABELS).inc()
@@ -226,20 +305,24 @@ async def dispatch_via_registry(
     increment_ui_callback_counter("callback", "ok")
 
 
-async def _log_unmatched(data: str, update: Update) -> None:
+async def _log_unmatched(data: str, update: Update, *, legacy: bool = False) -> None:
     user = getattr(update, "effective_user", None)
     chat = getattr(update, "effective_chat", None)
     user_id = getattr(user, "id", None)
     chat_id = getattr(chat, "id", None)
 
     log.info(
-        "ui.callback.unmatched data=%r user_id=%s chat_id=%s",
+        "ui.callback.unmatched data=%r user_id=%s chat_id=%s legacy=%s",
         data,
         user_id,
         chat_id,
+        legacy,
     )
     try:
-        metrics_inc("ui_callback_unmatched_total", tags={"source": "telegram"})
+        metrics_inc(
+            "ui_callback_unmatched_total",
+            tags={"source": "telegram", "legacy": "true" if legacy else "false"},
+        )
     except Exception:  # pragma: no cover - metrics guard
         log.debug("ui.callback.unmatched.metric_failed", exc_info=True)
     increment_ui_callback_counter("callback", "unmatched")
@@ -266,19 +349,43 @@ async def on_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         log.debug("ui.callback.ack.metric_failed", exc_info=True)
 
     raw_data = getattr(query, "data", "")
-    data = (raw_data or "").strip()
-    if not data:
+    normalized = normalize_callback_data(raw_data)
+    if not normalized.raw:
         return
 
-    if data.startswith("btn:"):
-        action = data.split(":", 1)[1].strip()
-        if not action:
-            await _log_unmatched(data, update)
-            return
-        await dispatch_via_registry(action, update, ctx, raw_data=data)
+    payload = dict(normalized.payload)
+    if normalized.action and normalized.normalized:
+        if normalized.legacy:
+            user = getattr(update, "effective_user", None)
+            chat = getattr(update, "effective_chat", None)
+            user_id = getattr(user, "id", None)
+            chat_id = getattr(chat, "id", None)
+            log.info(
+                "ui.callback.legacy_forwarded",
+                extra={
+                    "target": normalized.action,
+                    "raw": normalized.raw,
+                    "user_id": user_id,
+                    "chat_id": chat_id,
+                },
+            )
+            try:
+                ui_callback_legacy_forwarded_total.labels(
+                    target=normalized.action, **_BOT_LABELS
+                ).inc()
+            except Exception:  # pragma: no cover - metrics guard
+                log.debug("ui.callback.legacy.metric_failed", exc_info=True)
+        await dispatch_via_registry(
+            normalized.action,
+            update,
+            ctx,
+            raw_data=normalized.dedupe_key,
+            payload=payload or None,
+            legacy=normalized.legacy,
+        )
         return
 
-    await _log_unmatched(data, update)
+    await _log_unmatched(normalized.raw, update, legacy=normalized.legacy)
 
 
 async def handle_unmatched_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:

--- a/utils/input_state.py
+++ b/utils/input_state.py
@@ -6,9 +6,11 @@ import re
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, Mapping, Optional, Tuple, Literal
+import inspect
 
 import time
 
+from metrics import inc as metrics_inc
 from settings import REDIS_PREFIX
 
 from utils.telegram_utils import should_capture_to_prompt
@@ -339,4 +341,72 @@ class InputRegistry:
 
 
 input_state = InputRegistry()
+
+
+async def force_clear_user_state(user_id: int, *, reason: str = "profile_open") -> None:
+    """Forcefully drop wait/input locks and related user state."""
+
+    try:
+        uid = int(user_id)
+    except (TypeError, ValueError):
+        return
+
+    _logger.info("WAIT_CLEAR_ALL user_id=%s reason=%s", uid, reason)
+    try:
+        metrics_inc("ui_wait_clear_all_total", tags={"reason": str(reason)})
+    except Exception:  # pragma: no cover - metrics are best effort
+        _logger.debug("wait_clear_all.metric_failed", exc_info=True)
+
+    for handler, label in (
+        (lambda: clear_wait_state(uid, reason=reason), "wait_state"),
+        (lambda: input_state.clear(uid, reason=reason), "input_registry"),
+    ):
+        try:
+            handler()
+        except Exception:
+            _logger.debug(
+                "wait_clear_all.failed", extra={"user_id": uid, "stage": label}, exc_info=True
+            )
+
+    try:
+        from redis_utils import clear_mode_state as _clear_mode_state, release_user_lock as _release_user_lock
+    except Exception:  # pragma: no cover - optional dependencies
+        _clear_mode_state = None
+        _release_user_lock = None
+
+    lock_keys = ("video_menu", "reply-nav", "dialog", "kb", "mode_reset")
+    if _release_user_lock is not None:
+        for key in lock_keys:
+            try:
+                _release_user_lock(uid, key)
+            except Exception:
+                _logger.debug(
+                    "wait_clear_all.release_failed",
+                    extra={"user_id": uid, "lock": key},
+                    exc_info=True,
+                )
+
+    if _clear_mode_state is not None:
+        try:
+            result = _clear_mode_state(uid)
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            _logger.debug(
+                "wait_clear_all.mode_reset_failed", extra={"user_id": uid}, exc_info=True
+            )
+
+    try:
+        from helpers import debounce as _debounce
+    except Exception:  # pragma: no cover - optional helper
+        _debounce = None
+
+    if _debounce is not None:
+        try:
+            _debounce.reset(uid)
+        except Exception:
+            _logger.debug(
+                "wait_clear_all.debounce_failed", extra={"user_id": uid}, exc_info=True
+            )
+
 


### PR DESCRIPTION
## Summary
- force profile opens triggered by navigation buttons to refresh content, log metrics, and clear user wait states
- add a wait-state clearing helper and profile-specific debounce logic to avoid stale views
- normalize callback payloads, bridge legacy profile payloads, and tag profile buttons with source metadata for logging

## Testing
- pytest tests/test_profile_force_refresh.py tests/test_profile_clears_waits.py tests/test_router_legacy_bridge.py tests/test_router_ack_timing.py tests/test_profile_debounce.py

------
https://chatgpt.com/codex/tasks/task_e_68fb2cae3c2c832289dd35d8b755c549