### PR TITLE
Add Banana state management and handlers

### DIFF
--- a/handlers/banana.py
+++ b/handlers/banana.py
@@ -1,52 +1,225 @@
-"""Banana image editing handler."""
+"""Handlers for the Banana image editing workflow."""
+
 from __future__ import annotations
 
-import asyncio
+from typing import Any, Iterable, List, Optional
 
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import ContextTypes
+
+from core.balance_provider import aget_balance_snapshot
 from logging_utils import get_logger
 from services.banana_client import banana_process, banana_upload_bytes
-from utils.files import tg_image_bytes, validate_image
+from ui.renderers.banana import banana_card_kb, banana_card_text
+from utils.banana_state import BananaState, clear, load, save
+from utils.files import validate_image
 from utils.notify import admin_warn, user_error
 
 log = get_logger("handlers.banana")
 
+MAX_IMAGES = 4
 MODEL = "banana-nana"
 
 
-async def handle_banana_start(message, context) -> None:
-    bot = context.bot
-    chat_id = message.chat_id
-    try:
-        data = await tg_image_bytes(message, bot)
-        validate_image(data)
-    except Exception as exc:
+def _redis_client(context: ContextTypes.DEFAULT_TYPE) -> Any:
+    return getattr(context, "redis", None)
+
+
+async def _get_balance_value(user_id: int) -> int:
+    snapshot = await aget_balance_snapshot(user_id)
+    return snapshot.value or 0
+
+
+async def _render_card(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    state: BananaState,
+    *,
+    chat_id: Optional[int] = None,
+) -> None:
+    target_chat = chat_id or (update.effective_chat.id if update.effective_chat else None)
+    if target_chat is None:
+        return
+    balance = await _get_balance_value(target_chat)
+    text = banana_card_text(balance, state)
+    keyboard = banana_card_kb(state)
+    await context.bot.send_message(target_chat, text, reply_markup=keyboard)
+
+
+async def open_banana_card(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    user_id = update.effective_user.id
+    state = await load(_redis_client(context), user_id)
+    await _render_card(update, context, state, chat_id=user_id)
+
+
+async def on_banana_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    message = update.effective_message
+    if message is None or message.from_user is None:
+        return
+    user_id = message.from_user.id
+    state = await load(_redis_client(context), user_id)
+    if len(state.images) >= MAX_IMAGES:
         await user_error(
-            bot,
-            chat_id,
-            "Отправьте фото как *файл* (без сжатия) — текущее изображение не удалось прочитать.",
+            context.bot,
+            user_id,
+            f"Максимум {MAX_IMAGES} фото. Удалите лишнее или начните новую генерацию.",
         )
-        await admin_warn(bot, f"Banana input validate fail: {exc}")
         return
 
-    upload_id: str | None = None
-    try:
-        upload = await banana_upload_bytes(bytes(data), filename="input.png")
-        upload_id = upload.get("upload_id") or upload.get("id") or upload.get("temp_url")
-        if not upload_id:
-            raise RuntimeError(f"upload response malformed: {upload}")
-        response = await banana_process(MODEL, {"upload_id": upload_id})
-    except Exception:
-        await asyncio.sleep(1.0)
-        try:
-            response = await banana_process(MODEL, {"upload_id": upload_id})
-        except Exception as retry_exc:
-            await user_error(
-                bot,
-                chat_id,
-                "Сервис обработки временно недоступен. Попробуйте ещё раз.",
-            )
-            await admin_warn(bot, f"Banana 500: {retry_exc}")
-            return
+    file_id: Optional[str] = None
+    if message.photo:
+        file_id = message.photo[-1].file_id
+    elif message.document and message.document.mime_type and message.document.mime_type.startswith("image/"):
+        file_id = message.document.file_id
+    if not file_id:
+        await user_error(context.bot, user_id, "Не удалось определить файл изображения.")
+        return
 
-    log.debug("banana.process", extra={"chat_id": chat_id, "response": response})
-    # Further response handling should happen here.
+    state.images.append(file_id)
+    await save(_redis_client(context), user_id, state)
+    balance = await _get_balance_value(user_id)
+    await message.reply_text(
+        banana_card_text(balance, state),
+        reply_markup=banana_card_kb(state),
+    )
+
+
+async def on_banana_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    message = update.effective_message
+    if message is None or message.from_user is None:
+        return
+    user_id = message.from_user.id
+    text = (message.text or "").strip()
+    if not text:
+        return
+    state = await load(_redis_client(context), user_id)
+    state.prompt = text
+    await save(_redis_client(context), user_id, state)
+    balance = await _get_balance_value(user_id)
+    await message.reply_text(
+        banana_card_text(balance, state),
+        reply_markup=banana_card_kb(state),
+    )
+
+
+async def _download_image_bytes(context: ContextTypes.DEFAULT_TYPE, file_id: str) -> Optional[bytes]:
+    try:
+        tg_file = await context.bot.get_file(file_id)
+        data = await tg_file.download_as_bytearray()
+        return bytes(data)
+    except Exception as exc:  # pragma: no cover - network failures
+        log.warning("banana.download_failed", exc_info=True, extra={"file_id": file_id})
+        await admin_warn(context.bot, f"Banana tg fetch fail: {exc}")
+        return None
+
+
+async def _collect_upload_ids(
+    context: ContextTypes.DEFAULT_TYPE, image_ids: Iterable[str]
+) -> List[str]:
+    uploads: List[str] = []
+    for fid in image_ids:
+        payload = await _download_image_bytes(context, fid)
+        if not payload:
+            continue
+        try:
+            validate_image(payload)
+        except Exception as exc:
+            await admin_warn(context.bot, f"Banana image invalid: {exc}")
+            continue
+        try:
+            upload = await banana_upload_bytes(payload, filename="input.png")
+        except Exception as exc:
+            await admin_warn(context.bot, f"Banana upload fail: {exc}")
+            continue
+        upload_id = upload.get("upload_id") or upload.get("id") or upload.get("temp_url")
+        if upload_id:
+            uploads.append(str(upload_id))
+    return uploads
+
+
+async def _start_generation(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    *,
+    state: BananaState,
+) -> None:
+    query = update.callback_query
+    if query is not None:
+        await query.answer()
+    user_id = update.effective_user.id
+    if not state.ready:
+        await user_error(context.bot, user_id, "Добавьте фото и промпт.")
+        return
+
+    uploads = await _collect_upload_ids(context, state.images)
+    if not uploads:
+        await user_error(
+            context.bot,
+            user_id,
+            "Не удалось загрузить изображения. Пришлите фото как файл и попробуйте снова.",
+        )
+        return
+
+    payload = {"upload_ids": uploads, "prompt": state.prompt}
+    try:
+        response = await banana_process(MODEL, payload)
+    except Exception as exc:
+        await user_error(context.bot, user_id, "Сервис занят, попробуйте ещё раз.")
+        await admin_warn(context.bot, f"Banana process fail: {exc}")
+        return
+
+    result_bytes = response.get("result_bytes") if isinstance(response, dict) else None
+    if not result_bytes:
+        await user_error(context.bot, user_id, "Banana не вернула результат. Попробуйте ещё раз.")
+        await admin_warn(context.bot, f"Banana process invalid response: {response}")
+        return
+
+    doc = await context.bot.send_document(user_id, document=("result.png", result_bytes))
+    state.last_result_id = str(doc.message_id)
+    await save(_redis_client(context), user_id, state)
+
+    keyboard = InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("🔁 Сгенерировать ещё", callback_data="banana:again")],
+            [InlineKeyboardButton("🆕 Новая генерация", callback_data="banana:new")],
+        ]
+    )
+    await context.bot.send_message(user_id, "Готово ✅", reply_markup=keyboard)
+
+
+async def on_banana_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    state = await load(_redis_client(context), update.effective_user.id)
+    await _start_generation(update, context, state=state)
+
+
+async def on_banana_again(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    state = await load(_redis_client(context), update.effective_user.id)
+    await _start_generation(update, context, state=state)
+
+
+async def on_banana_new(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    if query is not None:
+        await query.answer()
+    user_id = update.effective_user.id
+    await clear(_redis_client(context), user_id)
+    state = BananaState(images=[], prompt=None)
+    await save(_redis_client(context), user_id, state)
+    await context.bot.send_message(
+        user_id,
+        "Новая карточка 🆕 Отправьте фото и промпт.",
+        reply_markup=banana_card_kb(state),
+    )
+
+
+__all__ = [
+    "MAX_IMAGES",
+    "MODEL",
+    "on_banana_again",
+    "on_banana_new",
+    "on_banana_photo",
+    "on_banana_start",
+    "on_banana_text",
+    "open_banana_card",
+]
+

--- a/ui/renderers/banana.py
+++ b/ui/renderers/banana.py
@@ -1,0 +1,44 @@
+"""UI helpers for rendering the Banana card."""
+
+from __future__ import annotations
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+from utils.banana_state import BananaState
+
+
+def banana_card_text(balance: int, state: BananaState) -> str:
+    """Return the textual representation of the Banana card."""
+
+    photos = f"📸 Фото: {len(state.images)}/4"
+    prompt_status = "есть" if state.prompt else "нет"
+    lines = [
+        "🍌 Карточка Banana",
+        f"💎 Баланс: {balance}",
+        f"{photos} • Промпт: {prompt_status}",
+    ]
+    return "\n".join(lines)
+
+
+def banana_card_kb(state: BananaState) -> InlineKeyboardMarkup:
+    """Return the inline keyboard for the Banana card."""
+
+    rows = []
+    if state.ready:
+        rows.append([
+            InlineKeyboardButton("🚀 Начать генерацию", callback_data="banana:start"),
+        ])
+    rows.append([
+        InlineKeyboardButton("✨ Готовые шаблоны", callback_data="banana:templates"),
+    ])
+    rows.append(
+        [
+            InlineKeyboardButton("⚙️ Движок", callback_data="img_engine:banana"),
+            InlineKeyboardButton("⬅️ Назад", callback_data="back_main"),
+        ]
+    )
+    return InlineKeyboardMarkup(rows)
+
+
+__all__ = ["banana_card_text", "banana_card_kb"]
+

--- a/utils/banana_state.py
+++ b/utils/banana_state.py
@@ -1,0 +1,130 @@
+"""State management helpers for the Banana image workflow."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional
+
+try:  # pragma: no cover - optional dependency
+    from redis_utils import rds as _redis_client
+except Exception:  # pragma: no cover - redis helpers may be unavailable in tests
+    _redis_client = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional settings import
+    from settings import REDIS_PREFIX as _REDIS_PREFIX
+except Exception:  # pragma: no cover - default fallback when settings missing
+    _REDIS_PREFIX = "bot"
+
+_KEY_TEMPLATE = f"{_REDIS_PREFIX}:banana:state:{{user_id}}"
+_TTL_SECONDS = 24 * 60 * 60
+_MEMORY_FALLBACK: Dict[int, Dict[str, Any]] = {}
+_MEMORY_LOCK = asyncio.Lock()
+
+
+@dataclass
+class BananaState:
+    """Represents the current Banana card state for a user."""
+
+    images: List[str]
+    prompt: Optional[str]
+    last_result_id: Optional[str] = None
+
+    @property
+    def ready(self) -> bool:
+        return bool(self.prompt) and len(self.images) >= 1
+
+
+def _resolve_client(candidate: Any) -> Any:
+    if candidate is not None:
+        return candidate
+    return _redis_client
+
+
+async def _redis_get(redis: Any, key: str) -> Optional[str]:
+    client = _resolve_client(redis)
+    if client is None:
+        return None
+    getter = getattr(client, "get", None)
+    if getter is None:
+        return None
+    if asyncio.iscoroutinefunction(getter):  # pragma: no cover - aioredis path
+        return await getter(key)
+    return await asyncio.to_thread(getter, key)
+
+
+async def _redis_set(redis: Any, key: str, value: str, *, ex: int) -> None:
+    client = _resolve_client(redis)
+    if client is None:
+        return
+    setter = getattr(client, "set", None)
+    if setter is None:
+        return
+    if asyncio.iscoroutinefunction(setter):  # pragma: no cover - aioredis path
+        await setter(key, value, ex=ex)
+        return
+    await asyncio.to_thread(setter, key, value, ex)
+
+
+async def _redis_delete(redis: Any, key: str) -> None:
+    client = _resolve_client(redis)
+    if client is None:
+        return
+    deleter = getattr(client, "delete", None)
+    if deleter is None:
+        return
+    if asyncio.iscoroutinefunction(deleter):  # pragma: no cover - aioredis path
+        await deleter(key)
+        return
+    await asyncio.to_thread(deleter, key)
+
+
+async def load(redis: Any, user_id: int) -> BananaState:
+    """Load the Banana state for ``user_id`` from Redis or fallback memory."""
+
+    key = _KEY_TEMPLATE.format(user_id=int(user_id))
+    raw = await _redis_get(redis, key)
+    if raw:
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            data = None
+        if isinstance(data, dict):
+            images = [str(x) for x in data.get("images") or []]
+            prompt = data.get("prompt")
+            last_result_id = data.get("last_result_id")
+            if prompt is not None:
+                prompt = str(prompt)
+            if last_result_id is not None:
+                last_result_id = str(last_result_id)
+            return BananaState(images=images, prompt=prompt, last_result_id=last_result_id)
+
+    async with _MEMORY_LOCK:
+        snapshot = _MEMORY_FALLBACK.get(int(user_id))
+        if snapshot:
+            return BananaState(**snapshot)
+    return BananaState(images=[], prompt=None)
+
+
+async def save(redis: Any, user_id: int, state: BananaState) -> None:
+    """Persist ``state`` for ``user_id`` in Redis with a TTL."""
+
+    payload = json.dumps(asdict(state))
+    key = _KEY_TEMPLATE.format(user_id=int(user_id))
+    await _redis_set(redis, key, payload, ex=_TTL_SECONDS)
+    async with _MEMORY_LOCK:
+        _MEMORY_FALLBACK[int(user_id)] = asdict(state)
+
+
+async def clear(redis: Any, user_id: int) -> None:
+    """Remove stored state for ``user_id`` from Redis and memory."""
+
+    key = _KEY_TEMPLATE.format(user_id=int(user_id))
+    await _redis_delete(redis, key)
+    async with _MEMORY_LOCK:
+        _MEMORY_FALLBACK.pop(int(user_id), None)
+
+
+__all__ = ["BananaState", "load", "save", "clear"]
+


### PR DESCRIPTION
## Summary
- add a dedicated BananaState dataclass with Redis-backed persistence helpers
- implement Banana UI rendering helpers and async handlers for the Banana workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69066556b9008322a791a2ba0582f223