### PR TITLE
Implement unified menu callbacks and quiet logging

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -321,6 +321,7 @@ from handlers.menu import (
     build_photo_card,
     build_profile_card,
     build_video_card,
+    open_main_menu,
 )
 from handlers.music import configure as configure_music_menu, open_menu as music_open_menu
 from handlers.photo import configure as configure_photo_menu, open_menu as photo_open_menu
@@ -1552,7 +1553,7 @@ class _LeaderContext:
                 ok = False
             if ok:
                 self._failures = 0
-                singleton_log.info("leader: heartbeat ok")
+                singleton_log.debug("leader: heartbeat ok")
             else:
                 self._failures += 1
                 if self._failures >= 3:
@@ -4328,7 +4329,8 @@ def log_evt(name: str, **kw) -> None:
         payload = json.dumps(kw, ensure_ascii=False, sort_keys=True)
     except Exception:
         payload = str(kw)
-    log.info("EVT_%s | %s", name, payload)
+    level = logging.DEBUG if name == "LOCK_HEARTBEAT" else logging.INFO
+    log.log(level, "EVT_%s | %s", name, payload)
 
 
 def event(tag: str, **kw):
@@ -22425,7 +22427,6 @@ class RedisRunnerLock:
 
 PRIORITY_COMMAND_SPECS: List[tuple[tuple[str, ...], Any]] = [
     (("start",), start),
-    (("menu",), menu_command),
     (("cancel",), cancel_command),
     (("faq",), faq_command_entry),
     (("prompt_master",), prompt_master_command),
@@ -22492,7 +22493,6 @@ ADDITIONAL_COMMAND_SPECS: List[tuple[tuple[str, ...], Any]] = [
 ]
 
 CALLBACK_HANDLER_SPECS: List[tuple[Optional[str], Any]] = [
-    (r"^kb_open$", knowledge_base_open_handler),
     (r"^dialog_default$", dialog_mode_callback),
     (r"^prompt_master$", prompt_master_mode_callback),
     (r"^dialog:choose_regular$", dialog_choose_regular_callback),
@@ -22512,10 +22512,9 @@ CALLBACK_HANDLER_SPECS: List[tuple[Optional[str], Any]] = [
     (r"^mj\.gallery\.back$", handle_mj_gallery_back),
     (r"^mj\.upscale\.menu:", handle_mj_upscale_menu),
     (r"^mj\.upscale:", handle_mj_upscale_choice),
-    (r"^menu:(profile|kb|photo|music|video|dialog)$", handle_main_menu_callback),
     (r"^(hub:open:(profile|kb|photo|music|video|dialog))$", handle_hub_open_callback),
     (
-        r"^(?:mnu:|home:|hub:|main_|profile_|pay_|nav_|nav:|menu:|back_main$|ai_modes$|chat_(?:normal|promptmaster)$|(?:ai|video|image|music|profile|kb):)",
+        r"^(?:mnu:|home:|hub:|main_|profile_|pay_|nav_|nav:|ai_modes$|chat_(?:normal|promptmaster)$|(?:ai|video|image|music|profile|kb):)",
         hub_router,
     ),
     (r"^go:", main_suggest_router),
@@ -22605,6 +22604,17 @@ def register_handlers(application: Any) -> None:
     )
     kb_text_handler.block = False
     application.add_handler(kb_text_handler, group=0)
+
+    application.add_handler(CommandHandler("menu", open_main_menu))
+
+    from ui.buttons.router import route_callback  # local import to avoid cycles
+
+    menu_router = CallbackQueryHandler(
+        route_callback,
+        pattern=r"^(btn:profile|kb_open|menu:(photo|music|video|dialog)|img_engine:.+|back_main)$",
+    )
+    menu_router.block = False
+    application.add_handler(menu_router, group=0)
 
     for names, callback in PRIORITY_COMMAND_SPECS:
         application.add_handler(CommandHandler(list(names), callback))

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import Sequence
 
-from telegram import InlineKeyboardButton
+from telegram import InlineKeyboardButton, Update
+from telegram.ext import ContextTypes
 
-from keyboards import CB, FEATURE_PM_ENABLED, kb_main, photo_engine_menu
+from keyboards import CB, FEATURE_PM_ENABLED, kb_main, main_menu_kb, photo_engines_kb
 from texts import (
     TXT_AI_DIALOG_CHOOSE,
     TXT_AI_DIALOG_NORMAL,
@@ -23,6 +24,68 @@ from logging_utils import get_logger
 log = get_logger("handlers.menu")
 
 _MAIN_MENU_SUBTITLE = "Выберите раздел:"
+
+
+async def open_main_menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    text = "📋 *Главное меню*\n_Выберите раздел:_"
+    message = update.effective_message
+    if message is None:
+        return
+    await message.reply_text(text, reply_markup=main_menu_kb(), parse_mode="Markdown")
+
+
+async def show_profile(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    target = query.message if query else update.effective_message
+    if target is None:
+        return
+    await target.reply_text("👤 Профиль\nБаланс: …\nТариф: …")
+
+
+async def show_kb(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    target = query.message if query else update.effective_message
+    if target is None:
+        return
+    await target.reply_text("📚 База знаний (в разработке)")
+
+
+async def open_photo_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    target = query.message if query else update.effective_message
+    if target is None:
+        return
+    await target.reply_text(
+        "📸 Выберите нейросеть для фотографий:",
+        reply_markup=photo_engines_kb(),
+    )
+
+
+async def open_music_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    target = query.message if query else update.effective_message
+    if target is None:
+        return
+    await target.reply_text("🎧 Музыка: Suno / загрузка каппеллы / инструкции (скоро).")
+
+
+async def open_video_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    target = query.message if query else update.effective_message
+    if target is None:
+        return
+    await target.reply_text("📹 Видео: Kling / VEO (скоро выбор).")
+
+
+async def open_dialog_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    target = query.message if query else update.effective_message
+    if target is None:
+        return
+    context.user_data["dialog_mode"] = "plain"
+    await target.reply_text(
+        "🧠 Обычный диалог включён. Пишите текст — отвечу без дополнительных меню."
+    )
 
 
 async def on_menu_dialog(update, context) -> None:
@@ -61,7 +124,7 @@ def build_profile_card(balance: str, warning: str | None = None) -> dict:
 
 
 def build_photo_card() -> dict:
-    markup = photo_engine_menu()
+    markup = photo_engines_kb()
     return build_card(TXT_KB_PHOTO, "Выбери движок для фото:", markup.inline_keyboard)
 
 
@@ -115,6 +178,13 @@ def build_dialog_card() -> dict:
 
 
 __all__ = [
+    "open_main_menu",
+    "show_profile",
+    "show_kb",
+    "open_photo_mode",
+    "open_music_mode",
+    "open_video_mode",
+    "open_dialog_mode",
     "on_menu_dialog",
     "build_dialog_card",
     "build_main_menu_card",

--- a/keyboards.py
+++ b/keyboards.py
@@ -203,7 +203,15 @@ def kb_main() -> InlineKeyboardMarkup:
 
 
 def main_menu_kb() -> InlineKeyboardMarkup:
-    return kb_main()
+    rows = []
+    for raw_row in _get_home_menu_layout():
+        buttons = [InlineKeyboardButton(text, callback_data=callback) for text, callback in raw_row]
+        rows.append(buttons)
+    if len(rows) == 4:
+        merged = rows[:2]
+        merged.append(rows[2] + rows[3])
+        rows = merged
+    return InlineKeyboardMarkup(rows)
 
 
 def kb_home_menu() -> InlineKeyboardMarkup:
@@ -340,6 +348,16 @@ def photo_engine_menu() -> InlineKeyboardMarkup:
         [InlineKeyboardButton("⬅️ Назад", callback_data="back")],
     ]
     return InlineKeyboardMarkup(rows)
+
+
+def photo_engines_kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("🍌 Nana Banana", callback_data="img_engine:banana")],
+            [InlineKeyboardButton("🖼 Midjourney (WIP)", callback_data="img_engine:mj")],
+            [InlineKeyboardButton("⬅️ Назад", callback_data="back_main")],
+        ]
+    )
 
 
 def kb_banana_templates() -> InlineKeyboardMarkup:

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -171,8 +171,11 @@ def get_logger(name: str) -> SafeLoggerAdapter:
     base = logging.getLogger(name)
     if name == "ui.buttons.router":
         base.setLevel(logging.WARNING)
-    if name == "input-state":
+    if name in {"wait-input", "input-state"}:
         base.setLevel(logging.WARNING)
+    if name == "veo3-bot.singleton":
+        level = logging.DEBUG if os.getenv("HEARTBEAT_VERBOSE") == "1" else logging.WARNING
+        base.setLevel(level)
     return SafeLoggerAdapter(base, {})
 
 

--- a/ui/buttons/router.py
+++ b/ui/buttons/router.py
@@ -50,6 +50,10 @@ DEBOUNCE_SEC = max(DEBOUNCE_SEC, 0.0)
 _LAST_CALLBACK_AT: dict[tuple[int, str], float] = {}
 
 
+# Allowed menu callback payloads handled by ``route_callback`` below.
+MENU_PAT = re.compile(r"^(btn:profile|kb_open|menu:(photo|music|video|dialog)|img_engine:.+|back_main)$")
+
+
 def _legacy_bridge_enabled() -> bool:
     try:
         if getattr(app_settings, "ROUTER_LEGACY_OFF", False):
@@ -644,3 +648,86 @@ async def on_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def handle_unmatched_callback(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     await on_callback(update, ctx)
+
+
+async def route_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    if query is None:
+        return
+
+    data = query.data or ""
+    try:
+        await query.answer()
+    except Exception:
+        pass
+
+    def _mark_handled() -> None:
+        try:
+            setattr(update, "_ui_button_handled", True)
+        except Exception:
+            pass
+        try:
+            setattr(query, "_ui_button_handled", True)
+        except Exception:
+            pass
+
+    if not MENU_PAT.match(data):
+        if log.isEnabledFor(10):  # DEBUG
+            log.debug("ui.callback.unmatched", extra={"data": data})
+        try:
+            await query.edit_message_reply_markup(reply_markup=None)
+        except Exception:
+            pass
+        message = query.message
+        if message is not None:
+            await message.reply_text("Кнопка устарела. Откройте /menu.")
+        return
+
+    if data == "btn:profile":
+        from handlers.menu import show_profile
+
+        _mark_handled()
+        await show_profile(update, context)
+        return
+
+    if data == "kb_open":
+        from handlers.menu import show_kb
+
+        _mark_handled()
+        await show_kb(update, context)
+        return
+
+    if data == "menu:photo":
+        from handlers.menu import open_photo_mode
+
+        _mark_handled()
+        await open_photo_mode(update, context)
+        return
+
+    if data == "menu:music":
+        from handlers.menu import open_music_mode
+
+        _mark_handled()
+        await open_music_mode(update, context)
+        return
+
+    if data == "menu:video":
+        from handlers.menu import open_video_mode
+
+        _mark_handled()
+        await open_video_mode(update, context)
+        return
+
+    if data == "menu:dialog":
+        from handlers.menu import open_dialog_mode
+
+        _mark_handled()
+        await open_dialog_mode(update, context)
+        return
+
+    if data == "back_main":
+        from handlers.menu import open_main_menu
+
+        _mark_handled()
+        await open_main_menu(update, context)
+        return


### PR DESCRIPTION
## Summary
- add a dedicated callback router for main menu buttons with graceful fallback
- refresh menu handlers and keyboards to use the new callbacks and photo engine picker
- tone down heartbeat-related logging noise and map /menu to the inline menu

## Testing
- pytest tests/test_menu_command.py

------
https://chatgpt.com/codex/tasks/task_e_690837d7767c8322aecce05158086a3b