### PR TITLE
Refactor Banana card UI and state management

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -174,6 +174,10 @@ from ui_helpers import (
     pm_result_kb,
     sync_suno_start_message,
 )
+from ui.renderers.banana import (
+    banana_card_kb as render_banana_card_kb,
+    banana_card_text as render_banana_card_text,
+)
 from stickers import delete_wait_sticker, send_ok_sticker, send_wait_sticker
 
 from core.constants import (
@@ -182,6 +186,7 @@ from core.constants import (
     SORA2_MODEL_IMAGE_TO_VIDEO,
     SORA2_MODEL_TEXT_TO_VIDEO,
 )
+from utils.banana_state import BananaState
 from utils.suno_state import (
     LYRICS_MAX_LENGTH,
     LyricsSource,
@@ -9170,38 +9175,44 @@ MJ_MODE_HINT_TEXT = (
     "🖼 Midjourney включён. Введите промпт сообщением и нажмите «Подтвердить»."
 )
 
-def banana_card_text(s: Dict[str, Any]) -> str:
-    n = len(s.get("banana_images") or [])
-    prompt = (s.get("last_prompt") or "").strip()
-    has_prompt = "есть" if prompt else "нет"
-    snippet = html.escape(_short_prompt(prompt, 200)) if prompt else ""
-    lines = ["🍌 <b>Карточка Banana</b>"]
-    balance = s.get("banana_balance")
-    if balance is not None:
-        lines.insert(1, f"💎 Баланс: <b>{balance}</b>")
-    lines.append(f"📸 Фото: <b>{n}/4</b> • Промпт: <b>{has_prompt}</b>")
-    if prompt:
-        lines.append(f"✏️ Промпт: \"{snippet}\"")
-    else:
-        lines.append("✏️ Промпт: —")
-    return "\n".join(lines)
+def _state_to_banana_state(state: Dict[str, Any]) -> BananaState:
+    images_raw = state.get("banana_images")
+    images: list[str] = []
+    if isinstance(images_raw, list):
+        for entry in images_raw:
+            file_id: Optional[str] = None
+            if isinstance(entry, dict):
+                file_id = (
+                    entry.get("file_id")
+                    or entry.get("url")
+                    or entry.get("file_path")
+                )
+            elif isinstance(entry, str):
+                file_id = entry
+            if file_id:
+                images.append(str(file_id))
+    prompt_raw = (state.get("last_prompt") or "").strip()
+    prompt = prompt_raw or None
+    last_result = state.get("last_banana_result_id")
+    if last_result is not None:
+        last_result = str(last_result)
+    return BananaState(images=images, prompt=prompt, last_result_id=last_result)
 
-def banana_kb() -> InlineKeyboardMarkup:
-    return InlineKeyboardMarkup(
-        [
-            [
-                InlineKeyboardButton("➕ Добавить фото", callback_data="banana:add_more"),
-                InlineKeyboardButton("✏️ Промпт", callback_data="banana:prompt"),
-                InlineKeyboardButton("🧹 Очистить", callback_data="banana:reset_all"),
-            ],
-            [InlineKeyboardButton("✨ Готовые шаблоны", callback_data="banana:templates")],
-            [InlineKeyboardButton("🚀 Начать генерацию", callback_data="banana:start")],
-            [
-                InlineKeyboardButton("🔄 Движок", callback_data="banana:switch_engine"),
-                InlineKeyboardButton("↩️ Назад", callback_data="back"),
-            ],
-        ]
-    )
+
+def banana_card_text(s: Dict[str, Any]) -> str:
+    banana_state = _state_to_banana_state(s)
+    balance_value = 0
+    balance_raw = s.get("banana_balance")
+    if isinstance(balance_raw, (int, float)):
+        balance_value = int(balance_raw)
+    elif isinstance(balance_raw, str) and balance_raw.strip().isdigit():
+        balance_value = int(balance_raw.strip())
+    return render_banana_card_text(balance_value, banana_state)
+
+
+def banana_kb(s: Optional[Dict[str, Any]] = None) -> InlineKeyboardMarkup:
+    banana_state = _state_to_banana_state(s or {})
+    return render_banana_card_kb(banana_state)
 
 
 def banana_generating_markup() -> InlineKeyboardMarkup:
@@ -19002,7 +19013,7 @@ async def show_banana_card(
     text = banana_card_text(s)
     if not force_new and text == s.get("_last_text_banana"):
         return
-    kb = banana_kb()
+    kb = banana_kb(s)
     mid = await upsert_card(
         ctx,
         chat_id,
@@ -20904,7 +20915,9 @@ async def on_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     ):
         if state_mode == "banana":
             if len(_get_banana_images(s)) >= 4:
-                await msg.reply_text("⚠️ Достигнут лимит 4 фото.", reply_markup=banana_kb())
+                await msg.reply_text(
+                    "⚠️ Достигнут лимит 4 фото.", reply_markup=banana_kb(s)
+                )
                 return
             await on_banana_photo_received(chat_id, ctx, text.strip())
             await msg.reply_text(f"📸 Фото принято ({len(s['banana_images'])}/4).")
@@ -21147,7 +21160,9 @@ async def on_photo(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     if s.get("mode") == "banana":
         images = _get_banana_images(s)
         if len(images) >= 4:
-            await message.reply_text("⚠️ Достигнут лимит 4 фото.", reply_markup=banana_kb())
+            await message.reply_text(
+                "⚠️ Достигнут лимит 4 фото.", reply_markup=banana_kb(s)
+            )
             return
         caption = (message.caption or "").strip()
         if caption:
@@ -21218,7 +21233,9 @@ async def on_document(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     if s.get("mode") == "banana":
         images = _get_banana_images(s)
         if len(images) >= 4:
-            await message.reply_text("⚠️ Достигнут лимит 4 фото.", reply_markup=banana_kb())
+            await message.reply_text(
+                "⚠️ Достигнут лимит 4 фото.", reply_markup=banana_kb(s)
+            )
             return
         caption = (message.caption or "").strip()
         if caption:

--- a/handlers/banana.py
+++ b/handlers/banana.py
@@ -1,52 +1,202 @@
-"""Banana image editing handler."""
+"""Handlers for Banana image editing workflow."""
+
 from __future__ import annotations
 
-import asyncio
+from typing import Optional
 
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+from core.balance_provider import aget_balance_snapshot
 from logging_utils import get_logger
 from services.banana_client import banana_process, banana_upload_bytes
-from utils.files import tg_image_bytes, validate_image
+from ui.renderers.banana import banana_card_kb, banana_card_text
+from utils.banana_state import BananaState, clear, load, save
+from utils.files import validate_image
 from utils.notify import admin_warn, user_error
 
 log = get_logger("handlers.banana")
 
-MODEL = "banana-nana"
+MODEL_NAME = "banana-nana"
+MAX_IMAGES = 4
 
 
-async def handle_banana_start(message, context) -> None:
-    bot = context.bot
-    chat_id = message.chat_id
+async def _require_redis(context) -> object:
+    redis = getattr(context, "redis", None)
+    if redis is None:
+        raise RuntimeError("context.redis is not configured")
+    return redis
+
+
+async def _get_balance_value(user_id: int) -> int:
     try:
-        data = await tg_image_bytes(message, bot)
-        validate_image(data)
-    except Exception as exc:
+        snapshot = await aget_balance_snapshot(int(user_id))
+    except Exception:  # pragma: no cover - defensive fallback
+        log.exception("banana.balance_failed", extra={"user_id": user_id})
+        return 0
+    return int(snapshot.value or 0)
+
+
+async def _fetch_file_bytes(bot, file_id: str) -> bytes:
+    tg_file = await bot.get_file(file_id)
+    return await tg_file.download_as_bytearray()
+
+
+async def open_banana_card(update, context) -> None:
+    user_id = update.effective_user.id
+    redis = await _require_redis(context)
+    state = await load(redis, user_id)
+    balance_value = await _get_balance_value(user_id)
+    text = banana_card_text(balance_value, state)
+    await context.bot.send_message(user_id, text, reply_markup=banana_card_kb(state))
+
+
+async def on_banana_photo(update, context) -> None:
+    message = update.effective_message
+    if message is None:
+        return
+    user_id = update.effective_user.id
+    redis = await _require_redis(context)
+    state = await load(redis, user_id)
+    if len(state.images) >= MAX_IMAGES:
         await user_error(
-            bot,
-            chat_id,
-            "Отправьте фото как *файл* (без сжатия) — текущее изображение не удалось прочитать.",
+            context.bot,
+            user_id,
+            f"Максимум {MAX_IMAGES} фото. Удалите лишнее или начните новую генерацию.",
         )
-        await admin_warn(bot, f"Banana input validate fail: {exc}")
+        return
+    file_id: Optional[str] = None
+    if message.photo:
+        file_id = message.photo[-1].file_id
+    elif getattr(message, "document", None) is not None:
+        document = message.document
+        if document and (document.mime_type or "").startswith("image/"):
+            file_id = document.file_id
+    if not file_id:
+        await user_error(
+            context.bot,
+            user_id,
+            "Пришлите фото как изображение или файл без сжатия.",
+        )
+        return
+    state.images.append(file_id)
+    await save(redis, user_id, state)
+    balance_value = await _get_balance_value(user_id)
+    await message.reply_text(
+        banana_card_text(balance_value, state), reply_markup=banana_card_kb(state)
+    )
+
+
+async def on_banana_text(update, context) -> None:
+    message = update.effective_message
+    if message is None or not message.text:
+        return
+    user_id = update.effective_user.id
+    redis = await _require_redis(context)
+    state = await load(redis, user_id)
+    state.prompt = message.text.strip()
+    await save(redis, user_id, state)
+    balance_value = await _get_balance_value(user_id)
+    await message.reply_text(
+        banana_card_text(balance_value, state), reply_markup=banana_card_kb(state)
+    )
+
+
+async def on_banana_start(update, context) -> None:
+    query = update.callback_query
+    if query is None:
+        return
+    await query.answer()
+    user_id = query.from_user.id
+    redis = await _require_redis(context)
+    state = await load(redis, user_id)
+    if not state.ready:
+        await user_error(context.bot, user_id, "Добавьте фото и промпт.")
         return
 
-    upload_id: str | None = None
-    try:
-        upload = await banana_upload_bytes(bytes(data), filename="input.png")
-        upload_id = upload.get("upload_id") or upload.get("id") or upload.get("temp_url")
-        if not upload_id:
-            raise RuntimeError(f"upload response malformed: {upload}")
-        response = await banana_process(MODEL, {"upload_id": upload_id})
-    except Exception:
-        await asyncio.sleep(1.0)
+    uploads: list[str] = []
+    for file_id in state.images:
         try:
-            response = await banana_process(MODEL, {"upload_id": upload_id})
-        except Exception as retry_exc:
-            await user_error(
-                bot,
-                chat_id,
-                "Сервис обработки временно недоступен. Попробуйте ещё раз.",
-            )
-            await admin_warn(bot, f"Banana 500: {retry_exc}")
-            return
+            data = await _fetch_file_bytes(context.bot, file_id)
+        except Exception as exc:
+            await admin_warn(context.bot, f"Banana tg fetch fail: {exc}")
+            continue
+        try:
+            validate_image(data)
+            response = await banana_upload_bytes(bytes(data), filename="input.png")
+        except Exception as exc:
+            await admin_warn(context.bot, f"Banana upload fail: {exc}")
+            continue
+        upload_id = (
+            response.get("upload_id")
+            or response.get("id")
+            or response.get("temp_url")
+        )
+        if upload_id:
+            uploads.append(str(upload_id))
 
-    log.debug("banana.process", extra={"chat_id": chat_id, "response": response})
-    # Further response handling should happen here.
+    if not uploads:
+        await user_error(
+            context.bot,
+            user_id,
+            "Не удалось загрузить изображения. Пришлите фото как файл и попробуйте снова.",
+        )
+        return
+
+    payload = {"upload_ids": uploads, "prompt": state.prompt}
+    try:
+        result = await banana_process(MODEL_NAME, payload)
+        result_bytes = result.get("result_bytes")
+        if not result_bytes:
+            raise RuntimeError("Banana response missing result_bytes")
+        message = await context.bot.send_document(user_id, ("result.png", result_bytes))
+    except Exception as exc:
+        await user_error(context.bot, user_id, "Сервис занят, попробуйте ещё раз.")
+        await admin_warn(context.bot, f"Banana process fail: {exc}")
+        return
+
+    state.last_result_id = str(message.message_id)
+    await save(redis, user_id, state)
+
+    keyboard = InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("🔁 Сгенерировать ещё", callback_data="banana:again")],
+            [InlineKeyboardButton("🆕 Новая генерация", callback_data="banana:new")],
+        ]
+    )
+    await context.bot.send_message(user_id, "Готово ✅", reply_markup=keyboard)
+
+
+async def on_banana_again(update, context) -> None:
+    query = update.callback_query
+    if query is None:
+        return
+    await query.answer()
+    await on_banana_start(update, context)
+
+
+async def on_banana_new(update, context) -> None:
+    query = update.callback_query
+    if query is None:
+        return
+    await query.answer()
+    user_id = query.from_user.id
+    redis = await _require_redis(context)
+    await clear(redis, user_id)
+    state = BananaState(images=[], prompt=None)
+    await save(redis, user_id, state)
+    balance_value = await _get_balance_value(user_id)
+    await context.bot.send_message(
+        user_id,
+        "Новая карточка 🆕 Отправьте фото и промпт.",
+        reply_markup=banana_card_kb(state),
+    )
+
+
+__all__ = [
+    "open_banana_card",
+    "on_banana_photo",
+    "on_banana_text",
+    "on_banana_start",
+    "on_banana_again",
+    "on_banana_new",
+]

--- a/tests/test_banana_card_ui.py
+++ b/tests/test_banana_card_ui.py
@@ -26,8 +26,8 @@ def test_banana_card_compact_summary(bot_module):
     text = bot_module.banana_card_text(state)
 
     assert "Примеры запросов" not in text
-    assert "📸 Фото: <b>1/4</b> • Промпт: <b>нет</b>" in text
-    assert "✏️ Промпт: —" in text
+    assert "📸 Фото: 1/4" in text
+    assert "Промпт: нет" in text
     assert "banana_helper_line" not in state
 
 
@@ -36,18 +36,13 @@ def test_banana_card_shows_prompt(bot_module):
 
     text = bot_module.banana_card_text(state)
 
-    assert '✏️ Промпт: "замени фон на студийный"' in text
-    assert "Промпт: <b>есть</b>" in text
+    assert "Промпт: есть" in text
 
 
 def test_banana_keyboard_layout(bot_module):
     keyboard = bot_module.banana_kb()
     rows = keyboard.inline_keyboard
 
-    assert rows[0][0].text == "➕ Добавить фото"
-    assert rows[0][1].text == "✏️ Промпт"
-    assert rows[0][2].text == "🧹 Очистить"
-    assert len(rows[1]) == 1 and rows[1][0].text == "✨ Готовые шаблоны"
-    assert len(rows[2]) == 1 and rows[2][0].text == "🚀 Начать генерацию"
-    assert rows[3][0].text == "🔄 Движок"
-    assert rows[3][1].text == "↩️ Назад"
+    assert rows[0][0].text == "✨ Готовые шаблоны"
+    assert rows[1][0].text == "⚙️ Движок"
+    assert rows[1][1].text == "⬅️ Назад"

--- a/ui/renderers/banana.py
+++ b/ui/renderers/banana.py
@@ -1,0 +1,32 @@
+"""Helpers to render Banana card UI."""
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+
+def banana_card_text(balance: int, state) -> str:
+    """Return the Banana card caption for ``state``."""
+
+    photos = f"📸 Фото: {len(state.images)}/4"
+    prompt_state = "есть" if state.prompt else "нет"
+    return f"🍌 Карточка Banana\n💎 Баланс: {balance}\n{photos} • Промпт: {prompt_state}"
+
+
+def banana_card_kb(state) -> InlineKeyboardMarkup:
+    """Return inline keyboard for Banana card based on readiness."""
+
+    rows: list[list[InlineKeyboardButton]] = []
+    if state.ready:
+        rows.append(
+            [InlineKeyboardButton("🚀 Начать генерацию", callback_data="banana:start")]
+        )
+    rows.append([InlineKeyboardButton("✨ Готовые шаблоны", callback_data="banana:templates")])
+    rows.append(
+        [
+            InlineKeyboardButton("⚙️ Движок", callback_data="img_engine:banana"),
+            InlineKeyboardButton("⬅️ Назад", callback_data="back_main"),
+        ]
+    )
+    return InlineKeyboardMarkup(rows)
+
+
+__all__ = ["banana_card_text", "banana_card_kb"]

--- a/utils/banana_state.py
+++ b/utils/banana_state.py
@@ -1,0 +1,55 @@
+"""Per-user Banana card state backed by Redis."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import List, Optional
+
+
+@dataclass(slots=True)
+class BananaState:
+    """Store Banana inputs awaiting generation."""
+
+    images: List[str]
+    prompt: Optional[str]
+    last_result_id: Optional[str] = None
+
+    @property
+    def ready(self) -> bool:
+        """Return ``True`` when both prompt and at least one image are present."""
+
+        return bool(self.prompt) and len(self.images) >= 1
+
+
+_KEY_TMPL = "banana:state:{user_id}"
+_TTL_SECONDS = 60 * 60 * 24
+
+
+def _key_for(user_id: int) -> str:
+    return _KEY_TMPL.format(user_id=int(user_id))
+
+
+async def load(redis, user_id: int) -> BananaState:
+    """Load Banana state for ``user_id`` from Redis."""
+
+    raw = await redis.get(_key_for(user_id))
+    if not raw:
+        return BananaState(images=[], prompt=None)
+    data = json.loads(raw)
+    return BananaState(**data)
+
+
+async def save(redis, user_id: int, state: BananaState) -> None:
+    """Persist ``state`` for ``user_id`` with a one-day TTL."""
+
+    await redis.set(_key_for(user_id), json.dumps(asdict(state)), ex=_TTL_SECONDS)
+
+
+async def clear(redis, user_id: int) -> None:
+    """Remove Banana state for ``user_id`` from Redis."""
+
+    await redis.delete(_key_for(user_id))
+
+
+__all__ = ["BananaState", "load", "save", "clear"]


### PR DESCRIPTION
## Summary
- add an async Redis-backed banana state helper and new banana handlers
- render the banana card via a dedicated UI helper and refresh the bot UI wiring
- update banana UI tests to reflect the new layout and prompt handling

## Testing
- pytest tests/test_banana_card_ui.py

------
https://chatgpt.com/codex/tasks/task_e_6906654ed5108322ac856c1d9c051008