### PR TITLE
Rework Banana restart UX

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -245,6 +245,7 @@ from keyboards import (
     AI_TO_PROMPTMASTER_CB,
     AI_TO_SIMPLE_CB,
     kb_banana_templates,
+    banana_result_kb,
     CB,
     CB_FAQ_PREFIX,
     CB_MAIN_BACK,
@@ -3898,7 +3899,7 @@ async def _deliver_banana_media(
     photo_reply_markup: Optional[Any] = None,
     document_reply_markup: Optional[Any] = None,
     send_document: bool = True,
-) -> bool:
+) -> Optional[int]:
     try:
         file_size = file_path.stat().st_size
     except OSError:
@@ -3960,6 +3961,7 @@ async def _deliver_banana_media(
         )
 
     doc_sent = False
+    doc_message_id: Optional[int] = None
     if send_document:
         doc_start = time.monotonic()
         suffix = file_path.suffix.lower() or ".jpg"
@@ -4044,7 +4046,12 @@ async def _deliver_banana_media(
         )
 
     cleanup_temp([file_path])
-    return sent_any or doc_sent
+
+    if doc_message_id is not None:
+        return doc_message_id
+    if photo_message_id is not None:
+        return photo_message_id if sent_any else None
+    return None
 
 
 
@@ -9226,7 +9233,25 @@ def _state_to_banana_state(state: Dict[str, Any]) -> BananaState:
     last_result = state.get("last_banana_result_id")
     if last_result is not None:
         last_result = str(last_result)
-    return BananaState(images=images, prompt=prompt, last_result_id=last_result)
+    last_job = state.get("banana_last_job_id")
+    if last_job is not None:
+        last_job = str(last_job)
+    last_payload = state.get("banana_last_payload")
+    if not isinstance(last_payload, dict):
+        last_payload = None
+    last_result_msg = state.get("banana_last_result_msg_id")
+    if isinstance(last_result_msg, str) and last_result_msg.isdigit():
+        last_result_msg = int(last_result_msg)
+    elif not isinstance(last_result_msg, int):
+        last_result_msg = None
+    return BananaState(
+        photos=images,
+        prompt=prompt,
+        last_job_id=last_job,
+        last_payload=last_payload,
+        last_result_msg_id=last_result_msg,
+        last_result_id=last_result,
+    )
 
 
 def banana_card_text(s: Dict[str, Any]) -> str:
@@ -9252,12 +9277,7 @@ def banana_generating_markup() -> InlineKeyboardMarkup:
 
 
 def banana_result_inline_keyboard() -> InlineKeyboardMarkup:
-    return InlineKeyboardMarkup(
-        [
-            [InlineKeyboardButton("🔁 Повторить генерацию", callback_data="banana:restart")],
-            [InlineKeyboardButton("🆕 Новая генерация", callback_data="banana:new")],
-        ]
-    )
+    return banana_result_kb()
 
 
 # --------- Suno Helpers ----------
@@ -19161,8 +19181,21 @@ async def _banana_initiate_generation(
     if query is None:
         return
     s = state(ctx)
-    images = list(_get_banana_images(s))
-    prompt = (s.get("last_prompt") or "").strip()
+    if action == "restart":
+        payload = s.get("banana_last_payload")
+        if not isinstance(payload, dict):
+            await query.answer("Нет данных для повтора", show_alert=True)
+            return
+        payload_images_raw = payload.get("images") or []
+        images = []
+        for item in payload_images_raw:
+            entry = _normalize_banana_image(item)
+            if entry is not None:
+                images.append(entry)
+        prompt = str(payload.get("prompt") or "").strip()
+    else:
+        images = list(_get_banana_images(s))
+        prompt = (s.get("last_prompt") or "").strip()
 
     if not images and not prompt:
         await query.answer("Добавь фото или промпт", show_alert=True)
@@ -19226,6 +19259,11 @@ async def _banana_initiate_generation(
     ack_text = "Повторяю…" if action == "restart" else "Запускаю…"
     with suppress(BadRequest):
         await query.answer(ack_text)
+
+    s["banana_last_payload"] = {
+        "images": [dict(item) for item in images],
+        "prompt": prompt,
+    }
 
     log.info(
         "[BANANA] %s_generate | chat_id=%s user_id=%s images=%s",
@@ -19510,6 +19548,10 @@ async def on_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         s["banana_images"] = []
         s["last_prompt"] = None
         s["_last_text_banana"] = None
+        s["last_banana_result_id"] = None
+        s["banana_last_payload"] = None
+        s["banana_last_job_id"] = None
+        s["banana_last_result_msg_id"] = None
         if chat_id is not None:
             await show_banana_card(chat_id, ctx, force_new=True)
         await q.answer("Новая карточка Banana ✨")
@@ -20041,6 +20083,9 @@ async def on_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
             s["last_prompt"] = None
             s["_last_text_banana"] = None
             s["last_banana_result_id"] = None
+            s["banana_last_payload"] = None
+            s["banana_last_job_id"] = None
+            s["banana_last_result_msg_id"] = None
             chat_ctx = update.effective_chat
             chat_id_val = chat_ctx.id if chat_ctx else (q.message.chat_id if q.message else None)
             if chat_id_val is not None:
@@ -21133,6 +21178,7 @@ async def _banana_run_and_send(
             create_banana_task, prompt, src_urls, "png", "auto", None, None, 60
         )
         task_info["id"] = str(task_id)
+        s["banana_last_job_id"] = task_info["id"]
         await ctx.bot.send_message(
             chat_id,
             f"🍌 Задача Banana создана.\n🆔 taskId={task_id}\nЖдём результат…",
@@ -21152,21 +21198,24 @@ async def _banana_run_and_send(
         suffix = _banana_guess_suffix(u0, content_type)
         temp_path = save_bytes_to_temp(data, suffix=suffix)
         caption = _banana_caption(prompt)
-        delivered = await _deliver_banana_media(
+        result_message_id = await _deliver_banana_media(
             ctx.bot,
             chat_id=chat_id,
             user_id=user_id,
             file_path=temp_path,
             caption=caption,
-            photo_reply_markup=banana_result_inline_keyboard(),
-            document_reply_markup=None,
+            photo_reply_markup=None,
+            document_reply_markup=banana_result_inline_keyboard(),
             send_document=BANANA_SEND_AS_DOCUMENT,
         )
-        if not delivered:
+        if result_message_id is None:
             await ctx.bot.send_message(
                 chat_id,
                 "❌ Не удалось отправить изображение Banana. Попробуйте позже.",
             )
+        else:
+            s["last_banana_result_id"] = result_message_id
+            s["banana_last_result_msg_id"] = result_message_id
     except KieBananaError as e:
         error_text = str(e)
         new_balance = await _refund("error", error_text)

--- a/handlers/banana.py
+++ b/handlers/banana.py
@@ -47,7 +47,9 @@ async def open_banana_card(update, context) -> None:
     state = await load(redis, user_id)
     balance_value = await _get_balance_value(user_id)
     text = banana_card_text(balance_value, state)
-    await context.bot.send_message(user_id, text, reply_markup=banana_card_kb(state))
+    await context.bot.send_message(
+        user_id, text, reply_markup=banana_card_kb(state.can_start())
+    )
 
 
 async def on_banana_photo(update, context) -> None:
@@ -82,7 +84,8 @@ async def on_banana_photo(update, context) -> None:
     await save(redis, user_id, state)
     balance_value = await _get_balance_value(user_id)
     await message.reply_text(
-        banana_card_text(balance_value, state), reply_markup=banana_card_kb(state)
+        banana_card_text(balance_value, state),
+        reply_markup=banana_card_kb(state.can_start()),
     )
 
 
@@ -97,7 +100,8 @@ async def on_banana_text(update, context) -> None:
     await save(redis, user_id, state)
     balance_value = await _get_balance_value(user_id)
     await message.reply_text(
-        banana_card_text(balance_value, state), reply_markup=banana_card_kb(state)
+        banana_card_text(balance_value, state),
+        reply_markup=banana_card_kb(state.can_start()),
     )
 
 
@@ -143,6 +147,8 @@ async def on_banana_start(update, context) -> None:
         return
 
     payload = {"upload_ids": uploads, "prompt": state.prompt}
+    state.last_payload = {"photos": list(state.photos), "prompt": state.prompt}
+    await save(redis, user_id, state)
     try:
         result = await banana_process(MODEL_NAME, payload)
         result_bytes = result.get("result_bytes")
@@ -155,6 +161,7 @@ async def on_banana_start(update, context) -> None:
         return
 
     state.last_result_id = str(message.message_id)
+    state.last_result_msg_id = message.message_id
     await save(redis, user_id, state)
 
     keyboard = InlineKeyboardMarkup(
@@ -182,13 +189,13 @@ async def on_banana_new(update, context) -> None:
     user_id = query.from_user.id
     redis = await _require_redis(context)
     await clear(redis, user_id)
-    state = BananaState(images=[], prompt=None)
+    state = BananaState(photos=[], prompt=None)
     await save(redis, user_id, state)
     balance_value = await _get_balance_value(user_id)
     await context.bot.send_message(
         user_id,
         "Новая карточка 🆕 Отправьте фото и промпт.",
-        reply_markup=banana_card_kb(state),
+        reply_markup=banana_card_kb(state.can_start()),
     )
 
 

--- a/keyboards.py
+++ b/keyboards.py
@@ -314,16 +314,22 @@ def build_menu(rows: list[list[tuple[str, str]]]) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(markup_rows)
 
 
-def banana_card_kb(has_inputs: bool) -> InlineKeyboardMarkup:
+def banana_card_kb(can_start: bool) -> InlineKeyboardMarkup:
     rows: list[list[InlineKeyboardButton]] = []
-    if has_inputs:
+    if can_start:
         rows.append([InlineKeyboardButton("🚀 Начать генерацию", callback_data="banana:start")])
-        rows.append([InlineKeyboardButton("🔁 Повторить генерацию", callback_data="banana:restart")])
-        rows.append([InlineKeyboardButton("🆕 Новая генерация", callback_data="banana:new")])
     rows.append([InlineKeyboardButton("🧹 Очистить карточку", callback_data="banana:clear")])
-    rows.append([InlineKeyboardButton("✨ Готовые шаблоны", callback_data="banana:templates")])
     rows.append([InlineKeyboardButton("⬅️ Назад", callback_data="back_main")])
     return InlineKeyboardMarkup(rows)
+
+
+def banana_result_kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("🔁 Повторить генерацию", callback_data="banana:restart")],
+            [InlineKeyboardButton("🆕 Новая генерация", callback_data="banana:new")],
+        ]
+    )
 
 
 def photo_engine_menu() -> InlineKeyboardMarkup:

--- a/tests/test_banana_flow.py
+++ b/tests/test_banana_flow.py
@@ -85,7 +85,9 @@ def test_banana_generate_flow(monkeypatch, tmp_path, bot_module):
     first_message = fake_bot.messages[0]
     assert first_message["text"].startswith("🍌 Задача Banana")
     photo_call = fake_bot.photo_calls[0]
-    markup = photo_call.get("reply_markup")
+    assert photo_call.get("reply_markup") is None
+    doc_call = fake_bot.document_calls[0]
+    markup = doc_call.get("reply_markup")
     assert isinstance(markup, InlineKeyboardMarkup)
     buttons = markup.inline_keyboard
     assert buttons and buttons[0][0].text == "🔁 Повторить генерацию"

--- a/tests/test_banana_regenerate.py
+++ b/tests/test_banana_regenerate.py
@@ -74,6 +74,10 @@ def test_banana_regenerate_clears_state(monkeypatch, bot_module):
     assert state_dict["banana_images"] == []
     assert state_dict.get("last_prompt") is None
     assert not state_dict.get("_last_text_banana")
+    assert state_dict.get("last_banana_result_id") is None
+    assert state_dict.get("banana_last_payload") is None
+    assert state_dict.get("banana_last_job_id") is None
+    assert state_dict.get("banana_last_result_msg_id") is None
     assert calls and calls[-1][0] == update.effective_chat.id
     assert calls[-1][1]["force_new"] is True
     assert update._answers and update._answers[-1]["text"] == "Новая карточка Banana ✨"

--- a/tests/test_handlers_image.py
+++ b/tests/test_handlers_image.py
@@ -55,7 +55,7 @@ def test_banana_deliver_photo_and_document(monkeypatch, tmp_path, bot_module):
         )
     )
 
-    assert delivered is True
+    assert delivered == 202
     assert not path.exists()
     assert len(bot.photo_calls) == 1
     assert bot.photo_calls[0]["caption"] == caption
@@ -97,7 +97,7 @@ def test_banana_deliver_skips_document(monkeypatch, tmp_path, bot_module):
         )
     )
 
-    assert delivered is True
+    assert delivered == 303
     assert not path.exists()
     assert len(bot.photo_calls) == 1
     assert bot.document_called is False

--- a/ui/renderers/banana.py
+++ b/ui/renderers/banana.py
@@ -16,7 +16,7 @@ def banana_card_text(balance: int, state) -> str:
 def banana_card_kb(state) -> InlineKeyboardMarkup:
     """Return inline keyboard for Banana card based on readiness."""
 
-    return build_banana_card_kb(state.has_photos_or_prompt())
+    return build_banana_card_kb(state.can_start())
 
 
 __all__ = ["banana_card_text", "banana_card_kb"]

--- a/utils/banana_state.py
+++ b/utils/banana_state.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict, dataclass
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 
 @dataclass(slots=True)
 class BananaState:
     """Store Banana inputs awaiting generation."""
 
-    images: List[str]
+    photos: List[str]
     prompt: Optional[str]
-    last_result_id: Optional[str] = None
+    last_job_id: Optional[str] = None
+    last_payload: Optional[Dict[str, Any]] = None
+    last_result_msg_id: Optional[int] = None
+    last_result_id: Optional[str] = None  # legacy alias for stored message id
 
     def _normalized_prompt(self) -> Optional[str]:
         if self.prompt is None:
@@ -30,7 +33,7 @@ class BananaState:
     def has_photos_or_prompt(self) -> bool:
         """Return ``True`` when the card has photos or text prompt."""
 
-        return bool(self.images) or bool(self._normalized_prompt())
+        return bool(self.photos) or bool(self._normalized_prompt())
 
     def can_start(self) -> bool:
         """Determine whether generation can be started."""
@@ -40,9 +43,22 @@ class BananaState:
     def reset(self) -> None:
         """Clear inputs while keeping the instance reusable."""
 
-        self.images.clear()
+        self.photos.clear()
         self.prompt = None
+        self.last_job_id = None
+        self.last_payload = None
+        self.last_result_msg_id = None
         self.last_result_id = None
+
+    # ---- Legacy aliases ----
+
+    @property
+    def images(self) -> List[str]:  # pragma: no cover - backwards compatibility
+        return self.photos
+
+    @images.setter
+    def images(self, value: List[str]) -> None:  # pragma: no cover - backwards compatibility
+        self.photos = value
 
 
 _KEY_TMPL = "banana:state:{user_id}"
@@ -58,8 +74,17 @@ async def load(redis, user_id: int) -> BananaState:
 
     raw = await redis.get(_key_for(user_id))
     if not raw:
-        return BananaState(images=[], prompt=None)
+        return BananaState(photos=[], prompt=None)
     data = json.loads(raw)
+    if "photos" not in data:
+        photos = data.get("images") or []
+        data["photos"] = photos
+    data.pop("images", None)
+    data.setdefault("prompt", None)
+    data.setdefault("last_job_id", None)
+    data.setdefault("last_payload", None)
+    data.setdefault("last_result_msg_id", None)
+    data.setdefault("last_result_id", None)
     return BananaState(**data)
 
 


### PR DESCRIPTION
## Summary
- hide the restart/new controls from the Banana card and add a dedicated result keyboard
- persist Banana payload/job metadata so restart/new actions reuse the last generation safely
- adjust result delivery to return the message id and refresh the tests for the new behaviour

## Testing
- pytest tests/test_banana_flow.py tests/test_handlers_image.py tests/test_banana_regenerate.py

------
https://chatgpt.com/codex/tasks/task_e_6907939133cc8322955145061cddb320