### PR TITLE
Improve error hygiene and button handling

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -216,6 +216,9 @@ from utils.suno_modes import (
     default_style_text as suno_default_style_text,
     get_mode_config as get_suno_mode_config,
 )
+from utils.errors import notify_admin
+
+BANANA_SENSITIVE_MARKERS = ("code=422", "E005")
 from utils.input_state import (
     WaitInputState,
     WaitKind,
@@ -21074,18 +21077,32 @@ async def _banana_run_and_send(
                 "❌ Не удалось отправить изображение Banana. Попробуйте позже.",
             )
     except KieBananaError as e:
-        new_balance = await _refund("error", str(e))
-        msg = f"❌ Banana ошибка: {e}\nПроизошла ошибка, 5💎 возвращены."
+        error_text = str(e)
+        new_balance = await _refund("error", error_text)
+        if any(marker in error_text for marker in BANANA_SENSITIVE_MARKERS):
+            base_msg = "❌ Нельзя обработать этот запрос. Попробуйте заменить входные данные."
+        else:
+            base_msg = "❌ Произошла ошибка. Попробуйте ещё раз позже."
+        refund_note = " Произошла ошибка, 5💎 возвращены."
         if new_balance is not None:
-            msg += f" Текущий баланс: {new_balance}."
-        await ctx.bot.send_message(chat_id, msg)
+            refund_note += f" Текущий баланс: {new_balance}💎."
+        await ctx.bot.send_message(chat_id, base_msg + refund_note)
+        await notify_admin(
+            ctx.bot,
+            f"Banana fail | task_id={task_info.get('id')} error={error_text}",
+        )
     except Exception as e:
-        new_balance = await _refund("exception", str(e))
+        error_text = str(e)
+        new_balance = await _refund("exception", error_text)
         log.exception("BANANA unexpected: %s", e)
         msg = "💥 Внутренняя ошибка Banana. Произошла ошибка, 5💎 возвращены."
         if new_balance is not None:
-            msg += f" Текущий баланс: {new_balance}."
+            msg += f" Текущий баланс: {new_balance}💎."
         await ctx.bot.send_message(chat_id, msg)
+        await notify_admin(
+            ctx.bot,
+            f"Banana exception | task_id={task_info.get('id')} error={error_text}",
+        )
 
 async def on_photo(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     await ensure_user_record(update)

--- a/tests/test_reply_buttons.py
+++ b/tests/test_reply_buttons.py
@@ -1,7 +1,6 @@
 import asyncio
-from types import SimpleNamespace
-
 import asyncio
+import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -12,14 +11,16 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-import os
-
 os.environ.setdefault("TELEGRAM_TOKEN", "test-token")
 os.environ.setdefault("REDIS_URL", "memory://")
 os.environ.setdefault("KIE_API_KEY", "test-key")
 
 import hub_router
+import bot as bot_module
+import handlers.sum as sum_module
+import ui.buttons.router as router
 from keyboards import TEXT_ACTION_VARIANTS
+from utils.input_state import clear_wait_state, set_wait
 
 
 class StubBot:
@@ -84,3 +85,171 @@ def test_reply_button_routes_text_dispatch(text, expected):
 def test_text_action_variants_cover_reply_labels(label):
     normalized = hub_router.resolve_text_action(label)
     assert normalized is not None
+
+
+def test_profile_button_debounced_ack(monkeypatch):
+    router._LAST_CALLBACK_AT.clear()
+    monkeypatch.setattr(router, "DEBOUNCE_SEC", 0.6)
+
+    ack_calls: list[str] = []
+    dispatch_calls: list[tuple[str, str]] = []
+
+    async def fake_safe_answer(query, cache_time=0):  # type: ignore[override]
+        ack_calls.append(query.data)
+        return "ok"
+
+    async def fake_dispatch(action, update, ctx, *, raw_data, payload=None, legacy=False):  # type: ignore[override]
+        dispatch_calls.append(("registry", action))
+
+    async def fake_namespace(normalized, update, ctx):  # type: ignore[override]
+        dispatch_calls.append(("namespace", f"{normalized.namespace}:{normalized.action}"))
+
+    monkeypatch.setattr(router, "safe_answer", fake_safe_answer)
+    monkeypatch.setattr(router, "dispatch_via_registry", fake_dispatch)
+    monkeypatch.setattr(router, "should_process", lambda user_id, key: True)
+    monkeypatch.setattr(router, "_dispatch_namespace_callback", fake_namespace)
+
+    query = SimpleNamespace(data="btn:profile", _ui_button_handled=False)
+    update = SimpleNamespace(
+        callback_query=query,
+        effective_chat=SimpleNamespace(id=1),
+        effective_user=SimpleNamespace(id=42),
+    )
+
+    asyncio.run(router.on_callback(update, SimpleNamespace()))
+    assert dispatch_calls == [("namespace", "profile:open")]
+
+    dispatch_calls.clear()
+    ack_calls.clear()
+    router._LAST_CALLBACK_AT[(42, "btn:profile")] = router.time.monotonic()
+
+    asyncio.run(router.on_callback(update, SimpleNamespace()))
+
+    assert dispatch_calls == []
+    assert len(ack_calls) == 1
+
+
+def test_sum_text_routed_to_sum(monkeypatch):
+    user_id = 101
+    chat_id = 202
+
+    events: list[tuple[str, str, int]] = []
+
+    async def fake_handle(ctx, message, cleaned_text, wait_state, *, user_id=None):  # type: ignore[override]
+        events.append((cleaned_text, wait_state.kind.value, int(user_id or 0)))
+        return True
+
+    monkeypatch.setattr(sum_module, "handle_wait_input", fake_handle)
+
+    class StubMessage:
+        def __init__(self) -> None:
+            self.chat_id = chat_id
+            self.text = "Привет"
+            self.message_id = 77
+            self.replies: list[str] = []
+
+        async def reply_text(self, text, **kwargs):  # type: ignore[override]
+            self.replies.append(text)
+
+    message = StubMessage()
+    update = SimpleNamespace(
+        effective_message=message,
+        message=message,
+        effective_user=SimpleNamespace(id=user_id),
+    )
+
+    ctx = SimpleNamespace(bot=None, user_data={})
+
+    set_wait(user_id, "sum_prompt", message.message_id, chat_id=chat_id, meta={})
+
+    try:
+        asyncio.run(bot_module.handle_card_input(update, ctx))
+    finally:
+        clear_wait_state(user_id)
+
+    assert events == [("Привет", "sum_prompt", user_id)]
+    assert "✅ Принято" in message.replies
+
+
+def test_sum_start_without_draft(monkeypatch):
+    alert_calls: list[dict[str, object]] = []
+
+    class StubQuery:
+        async def answer(self, text=None, show_alert=False):  # type: ignore[override]
+            alert_calls.append({"text": text, "show_alert": show_alert})
+
+    callback = SimpleNamespace(
+        query=StubQuery(),
+        user_id=303,
+        chat_id=404,
+        application_context=SimpleNamespace(bot=None),
+        card_message_id=None,
+        update=SimpleNamespace(),
+    )
+
+    class _CounterStub:
+        def labels(self, **kwargs):  # type: ignore[override]
+            return self
+
+        def inc(self):  # type: ignore[override]
+            return None
+
+    monkeypatch.setattr(sum_module, "_acquire_run", lambda user_id: True)
+    monkeypatch.setattr(sum_module, "_release_run", lambda user_id: None)
+    monkeypatch.setattr(sum_module, "_load_payload", lambda user_id: None)
+    monkeypatch.setattr(sum_module, "sum_start_total", _CounterStub())
+
+    asyncio.run(sum_module.start_from_callback(callback))
+
+    assert alert_calls and alert_calls[-1] == {
+        "text": "Нет текста для суммирования.",
+        "show_alert": True,
+    }
+
+
+def test_banana_sensitive_hidden_from_user(monkeypatch):
+    messages: list[str] = []
+    admin_alerts: list[str] = []
+
+    class StubBot:
+        async def send_message(self, chat_id, text, **kwargs):  # type: ignore[override]
+            messages.append(text)
+
+    async def fake_show_balance_notification(*args, **kwargs):  # pragma: no cover - test stub
+        return None
+
+    async def fake_show_banana_card(*args, **kwargs):  # pragma: no cover - test stub
+        return None
+
+    def fake_credit_balance(user_id, amount, *, reason, meta):  # type: ignore[override]
+        return 95
+
+    def fake_create_task(*args, **kwargs):
+        raise bot_module.KieBananaError("banana fail: code=422 E005")
+
+    monkeypatch.setattr(bot_module, "state", lambda ctx: {})
+    monkeypatch.setattr(bot_module, "show_banana_card", fake_show_banana_card)
+    monkeypatch.setattr(bot_module, "show_balance_notification", fake_show_balance_notification)
+    monkeypatch.setattr(bot_module, "credit_balance", fake_credit_balance)
+    monkeypatch.setattr(bot_module, "create_banana_task", fake_create_task)
+    monkeypatch.setattr(bot_module, "wait_for_banana_result", lambda *args, **kwargs: [])
+    async def fake_notify_admin(bot, text):  # type: ignore[override]
+        admin_alerts.append(text)
+
+    monkeypatch.setattr(bot_module, "notify_admin", fake_notify_admin)
+
+    ctx = SimpleNamespace(bot=StubBot())
+
+    asyncio.run(
+        bot_module._banana_run_and_send(
+            chat_id=111,
+            ctx=ctx,
+            prompt="demo",
+            price=5,
+            user_id=222,
+        )
+    )
+
+    assert messages and "422" not in messages[-1]
+    assert "Нельзя обработать" in messages[-1]
+    assert admin_alerts and "code=422" in admin_alerts[-1]

--- a/ui/buttons/router.py
+++ b/ui/buttons/router.py
@@ -41,6 +41,13 @@ log = logging.getLogger(__name__)
 _ENV = (os.getenv("APP_ENV") or "prod").strip() or "prod"
 _BOT_LABELS = {"env": _ENV, "service": "bot"}
 
+try:
+    DEBOUNCE_SEC = float(os.getenv("DEBOUNCE_SEC", "0.6") or "0")
+except ValueError:
+    DEBOUNCE_SEC = 0.6
+DEBOUNCE_SEC = max(DEBOUNCE_SEC, 0.0)
+_LAST_CALLBACK_AT: dict[tuple[int, str], float] = {}
+
 
 def _legacy_bridge_enabled() -> bool:
     try:
@@ -591,6 +598,26 @@ async def on_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     normalized = normalize_callback_data(raw_data)
     if not normalized.raw:
         return
+
+    user = getattr(update, "effective_user", None)
+    user_id = getattr(user, "id", None)
+    dedupe_key = normalized.dedupe_key
+    if (
+        DEBOUNCE_SEC > 0.0
+        and user_id is not None
+        and isinstance(dedupe_key, str)
+        and dedupe_key
+    ):
+        now = time.monotonic()
+        key = (int(user_id), dedupe_key)
+        last_at = _LAST_CALLBACK_AT.get(key)
+        if last_at is not None and now - last_at < DEBOUNCE_SEC:
+            log.debug(
+                "ui.callback.debounced",
+                extra={"user_id": user_id, "data": dedupe_key, "elapsed": round(now - last_at, 3)},
+            )
+            return
+        _LAST_CALLBACK_AT[key] = now
 
     payload = dict(normalized.payload)
     payload.setdefault("callback_started_at", started)

--- a/utils/errors.py
+++ b/utils/errors.py
@@ -1,0 +1,30 @@
+import os
+
+from telegram import Message
+from telegram.constants import ParseMode
+
+
+ADMIN_IDS = {
+    int(x)
+    for x in os.getenv("ADMIN_IDS", "").split(",")
+    if x
+}
+
+
+async def notify_admin(bot, text: str) -> None:
+    for admin_id in ADMIN_IDS:
+        try:
+            await bot.send_message(
+                admin_id,
+                f"⚠️ {text}",
+                parse_mode=ParseMode.HTML,
+            )
+        except Exception:
+            pass
+
+
+async def user_safe_error(msg: Message, user_text: str) -> None:
+    try:
+        await msg.reply_text(user_text, disable_web_page_preview=True)
+    except Exception:
+        pass

--- a/utils/input_state.py
+++ b/utils/input_state.py
@@ -297,6 +297,10 @@ def get_wait(user_id: int) -> Optional[WaitInputState]:
     return get_wait_state(user_id)
 
 
+def is_sum_prompt(state: Optional[WaitInputState]) -> bool:
+    return bool(state and state.kind == WaitKind.SUM_PROMPT)
+
+
 def is_waiting(user_id: int) -> bool:
     return get_wait_state(user_id) is not None
 


### PR DESCRIPTION
## Summary
- hide Banana sensitive failure details from end users while notifying admins
- add per-user callback debouncing and a helper for SUM wait-state handling
- cover the new behaviour with focused reply button tests

## Testing
- pytest tests/test_reply_buttons.py

------
https://chatgpt.com/codex/tasks/task_e_68fddfe48a388322afea789365cdda59