### PR TITLE
Refine logging and Banana upload workflow

### DIFF
--- a/handlers/banana.py
+++ b/handlers/banana.py
@@ -1,0 +1,52 @@
+"""Banana image editing handler."""
+from __future__ import annotations
+
+import asyncio
+
+from logging_utils import get_logger
+from services.banana_client import banana_process, banana_upload_bytes
+from utils.files import tg_image_bytes, validate_image
+from utils.notify import admin_warn, user_error
+
+log = get_logger("handlers.banana")
+
+MODEL = "banana-nana"
+
+
+async def handle_banana_start(message, context) -> None:
+    bot = context.bot
+    chat_id = message.chat_id
+    try:
+        data = await tg_image_bytes(message, bot)
+        validate_image(data)
+    except Exception as exc:
+        await user_error(
+            bot,
+            chat_id,
+            "Отправьте фото как *файл* (без сжатия) — текущее изображение не удалось прочитать.",
+        )
+        await admin_warn(bot, f"Banana input validate fail: {exc}")
+        return
+
+    upload_id: str | None = None
+    try:
+        upload = await banana_upload_bytes(bytes(data), filename="input.png")
+        upload_id = upload.get("upload_id") or upload.get("id") or upload.get("temp_url")
+        if not upload_id:
+            raise RuntimeError(f"upload response malformed: {upload}")
+        response = await banana_process(MODEL, {"upload_id": upload_id})
+    except Exception:
+        await asyncio.sleep(1.0)
+        try:
+            response = await banana_process(MODEL, {"upload_id": upload_id})
+        except Exception as retry_exc:
+            await user_error(
+                bot,
+                chat_id,
+                "Сервис обработки временно недоступен. Попробуйте ещё раз.",
+            )
+            await admin_warn(bot, f"Banana 500: {retry_exc}")
+            return
+
+    log.debug("banana.process", extra={"chat_id": chat_id, "response": response})
+    # Further response handling should happen here.

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -4,7 +4,7 @@ from typing import Sequence
 
 from telegram import InlineKeyboardButton
 
-from keyboards import CB, kb_main
+from keyboards import CB, FEATURE_PM_ENABLED, kb_main
 from texts import (
     TXT_AI_DIALOG_CHOOSE,
     TXT_AI_DIALOG_NORMAL,
@@ -18,7 +18,27 @@ from texts import (
 )
 from ui.card import build_card
 
+from logging_utils import get_logger
+
+log = get_logger("handlers.menu")
+
 _MAIN_MENU_SUBTITLE = "Выберите раздел:"
+
+
+async def on_menu_dialog(update, context) -> None:
+    """Switch the user into chat mode immediately."""
+
+    chat = getattr(update, "effective_chat", None)
+    if chat is None:
+        return
+    chat_id = chat.id
+    await context.bot.send_message(chat_id, "Напиши запрос — это обычный чат с ИИ.")
+    try:
+        context.user_data["mode"] = "chat"
+    except Exception:
+        log.debug("menu.dialog.set_mode.failed", exc_info=True)
+    else:
+        log.debug("menu.dialog.mode_set", extra={"chat_id": chat_id})
 
 
 def build_main_menu_card() -> dict:
@@ -84,17 +104,22 @@ def build_video_card(*, veo_fast_cost: int, veo_photo_cost: int, sora2_cost: int
 
 
 def build_dialog_card() -> dict:
-    rows = [
-        [
-            InlineKeyboardButton(TXT_AI_DIALOG_NORMAL, callback_data="mode:chat"),
-            InlineKeyboardButton(TXT_AI_DIALOG_PM, callback_data="mode:prompt_master"),
-        ],
-        [InlineKeyboardButton("⬅️ Назад", callback_data="back")],
-    ]
-    return build_card(TXT_KB_AI_DIALOG, TXT_AI_DIALOG_CHOOSE, rows)
+    subtitle = TXT_AI_DIALOG_CHOOSE if FEATURE_PM_ENABLED else "Напиши запрос — это обычный чат с ИИ."
+    if FEATURE_PM_ENABLED:
+        rows = [
+            [
+                InlineKeyboardButton(TXT_AI_DIALOG_NORMAL, callback_data="mode:chat"),
+                InlineKeyboardButton(TXT_AI_DIALOG_PM, callback_data="mode:prompt_master"),
+            ],
+            [InlineKeyboardButton("⬅️ Назад", callback_data="back")],
+        ]
+    else:
+        rows = [[InlineKeyboardButton("⬅️ Назад", callback_data="back")]]
+    return build_card(TXT_KB_AI_DIALOG, subtitle, rows)
 
 
 __all__ = [
+    "on_menu_dialog",
     "build_dialog_card",
     "build_main_menu_card",
     "build_music_card",

--- a/keyboards.py
+++ b/keyboards.py
@@ -1,6 +1,7 @@
 import logging
-from functools import lru_cache
+import os
 import re
+from functools import lru_cache
 from typing import Dict, Iterable, List, Optional, Tuple
 
 from telegram import (
@@ -13,6 +14,8 @@ from telegram import (
 
 from utils.text_normalizer import normalize_btn_text
 
+
+FEATURE_PM_ENABLED = os.getenv("FEATURE_PM_ENABLED", "0") == "1"
 
 log = logging.getLogger(__name__)
 
@@ -226,14 +229,10 @@ def build_main_reply_kb() -> ReplyKeyboardMarkup:
 
 
 def dialog_picker_inline() -> InlineKeyboardMarkup:
-    return InlineKeyboardMarkup(
-        [
-            [
-                InlineKeyboardButton("💬 Обычный чат", callback_data=DIALOG_PICK_REGULAR),
-                InlineKeyboardButton("📝 Prompt-Master", callback_data=DIALOG_PICK_PM),
-            ]
-        ]
-    )
+    buttons = [InlineKeyboardButton("💬 Обычный чат", callback_data=DIALOG_PICK_REGULAR)]
+    if FEATURE_PM_ENABLED:
+        buttons.append(InlineKeyboardButton("📝 Prompt-Master", callback_data=DIALOG_PICK_PM))
+    return InlineKeyboardMarkup([buttons])
 
 
 def build_empty_reply_kb() -> ReplyKeyboardRemove:
@@ -445,15 +444,17 @@ def faq_keyboard() -> InlineKeyboardMarkup:
             InlineKeyboardButton("💎 Баланс и оплата", callback_data=f"{CB_FAQ_PREFIX}billing"),
             InlineKeyboardButton("⚡ Токены и возвраты", callback_data=f"{CB_FAQ_PREFIX}tokens"),
         ],
-        [
-            InlineKeyboardButton("💬 Обычный чат", callback_data=f"{CB_FAQ_PREFIX}chat"),
-            InlineKeyboardButton("🧠 Prompt-Master", callback_data=f"{CB_FAQ_PREFIX}pm"),
-        ],
+    ]
+    chat_row = [InlineKeyboardButton("💬 Обычный чат", callback_data=f"{CB_FAQ_PREFIX}chat")]
+    if FEATURE_PM_ENABLED:
+        chat_row.append(InlineKeyboardButton("🧠 Prompt-Master", callback_data=f"{CB_FAQ_PREFIX}pm"))
+    rows.append(chat_row)
+    rows.append(
         [
             InlineKeyboardButton("ℹ️ Общие вопросы", callback_data=f"{CB_FAQ_PREFIX}common"),
             InlineKeyboardButton("⬅️ Назад (в главное)", callback_data=f"{CB_FAQ_PREFIX}back"),
-        ],
-    ]
+        ]
+    )
     return InlineKeyboardMarkup(rows)
 
 
@@ -490,16 +491,20 @@ def menu_main_like() -> InlineKeyboardMarkup:
 def menu_bottom_unified() -> InlineKeyboardMarkup:
     """Единое меню для перехода между режимами внутри карточек."""
 
-    return build_menu(
+    rows: list[list[tuple[str, str]]] = [
+        [(f"{EMOJI['video']} Генерация видео", "nav_video")],
+        [(f"{EMOJI['image']} Генерация изображений", "nav_image")],
+        [(f"{EMOJI['music']} Генерация музыки", "nav_music")],
+    ]
+    if FEATURE_PM_ENABLED:
+        rows.append([(f"{EMOJI['prompt']} Prompt-Master", "nav_prompt")])
+    rows.extend(
         [
-            [(f"{EMOJI['video']} Генерация видео", "nav_video")],
-            [(f"{EMOJI['image']} Генерация изображений", "nav_image")],
-            [(f"{EMOJI['music']} Генерация музыки", "nav_music")],
-            [(f"{EMOJI['prompt']} Prompt-Master", "nav_prompt")],
             [(f"{EMOJI['chat']} Обычный чат", "nav_chat")],
             [(f"{EMOJI['profile']} Профиль", "btn:profile|src=nav")],
         ]
     )
+    return build_menu(rows)
 
 
 def menu_pay_unified() -> InlineKeyboardMarkup:

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -11,6 +11,8 @@ import traceback
 from datetime import datetime, timezone
 from typing import Any, Mapping, MutableMapping
 
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+
 RESERVED = {
     "name",
     "msg",
@@ -35,6 +37,18 @@ RESERVED = {
     "message",
     "asctime",
 }
+
+
+class SubstringFilter(logging.Filter):
+    """Filter log records that contain noisy substrings."""
+
+    def __init__(self, patterns: list[str]):
+        super().__init__()
+        self._patterns = [re.compile(p) for p in patterns]
+
+    def filter(self, record: logging.LogRecord) -> bool:  # type: ignore[override]
+        message = record.getMessage()
+        return not any(pattern.search(message) for pattern in self._patterns)
 
 
 def _ensure_mapping(value: Any) -> dict[str, Any]:
@@ -124,10 +138,39 @@ class SafeLoggerAdapter(logging.LoggerAdapter):
         return msg, kwargs
 
 
+def setup_logging() -> None:
+    """Initialise the root logger with sensible defaults."""
+
+    root = logging.getLogger()
+    if root.handlers:
+        return
+
+    root.setLevel(getattr(logging, LOG_LEVEL, logging.INFO))
+    handler = logging.StreamHandler()
+    fmt = os.getenv("LOG_FORMAT", "%(levelname)s • %(name)s :: %(message)s")
+    handler.setFormatter(logging.Formatter(fmt))
+
+    noisy_patterns = [
+        r"leader: heartbeat ok",
+        r"EVT_LOCK_HEARTBEAT",
+        r"WAIT_SET ",
+        r"WAIT_CLEAR ",
+        r"invite\.url",
+        r"profile\.invite_link",
+        r"ui\.callback\.unmatched",
+        r"card_edit_noop",
+    ]
+    handler.addFilter(SubstringFilter(noisy_patterns))
+    root.addHandler(handler)
+
+
 def get_logger(name: str) -> SafeLoggerAdapter:
     """Return a sanitizing adapter for the named logger."""
 
+    setup_logging()
     base = logging.getLogger(name)
+    if name in {"ui.buttons.router"}:
+        base.setLevel(logging.DEBUG)
     return SafeLoggerAdapter(base, {})
 
 
@@ -157,6 +200,9 @@ def log_error(logger: logging.Logger, msg: str, *args: Any, **kwargs: Any) -> No
 
     _wrap_extra(kwargs)
     logger.error(msg, *args, **kwargs)
+
+
+setup_logging()
 
 
 logging.setLoggerClass(SanitizingLogger)

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service client helpers."""

--- a/services/banana_client.py
+++ b/services/banana_client.py
@@ -1,0 +1,32 @@
+"""Thin Banana API client."""
+from __future__ import annotations
+
+import os
+
+import aiohttp
+
+BANANA_KEY = os.getenv("BANANA_KEY")
+BANANA_UPLOAD = os.getenv("BANANA_UPLOAD", "https://api.banana.dev/v1/upload")
+BANANA_PROCESS = os.getenv("BANANA_PROCESS", "https://api.banana.dev/v1/process")
+
+
+async def banana_upload_bytes(data: bytes, filename: str = "image.png") -> dict:
+    """Upload raw bytes to Banana and return the JSON response."""
+
+    async with aiohttp.ClientSession() as session:
+        form = aiohttp.FormData()
+        form.add_field("file", data, filename=filename, content_type="application/octet-stream")
+        form.add_field("api_key", BANANA_KEY)
+        async with session.post(BANANA_UPLOAD, data=form) as response:
+            response.raise_for_status()
+            return await response.json()
+
+
+async def banana_process(model: str, payload: dict) -> dict:
+    """Trigger Banana model processing using an upload identifier."""
+
+    async with aiohttp.ClientSession() as session:
+        body = {"api_key": BANANA_KEY, "model": model, "input": payload}
+        async with session.post(BANANA_PROCESS, json=body) as response:
+            response.raise_for_status()
+            return await response.json()

--- a/ui/buttons/router.py
+++ b/ui/buttons/router.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import logging
-import re
 import os
+import re
 import time
 import uuid
 from dataclasses import dataclass
@@ -35,9 +34,11 @@ from .types import ButtonContext, ButtonId, ButtonSpec
 from .registry import REGISTRY
 from telegram_utils import safe_answer
 
+from logging_utils import get_logger
+
 import settings as app_settings
 
-log = logging.getLogger(__name__)
+log = get_logger("ui.buttons.router")
 _ENV = (os.getenv("APP_ENV") or "prod").strip() or "prod"
 _BOT_LABELS = {"env": _ENV, "service": "bot"}
 
@@ -545,7 +546,7 @@ async def _log_unmatched(data: str, update: Update, *, legacy: bool = False) -> 
     user_id = getattr(user, "id", None)
     chat_id = getattr(chat, "id", None)
 
-    log.warning(
+    log.debug(
         "ui.callback.unmatched",
         extra={
             "data": data,

--- a/utils/files.py
+++ b/utils/files.py
@@ -1,0 +1,27 @@
+"""Helpers for working with Telegram file attachments."""
+from __future__ import annotations
+
+import imghdr
+
+from telegram import Message
+
+MAX_MB = 25
+
+
+async def tg_image_bytes(message: Message, bot) -> bytes:
+    """Fetch raw bytes for an image contained in ``message``."""
+
+    if message.document and (message.document.mime_type or "").startswith("image/"):
+        file = await bot.get_file(message.document.file_id)
+    else:
+        file = await bot.get_file(message.photo[-1].file_id)
+    return await file.download_as_bytearray()
+
+
+def validate_image(data: bytes) -> None:
+    """Ensure the image payload is supported and within limits."""
+
+    if len(data) > MAX_MB * 1024 * 1024:
+        raise ValueError("image too large")
+    if imghdr.what(None, data) not in {"jpeg", "png", "webp"}:
+        raise ValueError("unsupported image type")

--- a/utils/notify.py
+++ b/utils/notify.py
@@ -1,0 +1,23 @@
+"""Notification helpers for user/admin messaging."""
+from __future__ import annotations
+
+import os
+
+ADMIN_ID = int(os.getenv("ADMIN_ID", "0") or 0)
+
+
+async def user_error(bot, chat_id: int, text: str) -> None:
+    """Send a short error notice to the user."""
+
+    await bot.send_message(chat_id, f"❌ {text}")
+
+
+async def admin_warn(bot, text: str) -> None:
+    """Send a warning to the configured admin user, if any."""
+
+    if not ADMIN_ID:
+        return
+    try:
+        await bot.send_message(ADMIN_ID, f"⚠️ {text[:3500]}")
+    except Exception:
+        pass

--- a/utils/telegram_safe.py
+++ b/utils/telegram_safe.py
@@ -137,3 +137,12 @@ async def safe_send_text(
 
     message_id = getattr(message, "message_id", None)
     return SafeSendResult(ok=True, message=message, error=None, message_id=message_id)
+
+
+async def safe_reply_text(message: Any, text: str, **kwargs: Any) -> Any:
+    """Reply to a Telegram message, swallowing permission-related errors."""
+
+    try:
+        return await message.reply_text(text, **kwargs)
+    except Exception:  # pragma: no cover - defensive wrapper
+        return None


### PR DESCRIPTION
## Summary
- configure logging with runtime filters, default format, and helper to fetch named loggers
- add Banana upload utilities to handle raw image bytes and notify admins on failures
- hide Prompt Master UI behind a flag while letting dialog mode jump straight into normal chat

## Testing
- pytest tests/test_banana_flow.py

------
https://chatgpt.com/codex/tasks/task_e_6906197c62c88322ae5f59f3cb340eba