### PR TITLE
Improve UI routing, metrics, and MJ/Sora2 resilience

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -154,9 +154,12 @@ from hub_router import (
     route_text as hub_route_text,
     set_fallback as set_hub_fallback,
 )
-from handlers import payments as payments_handlers
 from handlers import profile as profile_handlers
-from handlers.stars import open_stars_menu
+from handlers.stars import buy as stars_buy_handler, open_stars_menu
+from mj_client import (
+    build_status_candidates as mj_status_candidates,
+    remember_status_path as remember_mj_status_path,
+)
 
 from state import state as redis_state
 from scripts.migrate_from_redis import cleanup_redis
@@ -1262,13 +1265,19 @@ else:
 
 _KIE_MJ_STATUS_DEFAULT = "/api/v1/mj/recordInfo"
 _KIE_MJ_STATUS_RAW = _env("KIE_MJ_STATUS", _KIE_MJ_STATUS_DEFAULT)
-KIE_MJ_STATUS_PATHS = _normalize_endpoint_values(
+KIE_MJ_STATUS_BASE_PATHS = _normalize_endpoint_values(
+    "/api/v1/mj/record-info",
     _KIE_MJ_STATUS_RAW,
     _KIE_MJ_STATUS_DEFAULT,
-    "/api/v1/mj/record-info",
+    "/api/v1/mj/recordInfo",
     "/api/v1/mj/status",
     "/api/v1/mj/recordinfo",
 )
+if KIE_MJ_STATUS_BASE_PATHS:
+    KIE_MJ_STATUS_PATHS = mj_status_candidates(KIE_MJ_STATUS_BASE_PATHS)
+else:
+    KIE_MJ_STATUS_BASE_PATHS = [_KIE_MJ_STATUS_DEFAULT]
+    KIE_MJ_STATUS_PATHS = list(KIE_MJ_STATUS_BASE_PATHS)
 if KIE_MJ_STATUS_PATHS:
     KIE_MJ_STATUS = KIE_MJ_STATUS_PATHS[0]
 else:
@@ -8545,9 +8554,30 @@ async def handle_profile_back(callback: HubCallbackContext) -> None:
     await profile_handlers.on_profile_back(callback.update, callback.application_context)
 
 
-@register_callback_action("payments", "stars_buy", module="payments")
-async def handle_payments_stars_buy(callback: HubCallbackContext) -> None:
-    await payments_handlers.stars_buy(callback.update, callback.application_context)
+@register_callback_action("stars", "buy", module="stars")
+async def handle_stars_buy(callback: HubCallbackContext) -> None:
+    payload = getattr(callback.update, "_ui_router_payload", {})
+    amount = None
+    if isinstance(payload, dict):
+        raw = payload.get("amount")
+        try:
+            amount = int(raw) if raw is not None else None
+        except (TypeError, ValueError):
+            amount = None
+    if amount is None:
+        data = getattr(getattr(callback.update, "callback_query", None), "data", "")
+        match = re.search(r"stars:buy:(\d+)", data or "")
+        if match:
+            try:
+                amount = int(match.group(1))
+            except (TypeError, ValueError):
+                amount = None
+    await stars_buy_handler(
+        callback.application_context,
+        amount=amount or 0,
+        update=callback.update,
+        source="callback",
+    )
 
 
 async def _build_balance_menu_with_referral(
@@ -13491,22 +13521,31 @@ def _remember_endpoint(service: str, kind: str, path: str):
             KIE_MJ_GENERATE = path
         elif kind == "status":
             KIE_MJ_STATUS = path
+            remember_mj_status_path(path)
 
 
 def _endpoint_candidates(service: str, kind: str, base_paths: List[str]) -> List[str]:
     cached = app_cache.get(_endpoint_cache_key(service, kind))
+    if service == "mj" and kind == "status":
+        ordered = mj_status_candidates(base_paths)
+    else:
+        ordered = list(base_paths)
     if cached:
-        return _normalize_endpoint_values(cached, base_paths)
-    return list(base_paths)
+        return _normalize_endpoint_values(cached, ordered)
+    return ordered
 
 def _is_not_found_response(status: int, payload: Dict[str, Any]) -> bool:
-    if status == 404:
+    if status in {404, 405}:
         return True
     for key in ("code", "status"):
         val = payload.get(key)
         if isinstance(val, int) and val == 404:
             return True
+        if isinstance(val, int) and val == 405:
+            return True
         if isinstance(val, str) and val.strip() == "404":
+            return True
+        if isinstance(val, str) and val.strip() == "405":
             return True
     message = payload.get("message") or payload.get("error")
     if isinstance(message, str) and "not found" in message.lower():
@@ -21285,6 +21324,23 @@ async def successful_payment_handler(update: Update, ctx: ContextTypes.DEFAULT_T
         return
 
     _set_cached_balance(ctx, new_balance)
+
+    profile_chat_id = getattr(message, "chat_id", None)
+    if profile_chat_id is None and update.effective_chat is not None:
+        profile_chat_id = getattr(update.effective_chat, "id", None)
+    try:
+        await profile_handlers.refresh(
+            ctx,
+            chat_id=int(profile_chat_id) if profile_chat_id is not None else int(user_id),
+            user_id=int(user_id),
+            source="payment",
+        )
+    except Exception:
+        log.debug(
+            "profile.refresh.after_payment_failed",
+            exc_info=True,
+            extra={"user": user_id, "chat_id": profile_chat_id},
+        )
 
     log.info(
         "stars_payment_success | user=%s charge_id=%s stars=%s diamonds=%s balance=%s",

--- a/core/settings.py
+++ b/core/settings.py
@@ -178,6 +178,7 @@ class Settings(BaseSettings):
 
     PROFILE_LAZY_INVITE: bool = Field(default=True)
     ROUTER_LEGACY_BRIDGE: bool = Field(default=True)
+    ROUTER_LEGACY_OFF: bool = Field(default=True)
     PAYMENTS_STARS_ENABLED: bool = Field(default=True)
 
     DIALOG_ENABLED: Optional[bool] = Field(default=None)

--- a/handlers/profile.py
+++ b/handlers/profile.py
@@ -5,12 +5,14 @@ import inspect
 import logging
 import os
 import time
+import uuid
+from threading import Lock
 from types import SimpleNamespace
 from collections.abc import MutableMapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, cast
 
 from html import escape
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message, Update
@@ -20,19 +22,28 @@ from telegram.ext import ContextTypes
 
 from helpers.telegram_html import sanitize_profile_html, strip_telegram_html, tg_html_safe
 from telegram_utils import safe_answer, safe_send
-from .stars import build_stars_kb, open_stars_menu, render_stars_text
+from .stars import build_stars_kb, open as open_stars, render_stars_text
 from ui.card import build_card
 from utils.input_state import (
     WaitInputState,
     WaitKind,
     clear_wait_state,
+    clear_wait_states,
     force_clear_user_state,
     get_wait_state,
     input_state,
     set_wait_state,
 )
-from metrics import profile_first_paint_ms, profile_open_total, profile_render_ms
+from metrics import lbl_safe, profile_first_paint_ms, profile_open_total
 import settings as app_settings
+from redis_utils import rds as redis_client
+
+try:  # pragma: no cover - optional dependency during tests
+    import redis  # type: ignore
+except Exception:  # pragma: no cover - fallback when redis is unavailable
+    redis = None
+
+RedisError = getattr(redis, "RedisError", Exception)
 log = logging.getLogger(__name__)
 
 try:
@@ -41,6 +52,25 @@ except ValueError:
     _DEBOUNCE_MS = 400
 _DEBOUNCE_MS = max(_DEBOUNCE_MS, 0)
 _DEBOUNCE_SEC = _DEBOUNCE_MS / 1000 if _DEBOUNCE_MS else 0.0
+
+
+_PROFILE_REDIS_PREFIX = getattr(app_settings, "REDIS_PREFIX", "bot")
+_PROFILE_LOCK_KEY_TMPL = f"{_PROFILE_REDIS_PREFIX}:prof:lock:{{user_id}}"
+_PROFILE_LAST_KEY_TMPL = f"{_PROFILE_REDIS_PREFIX}:prof:last:{{user_id}}"
+_PROFILE_MSG_KEY_TMPL = f"{_PROFILE_REDIS_PREFIX}:prof:msg:{{chat_id}}"
+
+_PROFILE_LOCK_TTL_SECONDS = 5
+_PROFILE_DEBOUNCE_WINDOW = 0.6
+_PROFILE_LAST_TTL_SECONDS = 30
+_PROFILE_MSG_TTL_SECONDS = 24 * 60 * 60
+
+_PROFILE_LOCK_MEMORY: dict[int, tuple[float, str]] = {}
+_PROFILE_LAST_MEMORY: dict[int, tuple[float, float]] = {}
+_PROFILE_MSG_MEMORY: dict[int, tuple[float, int]] = {}
+
+_PROFILE_LOCK_GUARD = Lock()
+_PROFILE_LAST_GUARD = Lock()
+_PROFILE_MSG_GUARD = Lock()
 
 
 def _simple_profile_enabled() -> bool:
@@ -63,6 +93,150 @@ _HISTORY_TYPE_LABELS = {
     "refund": "Возврат",
 }
 
+
+def _profile_lock_key(user_id: int) -> str:
+    return _PROFILE_LOCK_KEY_TMPL.format(user_id=int(user_id))
+
+
+def _profile_last_key(user_id: int) -> str:
+    return _PROFILE_LAST_KEY_TMPL.format(user_id=int(user_id))
+
+
+def _profile_msg_key(chat_id: int) -> str:
+    return _PROFILE_MSG_KEY_TMPL.format(chat_id=int(chat_id))
+
+
+def _acquire_profile_lock(user_id: int) -> tuple[bool, Optional[str]]:
+    token = uuid.uuid4().hex
+    if redis_client is not None:
+        try:
+            if redis_client.set(_profile_lock_key(user_id), token, ex=_PROFILE_LOCK_TTL_SECONDS, nx=True):
+                return True, token
+        except RedisError:  # pragma: no cover - best effort guard
+            log.debug("profile.lock.redis_failed", exc_info=True, extra={"user_id": user_id})
+
+    now = time.monotonic()
+    with _PROFILE_LOCK_GUARD:
+        entry = _PROFILE_LOCK_MEMORY.get(int(user_id))
+        if entry and entry[0] > now:
+            return False, None
+        _PROFILE_LOCK_MEMORY[int(user_id)] = (now + _PROFILE_LOCK_TTL_SECONDS, token)
+        return True, token
+
+
+def _release_profile_lock(user_id: int, token: Optional[str]) -> None:
+    if not token:
+        return
+
+    key = _profile_lock_key(user_id)
+    if redis_client is not None:
+        try:
+            stored = redis_client.get(key)
+        except RedisError:  # pragma: no cover - best effort guard
+            log.debug("profile.lock.redis_get_failed", exc_info=True, extra={"user_id": user_id})
+        else:
+            if stored == token:
+                try:
+                    redis_client.delete(key)
+                except RedisError:
+                    log.debug("profile.lock.redis_delete_failed", exc_info=True, extra={"user_id": user_id})
+
+    with _PROFILE_LOCK_GUARD:
+        entry = _PROFILE_LOCK_MEMORY.get(int(user_id))
+        if entry and entry[1] == token:
+            _PROFILE_LOCK_MEMORY.pop(int(user_id), None)
+
+
+def _load_last_open_ts(user_id: int) -> Optional[float]:
+    if redis_client is not None:
+        try:
+            raw = redis_client.get(_profile_last_key(user_id))
+        except RedisError:  # pragma: no cover - best effort guard
+            log.debug("profile.last.redis_get_failed", exc_info=True, extra={"user_id": user_id})
+        else:
+            if raw is not None:
+                try:
+                    return float(raw)
+                except (TypeError, ValueError):
+                    return None
+
+    now = time.monotonic()
+    with _PROFILE_LAST_GUARD:
+        entry = _PROFILE_LAST_MEMORY.get(int(user_id))
+        if not entry:
+            return None
+        expires_at, stored = entry
+        if expires_at <= now:
+            _PROFILE_LAST_MEMORY.pop(int(user_id), None)
+            return None
+        return stored
+
+
+def _store_last_open_ts(user_id: int, timestamp: float) -> None:
+    if redis_client is not None:
+        try:
+            redis_client.setex(_profile_last_key(user_id), _PROFILE_LAST_TTL_SECONDS, str(timestamp))
+        except RedisError:  # pragma: no cover - best effort guard
+            log.debug("profile.last.redis_set_failed", exc_info=True, extra={"user_id": user_id})
+
+    expires_at = time.monotonic() + _PROFILE_LAST_TTL_SECONDS
+    with _PROFILE_LAST_GUARD:
+        _PROFILE_LAST_MEMORY[int(user_id)] = (expires_at, float(timestamp))
+
+
+def _load_profile_message_id(chat_id: Optional[int]) -> Optional[int]:
+    if chat_id is None:
+        return None
+
+    if redis_client is not None:
+        try:
+            raw = redis_client.get(_profile_msg_key(chat_id))
+        except RedisError:  # pragma: no cover - best effort guard
+            log.debug("profile.msg.redis_get_failed", exc_info=True, extra={"chat_id": chat_id})
+        else:
+            if raw is not None:
+                try:
+                    return int(raw)
+                except (TypeError, ValueError):
+                    return None
+
+    now = time.time()
+    with _PROFILE_MSG_GUARD:
+        entry = _PROFILE_MSG_MEMORY.get(int(chat_id))
+        if not entry:
+            return None
+        expires_at, stored = entry
+        if expires_at <= now:
+            _PROFILE_MSG_MEMORY.pop(int(chat_id), None)
+            return None
+        return stored
+
+
+def _store_profile_message_id(chat_id: Optional[int], message_id: Optional[int]) -> None:
+    if chat_id is None:
+        return
+
+    key = _profile_msg_key(chat_id)
+    if message_id is None:
+        if redis_client is not None:
+            try:
+                redis_client.delete(key)
+            except RedisError:  # pragma: no cover - best effort guard
+                log.debug("profile.msg.redis_delete_failed", exc_info=True, extra={"chat_id": chat_id})
+        with _PROFILE_MSG_GUARD:
+            _PROFILE_MSG_MEMORY.pop(int(chat_id), None)
+        return
+
+    payload = int(message_id)
+    if redis_client is not None:
+        try:
+            redis_client.setex(key, _PROFILE_MSG_TTL_SECONDS, payload)
+        except RedisError:  # pragma: no cover - best effort guard
+            log.debug("profile.msg.redis_set_failed", exc_info=True, extra={"chat_id": chat_id})
+
+    expires_at = time.time() + _PROFILE_MSG_TTL_SECONDS
+    with _PROFILE_MSG_GUARD:
+        _PROFILE_MSG_MEMORY[int(chat_id)] = (expires_at, payload)
 
 def _resolve_callback_started_at(
     update: Update,
@@ -133,13 +307,11 @@ class _FirstPaintTracker:
         if self.started_at is None:
             return
         latency_ms = max((time.perf_counter() - float(self.started_at)) * 1000.0, 0.0)
-        try:
-            profile_first_paint_ms.labels(
-                force_refresh="true" if self.force_refresh else "false",
-                source=_normalize_source_label(self.source),
-            ).observe(latency_ms)
-        except Exception:
-            log.debug("profile.metrics.first_paint_failed", exc_info=True)
+        observer = lbl_safe(profile_first_paint_ms, source=_normalize_source_label(self.source))
+        if observer is None:
+            log.debug("profile.metrics.first_paint_failed", extra={"source": self.source})
+            return
+        observer.observe(latency_ms)
 
 
 @dataclass(slots=True)
@@ -461,7 +633,12 @@ async def profile_update_or_send(
                     return SimpleNamespace(message_id=msg_id_cached)
                 return None
 
-    msg_id = _get_profile_msg_id(chat_data)
+    redis_msg_id = _load_profile_message_id(chat_id)
+    if redis_msg_id is not None and isinstance(chat_data, MutableMapping):
+        stored_mid = _get_profile_msg_id(chat_data)
+        if stored_mid != redis_msg_id:
+            _store_profile_msg_id(chat_data, redis_msg_id)
+    msg_id = redis_msg_id if redis_msg_id is not None else _get_profile_msg_id(chat_data)
 
     safe_source = tg_html_safe(text)
     safe_text, safe_mode = sanitize_profile_html(safe_source)
@@ -495,6 +672,7 @@ async def profile_update_or_send(
                         "error": str(exc),
                     },
                 )
+            _store_profile_message_id(chat_id, None)
             msg_id = None
         else:
             if result is None:
@@ -505,6 +683,8 @@ async def profile_update_or_send(
                 if isinstance(chat_data, MutableMapping) and isinstance(new_id, int):
                     chat_data[PROFILE_MSG_ID] = new_id
                     chat_data["profile_last_msg_id"] = new_id
+                if isinstance(new_id, int):
+                    _store_profile_message_id(chat_id, int(new_id))
             if token_store is not None:
                 token_store["profile_last_result"] = response
             return response
@@ -517,6 +697,8 @@ async def profile_update_or_send(
         parse_mode=parse_mode,
         log_context=log_context,
     )
+    if isinstance(getattr(response, "message_id", None), int):
+        _store_profile_message_id(chat_id, int(getattr(response, "message_id")))
     if token_store is not None:
         token_store["profile_last_result"] = response
     return response
@@ -668,24 +850,7 @@ async def handle_profile_view(
             root_payload = await _prepare_root_payload(update, ctx)
             data = dict(root_payload.payload)
         elif normalized == "topup":
-            message_obj = getattr(update, "effective_message", None)
-            if query is not None and getattr(query, "message", None) is not None:
-                message_obj = query.message
-
-            chat_obj = getattr(update, "effective_chat", None)
-            chat_id = getattr(chat_obj, "id", None)
-            if chat_id is None and message_obj is not None:
-                chat_id = getattr(message_obj, "chat_id", None)
-
-            message_id = getattr(message_obj, "message_id", None)
-
-            result = await open_stars_menu(
-                ctx,
-                chat_id=chat_id,
-                message_id=message_id,
-                edit_message=True,
-                source="profile",
-            )
+            result = await open_stars(ctx, update=update, source="profile")
 
             if query is not None:
                 with suppress(BadRequest):
@@ -960,6 +1125,8 @@ async def profile_reset_command(update: Update, ctx: ContextTypes.DEFAULT_TYPE) 
 
     chat = getattr(update, "effective_chat", None)
     chat_id = getattr(chat, "id", None)
+    if chat_id is not None:
+        _store_profile_message_id(int(chat_id), None)
     log.info(
         "profile.cache.cleared",
         extra={"chat_id": chat_id, "keys": cleared_keys},
@@ -977,6 +1144,7 @@ async def profile_reset_command(update: Update, ctx: ContextTypes.DEFAULT_TYPE) 
 class OpenedProfile:
     msg_id: Optional[int]
     reused: bool
+    status: str = "ok"
 
 
 def _get_profile_msg_id(chat_data: MutableMapping[str, Any] | None) -> Optional[int]:
@@ -1014,21 +1182,16 @@ async def open_profile(
         await profile_simple.profile_open(update, ctx)
         return
 
+    user_id = _resolve_profile_user_id(update, ctx)
+    source_label = _normalize_source_label(source)
     chat_data, flag, previous_nav = _set_nav_event(ctx, source=source)
+    started_perf = time.perf_counter()
+    first_paint_ms: Optional[float] = None
+    result_label = "ok"
+    lock_token: Optional[str] = None
     try:
         now = time.monotonic()
         if isinstance(chat_data, MutableMapping):
-            raw_open_at = chat_data.get(PROFILE_OPEN_AT)
-            try:
-                last_open = float(raw_open_at)
-            except (TypeError, ValueError):
-                last_open = 0.0
-            if now - last_open < 0.5:
-                log.debug(
-                    "profile.open.debounced",
-                    extra={"source": source, "delta": now - last_open},
-                )
-                return
             chat_data[PROFILE_OPEN_AT] = now
             chat_data.pop("wait_kind", None)
             try:
@@ -1038,43 +1201,45 @@ async def open_profile(
             chat_data[NAV_UNTIL] = max(previous_deadline, now + 2.0)
             chat_data["suppress_dialog_notice"] = True
 
-        started = time.perf_counter()
-        metrics_result = "ok"
-        reused = False
-        try:
-            result = await open_profile_card(
-                update,
-                ctx,
-                source=source,
-                suppress_nav=suppress_nav,
-                force_refresh=force_refresh,
-            )
-            reused = bool(result.reused) if isinstance(result, OpenedProfile) else False
-            log.debug(
-                "profile.open",
-                extra={"source": source, "reused_msg": reused, "force_refresh": force_refresh},
-            )
-        except Exception:
-            metrics_result = "error"
-            raise
-        finally:
-            elapsed_ms = max((time.perf_counter() - started) * 1000.0, 0.0)
+        if user_id is not None:
+            acquired, token = _acquire_profile_lock(user_id)
+            if not acquired:
+                result_label = "skip_inflight"
+                return
+            lock_token = token
+            last_open = _load_last_open_ts(user_id)
+            if last_open is not None and (now - last_open) < _PROFILE_DEBOUNCE_WINDOW:
+                result_label = "debounce"
+                return
+            _store_last_open_ts(user_id, now)
             try:
-                profile_render_ms.labels(
-                    force_refresh="true" if force_refresh else "false",
-                    source=_normalize_source_label(source),
-                ).observe(elapsed_ms)
+                clear_wait_states(user_id, exclude={WaitKind.PROMO_CODE.value}, reason="profile_open")
             except Exception:
-                log.debug("profile.metrics.render_failed", exc_info=True)
-            try:
-                profile_open_total.labels(
-                    force_refresh="true" if force_refresh else "false",
-                    source=_normalize_source_label(source),
-                    result=metrics_result,
-                ).inc()
-            except Exception:
-                log.debug("profile.metrics.open_failed", exc_info=True)
+                log.debug("profile.wait_states.clear_failed", exc_info=True, extra={"user_id": user_id})
+
+        result = await open_profile_card(
+            update,
+            ctx,
+            source=source,
+            suppress_nav=suppress_nav,
+            force_refresh=force_refresh,
+        )
+        if isinstance(result, OpenedProfile) and result.status == "repair":
+            result_label = "repair"
+        log.debug(
+            "profile.open",
+            extra={"source": source, "force_refresh": force_refresh, "result": result_label},
+        )
+        first_paint_ms = max((time.perf_counter() - started_perf) * 1000.0, 0.0)
     finally:
+        if first_paint_ms is not None:
+            observer = lbl_safe(profile_first_paint_ms, source=source_label)
+            observer and observer.observe(first_paint_ms)
+        counter = lbl_safe(profile_open_total, source=source_label, result=result_label)
+        counter and counter.inc()
+        log.info("profile.open", extra={"source": source_label, "result": result_label})
+        if user_id is not None:
+            _release_profile_lock(user_id, lock_token)
         _clear_nav_event(chat_data, flag, ctx, previous_nav)
 
 
@@ -1133,6 +1298,8 @@ async def open(
         chat_data = _chat_data(ctx)
         if isinstance(chat_data, MutableMapping):
             chat_data.pop(PROFILE_MSG_ID, None)
+        if chat_id is not None:
+            _store_profile_message_id(int(chat_id), None)
 
     await open_profile(
         update,
@@ -1141,6 +1308,41 @@ async def open(
         suppress_nav=suppress_nav,
         force_refresh=bool(force_refresh),
     )
+
+
+async def refresh(
+    ctx: ContextTypes.DEFAULT_TYPE,
+    *,
+    chat_id: int,
+    user_id: Optional[int] = None,
+    source: str = "payment",
+) -> None:
+    """Refresh the profile card in ``chat_id`` using the cached message pointer."""
+
+    fake_chat = SimpleNamespace(id=int(chat_id))
+    fake_message = SimpleNamespace(chat=fake_chat, chat_id=int(chat_id))
+    fake_user = SimpleNamespace(id=int(user_id)) if user_id is not None else None
+    placeholder = SimpleNamespace(
+        effective_chat=fake_chat,
+        effective_message=fake_message,
+        effective_user=fake_user,
+    )
+    try:
+        await _open_profile_card_impl(
+            int(chat_id),
+            int(user_id) if user_id is not None else None,
+            update=cast(Update, placeholder),
+            ctx=ctx,
+            suppress_nav=True,
+            source=source,
+            force_refresh=False,
+        )
+    except Exception:
+        log.debug(
+            "profile.refresh.failed",
+            exc_info=True,
+            extra={"chat_id": chat_id, "user_id": user_id, "source": source},
+        )
 
 
 async def _open_profile_card_impl(
@@ -1180,7 +1382,10 @@ async def _open_profile_card_impl(
         resolved_chat_id = getattr(chat, "id", None)
 
     chat_data = _chat_data(ctx)
-    previous_mid = _get_profile_msg_id(chat_data)
+    redis_mid = _load_profile_message_id(resolved_chat_id)
+    if redis_mid is not None and isinstance(chat_data, MutableMapping):
+        _store_profile_msg_id(chat_data, redis_mid)
+    previous_mid = redis_mid if redis_mid is not None else _get_profile_msg_id(chat_data)
     reuse_existing = previous_mid is not None and not force_refresh
 
     if isinstance(chat_data, MutableMapping):
@@ -1191,7 +1396,7 @@ async def _open_profile_card_impl(
                 "profile.open.skip_duplicate",
                 extra={"chat_id": resolved_chat_id, "user_id": user_id},
             )
-            return OpenedProfile(msg_id=previous_mid, reused=True)
+            return OpenedProfile(msg_id=previous_mid, reused=True, status="ok")
         chat_data[_PROFILE_LOCK_KEY] = True
 
     try:
@@ -1217,12 +1422,21 @@ async def _open_profile_card_impl(
         and message_id == previous_mid
     )
 
+    status = "ok"
+    if previous_mid is not None and isinstance(previous_mid, int):
+        if not isinstance(message_id, int) or message_id != previous_mid:
+            status = "repair"
+
     log.debug(
         "profile.opened reused=%s msg_id=%s",
         reused_actual,
         message_id,
     )
-    return OpenedProfile(msg_id=message_id if isinstance(message_id, int) else None, reused=reused_actual)
+    return OpenedProfile(
+        msg_id=message_id if isinstance(message_id, int) else None,
+        reused=reused_actual,
+        status=status,
+    )
 
 
 async def open_profile_card(
@@ -1316,25 +1530,13 @@ async def on_profile_topup(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> No
         return
 
     log.info("profile.click", extra={"action": "topup"})
-    message = getattr(update, "effective_message", None)
     query = getattr(update, "callback_query", None)
-    if query is not None and getattr(query, "message", None) is not None:
-        message = query.message
 
-    chat_obj = getattr(update, "effective_chat", None)
-    chat_id = getattr(chat_obj, "id", None)
-    if chat_id is None and message is not None:
-        chat_id = getattr(message, "chat_id", None)
+    await open_stars(ctx, update=update, source="profile")
 
-    message_id = getattr(message, "message_id", None)
-
-    await open_stars_menu(
-        ctx,
-        chat_id=chat_id,
-        message_id=message_id,
-        edit_message=True,
-        source="profile",
-    )
+    if query is not None:
+        with suppress(BadRequest):
+            await safe_answer(query)
 
 
 async def _billing_history(user_id: int) -> list[dict[str, Any]]:
@@ -1698,6 +1900,7 @@ __all__ = [
     "open",
     "open_profile",
     "open_profile_card",
+    "refresh",
     "on_profile_history",
     "on_profile_invite",
     "on_profile_menu",

--- a/handlers/stars.py
+++ b/handlers/stars.py
@@ -1,7 +1,15 @@
+import json
 import logging
+from contextlib import suppress
 from typing import List, Optional, Sequence
 
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, LabeledPrice, Message, Update
+from telegram.error import BadRequest
+from telegram.ext import ContextTypes
+
+from telegram_utils import safe_answer
+
+import settings as app_settings
 
 log = logging.getLogger(__name__)
 
@@ -14,6 +22,9 @@ STARS_TIERS: Sequence[tuple[int, int]] = (
     (500, 550),
 )
 
+_DEFAULT_DISPLAY_TIERS: Sequence[int] = (50, 100, 300)
+_STARS_PACK_MAP = {stars: gems for stars, gems in STARS_TIERS}
+
 
 def render_stars_text() -> str:
     """Render the Stars top-up description."""
@@ -24,9 +35,11 @@ def render_stars_text() -> str:
     )
 
 
-def build_stars_kb() -> InlineKeyboardMarkup:
+def build_stars_kb(*, tiers: Sequence[int] | None = None) -> InlineKeyboardMarkup:
     rows: List[List[InlineKeyboardButton]] = []
-    for stars, gems in STARS_TIERS:
+    selected = list(tiers) if tiers is not None else [stars for stars, _ in STARS_TIERS]
+    for stars in selected:
+        gems = _STARS_PACK_MAP.get(stars, stars)
         rows.append(
             [
                 InlineKeyboardButton(
@@ -80,6 +93,7 @@ async def open_stars_menu(
     message_id: Optional[int] = None,
     edit_message: bool = True,
     source: Optional[str] = None,
+    tiers: Optional[Sequence[int]] = None,
 ) -> Optional[Message]:
     """Show the Stars purchase screen."""
 
@@ -94,7 +108,7 @@ async def open_stars_menu(
     log.info("stars.open", extra={"source": source or "unknown", "chat_id": target_chat_id})
 
     text = render_stars_text()
-    keyboard = build_stars_kb()
+    keyboard = build_stars_kb(tiers=tiers or _DEFAULT_DISPLAY_TIERS)
 
     if edit_message and target_chat_id is not None and target_message_id is not None:
         try:
@@ -126,4 +140,130 @@ async def open_stars_menu(
         reply_markup=keyboard,
         parse_mode="HTML",
         disable_web_page_preview=True,
+    )
+
+
+async def open(
+    ctx: ContextTypes.DEFAULT_TYPE,
+    *,
+    update: Optional[Update] = None,
+    chat_id: Optional[int] = None,
+    message_id: Optional[int] = None,
+    source: str = "profile",
+    tiers: Optional[Sequence[int]] = None,
+) -> Optional[Message]:
+    """Render the Stars menu with the configured tiers."""
+
+    resolved_chat_id = chat_id
+    resolved_message_id = message_id
+    if update is not None:
+        query = getattr(update, "callback_query", None)
+        message = getattr(query, "message", None)
+        if message is None:
+            message = getattr(update, "effective_message", None)
+        if resolved_chat_id is None:
+            chat_obj = getattr(update, "effective_chat", None)
+            resolved_chat_id = getattr(chat_obj, "id", None)
+            if resolved_chat_id is None and message is not None:
+                resolved_chat_id = getattr(message, "chat_id", None)
+        if resolved_message_id is None and message is not None:
+            resolved_message_id = getattr(message, "message_id", None)
+
+    return await open_stars_menu(
+        ctx,
+        chat_id=resolved_chat_id,
+        message_id=resolved_message_id,
+        edit_message=True,
+        source=source,
+        tiers=tiers,
+    )
+
+
+async def buy(
+    ctx: ContextTypes.DEFAULT_TYPE,
+    *,
+    amount: int,
+    update: Optional[Update] = None,
+    source: str = "stars",
+) -> None:
+    """Initiate a Telegram Stars invoice for the desired ``amount``."""
+
+    try:
+        normalized_amount = int(amount)
+    except (TypeError, ValueError):
+        normalized_amount = 0
+
+    if normalized_amount <= 0:
+        log.warning("stars.buy.invalid_amount", extra={"amount": amount})
+        return
+
+    if not getattr(app_settings, "PAYMENTS_STARS_ENABLED", True):
+        log.info("stars.buy.disabled", extra={"amount": amount})
+        return
+
+    query = getattr(update, "callback_query", None) if update is not None else None
+    message = getattr(query, "message", None)
+    if message is None and update is not None:
+        message = getattr(update, "effective_message", None)
+
+    chat_id = None
+    if message is not None:
+        chat_obj = getattr(message, "chat", None)
+        chat_id = getattr(chat_obj, "id", None)
+        if chat_id is None:
+            chat_id = getattr(message, "chat_id", None)
+    if chat_id is None and update is not None:
+        chat_obj = getattr(update, "effective_chat", None)
+        chat_id = getattr(chat_obj, "id", None)
+
+    if normalized_amount not in _STARS_PACK_MAP:
+        if query is not None:
+            with suppress(BadRequest):
+                await safe_answer(query, text="Пакет недоступен", show_alert=True)
+        log.warning("stars.buy.invalid", extra={"amount": normalized_amount, "source": source})
+        return
+
+    target_chat_id = chat_id
+    if target_chat_id is None:
+        log.warning("stars.buy.missing_chat", extra={"amount": normalized_amount, "source": source})
+        return
+
+    diamonds = _STARS_PACK_MAP.get(normalized_amount, normalized_amount)
+    title = f"{normalized_amount}⭐ → {diamonds}💎"
+    invoice_payload = json.dumps(
+        {
+            "type": "stars_pack",
+            "stars": normalized_amount,
+            "diamonds": diamonds,
+            "bonus": max(diamonds - normalized_amount, 0),
+        }
+    )
+
+    try:
+        await ctx.bot.send_invoice(
+            chat_id=int(target_chat_id),
+            title=title,
+            description="Пакет пополнения токенов",
+            payload=invoice_payload,
+            provider_token="",
+            currency="XTR",
+            prices=[LabeledPrice(label=title, amount=normalized_amount)],
+        )
+    except Exception as exc:  # pragma: no cover - network issues
+        log.exception(
+            "stars.buy.invoice_failed",
+            extra={"amount": normalized_amount, "chat_id": target_chat_id, "error": str(exc)},
+        )
+        if query is not None:
+            with suppress(BadRequest):
+                await safe_answer(query, text="Не удалось открыть счёт", show_alert=True)
+        return
+
+    if query is not None:
+        with suppress(BadRequest):
+            await safe_answer(query)
+
+    log.info(
+        "stars.buy.invoice_sent",
+        extra={"amount": normalized_amount, "diamonds": diamonds, "chat_id": target_chat_id, "source": source},
     )

--- a/metrics.py
+++ b/metrics.py
@@ -1,6 +1,7 @@
 """Prometheus metrics helpers shared across bot and web services."""
 from __future__ import annotations
 
+import logging
 import os
 import time
 from typing import Iterable
@@ -10,6 +11,7 @@ from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, gene
 REGISTRY = CollectorRegistry()
 
 _ENV = (os.getenv("APP_ENV") or "prod").strip() or "prod"
+_log = logging.getLogger(__name__)
 
 
 def _labels(service: str) -> dict[str, str]:
@@ -154,25 +156,24 @@ router_callback_legacy_total = Counter(
 
 profile_open_total = Counter(
     "profile_open_total",
-    "Profile open attempts grouped by force refresh decision and result.",
-    labelnames=("force_refresh", "source", "result"),
+    "Profile open attempts grouped by source and result.",
+    labelnames=("source", "result"),
     registry=REGISTRY,
-)
-
-profile_render_ms = Histogram(
-    "profile_render_ms",
-    "Latency of rendering the profile screen in milliseconds.",
-    labelnames=("force_refresh", "source"),
-    registry=REGISTRY,
-    buckets=(25, 50, 100, 150, 200, 300, 400, 600, 1000, 1500),
 )
 
 profile_first_paint_ms = Histogram(
     "profile_first_paint_ms",
     "Latency between callback reception and first profile render in milliseconds.",
-    labelnames=("force_refresh", "source"),
+    labelnames=("source",),
     registry=REGISTRY,
     buckets=(25, 50, 100, 150, 200, 300, 400, 600, 1000, 1500),
+)
+
+router_callback_unmatched_total = Counter(
+    "router_callback_unmatched_total",
+    "Namespace router callbacks that were not matched to any handler.",
+    labelnames=("data",),
+    registry=REGISTRY,
 )
 
 ui_wait_clear_all_total = Counter(
@@ -378,9 +379,24 @@ def render_metrics() -> bytes:
     return generate_latest(REGISTRY)
 
 
+def lbl_safe(metric, /, **labels):
+    """Return a labelled child instance without propagating errors."""
+
+    try:
+        return metric.labels(**labels)
+    except Exception:  # pragma: no cover - defensive guard
+        _log.debug(
+            "metrics.lbl_safe.failed",
+            exc_info=True,
+            extra={"metric": getattr(metric, "_name", None), "labels": labels},
+        )
+        return None
+
+
 __all__: Iterable[str] = [
     "REGISTRY",
     "inc",
+    "lbl_safe",
     "suno_requests_total",
     "suno_callback_download_fail_total",
     "suno_task_store_total",
@@ -412,6 +428,9 @@ __all__: Iterable[str] = [
     "ui_callback_ack_latency_ms",
     "ui_callback_dedup_total",
     "ui_callback_unmatched_total",
+    "profile_open_total",
+    "profile_first_paint_ms",
+    "router_callback_unmatched_total",
     "process_uptime_seconds",
     "render_metrics",
 ]

--- a/mj_client.py
+++ b/mj_client.py
@@ -1,0 +1,120 @@
+"""Utilities for interacting with Midjourney status endpoints."""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Iterable, Sequence
+
+from redis_utils import rds
+from settings import REDIS_PREFIX
+
+_log = logging.getLogger(__name__)
+
+_STATUS_CACHE_KEY = f"{REDIS_PREFIX}:mj:status:path"
+_STATUS_CACHE_TTL = 10 * 60
+_memory_cache: tuple[str, float] | None = None
+
+
+def _now() -> float:
+    return time.monotonic()
+
+
+def _normalize_path(path: str | None) -> str | None:
+    if path is None:
+        return None
+    normalized = path.strip()
+    return normalized or None
+
+
+def _deduplicate(paths: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for path in paths:
+        normalized = _normalize_path(path)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
+
+def _load_cached_path() -> str | None:
+    global _memory_cache
+    now = _now()
+    if _memory_cache is not None:
+        cached_path, expires_at = _memory_cache
+        if expires_at > now:
+            return cached_path
+        _memory_cache = None
+
+    if rds is None:
+        return None
+
+    try:
+        raw = rds.get(_STATUS_CACHE_KEY)
+    except Exception:  # pragma: no cover - defensive guard
+        _log.debug("mj.status.cache.redis_get_failed", exc_info=True)
+        return None
+
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8", errors="ignore")
+    if isinstance(raw, str):
+        normalized = _normalize_path(raw)
+        if normalized:
+            _memory_cache = (normalized, now + 60.0)
+            return normalized
+    return None
+
+
+def build_status_candidates(base_paths: Sequence[str]) -> list[str]:
+    """Return ordered MJ status endpoints honouring cached preference."""
+
+    candidates = _deduplicate(base_paths)
+    if not candidates:
+        return []
+
+    cached = _load_cached_path()
+    if cached and cached in candidates:
+        return [cached] + [p for p in candidates if p != cached]
+    return candidates
+
+
+def remember_status_path(path: str, *, ttl: int = _STATUS_CACHE_TTL) -> None:
+    """Persist the working status endpoint for subsequent requests."""
+
+    normalized = _normalize_path(path)
+    if not normalized:
+        return
+
+    expires_at = _now() + max(1, ttl)
+    global _memory_cache
+    _memory_cache = (normalized, expires_at)
+
+    if rds is None:
+        return
+
+    try:
+        rds.setex(_STATUS_CACHE_KEY, max(1, int(ttl)), normalized)
+    except Exception:  # pragma: no cover - defensive guard
+        _log.debug("mj.status.cache.redis_set_failed", exc_info=True)
+
+
+def clear_status_cache() -> None:
+    """Drop cached MJ status endpoint preference."""
+
+    global _memory_cache
+    _memory_cache = None
+
+    if rds is None:
+        return
+    try:
+        rds.delete(_STATUS_CACHE_KEY)
+    except Exception:  # pragma: no cover - defensive guard
+        _log.debug("mj.status.cache.redis_del_failed", exc_info=True)
+
+
+__all__ = [
+    "build_status_candidates",
+    "remember_status_path",
+    "clear_status_cache",
+]

--- a/settings.py
+++ b/settings.py
@@ -122,6 +122,7 @@ def _populate_from_settings() -> None:
     g["FEATURE_PROFILE_SIMPLE"] = bool(settings.FEATURE_PROFILE_SIMPLE)
     g["PROFILE_LAZY_INVITE"] = bool(settings.PROFILE_LAZY_INVITE)
     g["ROUTER_LEGACY_BRIDGE"] = bool(settings.ROUTER_LEGACY_BRIDGE)
+    g["ROUTER_LEGACY_OFF"] = bool(settings.ROUTER_LEGACY_OFF)
     g["PAYMENTS_STARS_ENABLED"] = bool(settings.PAYMENTS_STARS_ENABLED)
 
     g["PUBLIC_BASE_URL"] = settings.PUBLIC_BASE_URL

--- a/sora2_client.py
+++ b/sora2_client.py
@@ -588,40 +588,56 @@ async def kie_create_sora2_task(
 
     endpoint = _kie_create_endpoint()
     headers = _kie_headers(json_payload=True)
-    async with httpx.AsyncClient(timeout=60.0) as client:
-        response = await client.post(endpoint, json=payload, headers=headers)
-    if response.status_code == 404:
-        logger.error(
-            "sora2.fail_404",
-            extra={"url": endpoint, "payload": _sanitize_payload_for_log(payload)},
+    async def _submit_once() -> tuple[Optional[str], bool]:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(endpoint, json=payload, headers=headers)
+        if response.status_code == 404:
+            logger.error(
+                "sora2.fail_404",
+                extra={"url": endpoint, "payload": _sanitize_payload_for_log(payload)},
+            )
+            return None, False
+        logger.info(
+            "kie.http.create",
+            extra={
+                "status": response.status_code,
+                "elapsed_ms": _elapsed_ms(response),
+            },
         )
+        response.raise_for_status()
+        try:
+            data = response.json()
+        except Exception as exc:  # pragma: no cover - unexpected payload
+            raise RuntimeError("KIE: invalid JSON response") from exc
+        task_id: Optional[str] = None
+        if isinstance(data, Mapping):
+            data_block = data.get("data")
+            if isinstance(data_block, Mapping):
+                raw_task = data_block.get("taskId") or data_block.get("task_id")
+                if raw_task:
+                    task_id = str(raw_task)
+            if not task_id:
+                raw_task = data.get("taskId") or data.get("task_id")
+                if raw_task:
+                    task_id = str(raw_task)
+        return task_id, True
+
+    task_id, retryable = await _submit_once()
+    if task_id:
+        return task_id
+    if not retryable:
         return None
-    logger.info(
-        "kie.http.create",
-        extra={
-            "status": response.status_code,
-            "elapsed_ms": _elapsed_ms(response),
-        },
+
+    await asyncio.sleep(0.18)
+    task_id, _ = await _submit_once()
+    if task_id:
+        return task_id
+
+    logger.error(
+        "sora2.submit_failed",
+        extra={"url": endpoint, "payload": _sanitize_payload_for_log(payload)},
     )
-    response.raise_for_status()
-    try:
-        data = response.json()
-    except Exception as exc:  # pragma: no cover - unexpected payload
-        raise RuntimeError("KIE: invalid JSON response") from exc
-    task_id: Optional[str] = None
-    if isinstance(data, Mapping):
-        data_block = data.get("data")
-        if isinstance(data_block, Mapping):
-            raw_task = data_block.get("taskId") or data_block.get("task_id")
-            if raw_task:
-                task_id = str(raw_task)
-        if not task_id:
-            raw_task = data.get("taskId") or data.get("task_id")
-            if raw_task:
-                task_id = str(raw_task)
-    if not task_id:
-        raise RuntimeError("KIE: taskId is empty")
-    return task_id
+    return None
 
 
 async def kie_poll_sora2(

--- a/tests/test_profile_metrics_labels.py
+++ b/tests/test_profile_metrics_labels.py
@@ -1,7 +1,6 @@
-from metrics import profile_first_paint_ms, profile_open_total, profile_render_ms
+from metrics import profile_first_paint_ms, profile_open_total
 
 
 def test_profile_metrics_accept_expected_labels():
-    profile_render_ms.labels(force_refresh="true", source="button")
-    profile_open_total.labels(force_refresh="false", source="menu", result="ok")
-    profile_first_paint_ms.labels(force_refresh="false", source="unknown")
+    profile_open_total.labels(source="menu", result="ok")
+    profile_first_paint_ms.labels(source="unknown")

--- a/ui/buttons/router.py
+++ b/ui/buttons/router.py
@@ -11,7 +11,9 @@ from typing import Mapping, Optional
 from metrics import (
     callback_ack_latency_ms,
     inc as metrics_inc,
+    lbl_safe,
     router_callback_legacy_total,
+    router_callback_unmatched_total,
     ui_ack_latency_ms,
     ui_callback_ack_latency_ms,
     ui_callback_ack_total,
@@ -40,6 +42,11 @@ _BOT_LABELS = {"env": _ENV, "service": "bot"}
 
 
 def _legacy_bridge_enabled() -> bool:
+    try:
+        if getattr(app_settings, "ROUTER_LEGACY_OFF", False):
+            return False
+    except Exception:  # pragma: no cover - defensive
+        pass
     try:
         return bool(getattr(app_settings, "ROUTER_LEGACY_BRIDGE"))
     except Exception:  # pragma: no cover - defensive
@@ -83,6 +90,7 @@ _LEGACY_PROFILE_ALIASES: dict[str, tuple[str, str]] = {
 }
 
 _STARS_BUY_PATTERN = re.compile(r"^stars:buy:(\d+)$", re.IGNORECASE)
+_PROFILE_ROUTE_PATTERN = re.compile(r"^profile:(invite|promo)$", re.IGNORECASE)
 
 
 def _parse_params(parts: list[str]) -> dict[str, str]:
@@ -106,6 +114,30 @@ def normalize_callback_data(data: str) -> NormalizedCallback:
 
     lowered = stripped.lower()
 
+    if lowered == "nav:back":
+        return NormalizedCallback(
+            raw=stripped,
+            normalized="nav:back",
+            namespace="nav",
+            action="back",
+            payload=payload,
+            legacy=False,
+            dedupe_key="nav:back",
+        )
+
+    profile_direct = _PROFILE_ROUTE_PATTERN.match(stripped)
+    if profile_direct:
+        action_name = profile_direct.group(1).lower()
+        return NormalizedCallback(
+            raw=stripped,
+            normalized=stripped,
+            namespace="profile",
+            action=action_name,
+            payload=payload,
+            legacy=False,
+            dedupe_key=f"profile:{action_name}",
+        )
+
     stars_match = _STARS_BUY_PATTERN.match(stripped)
     if stars_match:
         try:
@@ -113,14 +145,14 @@ def normalize_callback_data(data: str) -> NormalizedCallback:
         except (TypeError, ValueError):
             amount = None
         if amount is not None:
-            payload = {"amount": amount, "legacy": True}
+            payload = {"amount": amount}
             return NormalizedCallback(
                 raw=stripped,
                 normalized="stars:buy",
-                namespace="payments",
-                action="stars_buy",
+                namespace="stars",
+                action="buy",
                 payload=payload,
-                legacy=True,
+                legacy=False,
                 dedupe_key=f"stars:buy:{amount}",
             )
 
@@ -138,8 +170,11 @@ def normalize_callback_data(data: str) -> NormalizedCallback:
         if action == "profile":
             view_raw = payload.pop("view", None)
             view = str(view_raw or "").strip().lower()
-            if view and view != "open":
-                namespace = "profile"
+            namespace = "profile"
+            if not view or view == "open":
+                action = "open"
+                dedupe_key = "btn:profile"
+            else:
                 action = view
                 dedupe_key = f"{base}|view={view}"
         return NormalizedCallback(
@@ -461,7 +496,7 @@ async def _log_unmatched(data: str, update: Update, *, legacy: bool = False) -> 
     user_id = getattr(user, "id", None)
     chat_id = getattr(chat, "id", None)
 
-    log.info(
+    log.warning(
         "ui.callback.unmatched data=%r user_id=%s chat_id=%s legacy=%s",
         data,
         user_id,
@@ -475,6 +510,8 @@ async def _log_unmatched(data: str, update: Update, *, legacy: bool = False) -> 
         )
     except Exception:  # pragma: no cover - metrics guard
         log.debug("ui.callback.unmatched.metric_failed", exc_info=True)
+    counter = lbl_safe(router_callback_unmatched_total, data=str(data))
+    counter and counter.inc()
     increment_ui_callback_counter("callback", "unmatched")
 
 

--- a/utils/input_state.py
+++ b/utils/input_state.py
@@ -5,7 +5,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, Mapping, Optional, Tuple, Literal
+from typing import Any, Dict, Mapping, Optional, Tuple, Literal, Collection
 import inspect
 
 import time
@@ -212,6 +212,31 @@ def clear_wait_state(user_id: int, *, reason: str = "manual") -> None:
             _logger.exception("Failed to clear wait-state in redis", extra={"user_id": user_id})
     _memory_store.pop(int(user_id), None)
     _logger.info("WAIT_CLEAR user_id=%s reason=%s", user_id, reason)
+
+
+def clear_wait_states(
+    user_id: int,
+    *,
+    exclude: Collection[str] | None = None,
+    reason: str = "manual",
+) -> bool:
+    """Clear wait state for ``user_id`` unless ``kind`` is excluded."""
+
+    state = get_wait_state(user_id)
+    if not state:
+        return False
+
+    excluded: set[str]
+    if exclude:
+        excluded = {str(item).strip().lower() for item in exclude if str(item).strip()}
+    else:
+        excluded = set()
+
+    if state.kind.value.strip().lower() in excluded:
+        return False
+
+    clear_wait_state(user_id, reason=reason)
+    return True
 
 
 def refresh_card_pointer(user_id: int, new_message_id: int) -> None:


### PR DESCRIPTION
## Summary
- restructure Prometheus helpers and migrate profile handler to Redis-backed single-flight with safe metrics updates
- add Telegram Stars top-up flow with router integration and Stars payment refresh logic
- harden Sora2 submission by retrying empty task ids and remember Midjourney status endpoints via Redis cache

## Testing
- pytest tests/test_video_sora2.py --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68fd33c84118832298307c82acf8c352