### PR TITLE
Integrate Banana async handler into Telegram flow

### DIFF
--- a/bot_logger.py
+++ b/bot_logger.py
@@ -1,0 +1,62 @@
+"""Async logger helper that mirrors events to Redis debug channel."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Mapping, MutableMapping, Optional
+
+_DEFAULT_CHANNEL = "bot:debug"
+
+
+class BotLogger:
+    """Emit logs to standard logging and optionally publish to Redis."""
+
+    def __init__(
+        self,
+        *,
+        redis: Any = None,
+        channel: str = _DEFAULT_CHANNEL,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._redis = redis
+        self._channel = channel
+        base = logger or logging.getLogger("bot.async")
+        self._logger = base
+
+    async def info(self, message: str, **fields: Any) -> None:
+        """Log an info message and mirror to Redis."""
+
+        self._emit(logging.INFO, message, fields)
+        await self._publish("info", message, fields)
+
+    async def error(self, message: str, **fields: Any) -> None:
+        """Log an error message and mirror to Redis."""
+
+        self._emit(logging.ERROR, message, fields)
+        await self._publish("error", message, fields)
+
+    def _emit(self, level: int, message: str, fields: Mapping[str, Any]) -> None:
+        extra: MutableMapping[str, Any] = {"meta": {"ctx": dict(fields)}} if fields else {}
+        self._logger.log(level, message, extra=extra or None)
+
+    async def _publish(self, level: str, message: str, fields: Mapping[str, Any]) -> None:
+        if self._redis is None:
+            return
+        publish = getattr(self._redis, "publish", None)
+        if publish is None:
+            return
+        payload = {"level": level, "message": message, **dict(fields)}
+        try:
+            data = json.dumps(payload)
+        except (TypeError, ValueError):
+            data = json.dumps({"level": level, "message": message})
+        try:
+            result = publish(self._channel, data)
+            if hasattr(result, "__await"):
+                await result  # type: ignore[misc]
+        except Exception:
+            self._logger.debug("bot_logger.publish_failed", exc_info=True)
+
+
+__all__ = ["BotLogger"]

--- a/cache_helper.py
+++ b/cache_helper.py
@@ -1,0 +1,61 @@
+"""Async cache helpers backed by Redis."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Awaitable, Callable, Mapping, MutableMapping, Optional
+
+RedisLike = Any
+
+__all__ = ["get_or_set_cache"]
+
+
+async def get_or_set_cache(
+    key: str,
+    coro: Awaitable[Mapping[str, Any]] | Callable[[], Awaitable[Mapping[str, Any]]],
+    *,
+    redis: Optional[RedisLike] = None,
+    ttl: int = 3600,
+) -> MutableMapping[str, Any]:
+    """Return cached payload for ``key`` or store the computed value."""
+
+    if redis is None:
+        if callable(coro):
+            result = await coro()
+        else:
+            result = await coro
+        return {**result, "_cached": False}
+
+    try:
+        raw = await redis.get(key)
+    except AttributeError:
+        raw = None
+    if raw:
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8", errors="ignore")
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            payload = None
+        if isinstance(payload, Mapping):
+            return {**payload, "_cached": True}
+
+    if callable(coro):
+        result = await coro()
+    else:
+        result = await coro
+
+    try:
+        serialized = json.dumps(result)
+    except (TypeError, ValueError):
+        serialized = None
+    if serialized is not None:
+        try:
+            await redis.set(key, serialized, ex=max(int(ttl), 1))
+        except AttributeError:
+            try:
+                redis.set(key, serialized, ex=max(int(ttl), 1))
+            except Exception:
+                pass
+
+    return {**result, "_cached": False}

--- a/error_utils.py
+++ b/error_utils.py
@@ -1,0 +1,18 @@
+"""Shared helpers for async error handling."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger("async-errors")
+
+
+async def handle_async_error(exc: Exception, context: str) -> dict[str, Any]:
+    """Log ``exc`` with ``context`` and return a structured payload."""
+
+    logger.error("[%s] %s: %s", context, type(exc).__name__, exc)
+    return {"ok": False, "error": str(exc)}
+
+
+__all__ = ["handle_async_error"]

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,5 +1,6 @@
 """Public handler shortcuts."""
 
+from .banana_async_handler import BananaAsyncHandler
 from .faq_handler import configure_faq, faq_callback, faq_command
 from .help_handler import help_command, support_command
 from .prompt_master_handler import (
@@ -29,4 +30,5 @@ __all__ = [
     "veo_animate",
     "veo_animate_command",
     "handle_veo_animate_photo",
+    "BananaAsyncHandler",
 ]

--- a/handlers/banana.py
+++ b/handlers/banana.py
@@ -25,6 +25,7 @@ from ui.renderers.banana import banana_card_kb, banana_card_text
 from utils.banana_state import BananaState, clear, load, save
 from utils.files import validate_image
 
+from error_utils import handle_async_error
 from logging_utils import get_logger
 
 log = get_logger("handlers.banana")
@@ -303,8 +304,8 @@ async def _send_cached_result(
                 ]
             ),
         )
-    except Exception:  # pragma: no cover - defensive guard
-        log.exception("banana.send_cached_fail", extra={"user_id": user_id})
+    except Exception as exc:  # pragma: no cover - defensive guard
+        await handle_async_error(exc, "Banana.send_cached_result")
 
 
 async def _prepare_image_urls(bot, file_ids: Sequence[str]) -> list[str]:

--- a/handlers/banana_async_handler.py
+++ b/handlers/banana_async_handler.py
@@ -1,0 +1,482 @@
+"""Async Banana handler integrated with Telegram workflow."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, MutableMapping, Optional, Sequence
+
+from telegram import InputMediaDocument, Update
+from telegram.ext import ContextTypes
+
+from bot_logger import BotLogger
+from cache_helper import get_or_set_cache
+from error_utils import handle_async_error
+from services.kie_api_async import (
+    KieAPIAsync,
+    KieAPIHTTPError,
+    KieAPITimeoutError,
+    KieAPITransportError,
+)
+from keyboards import banana_result_kb
+from utils.banana_state import BananaState, load, save
+from utils.files import validate_image
+
+from handlers.banana import (
+    BananaBackendError,
+    BananaBadRequest,
+    BananaTimeout,
+)
+
+_ACK_TEXT = "🟡 Processing your Banana edit... please wait."
+_SUCCESS_CAPTION = "✅ Banana edit ready!"
+_FAILURE_TEXT = "⚠️ Something went wrong on Banana servers. Please try again later."
+
+_BANANA_MODEL = "google/nano-banana-edit"
+_BANANA_CREATE_PATH = "/api/v1/jobs/createTask"
+_BANANA_STATUS_PATH = "/api/v1/jobs/recordInfo"
+_UPLOAD_PATH = "/api/v1/upload/base64"
+
+_WAIT_STATES = {"waiting", "queuing", "queued", "generating", "processing", "running", "pending", "0", 0}
+_SUCCESS_STATES = {"success", "1", 1, "done", "finished", "completed", "ready"}
+_FAIL_STATES = {"fail", "failed", "error", "2", 2, "3", 3, "canceled", "cancelled", "timeout"}
+
+
+@dataclass(slots=True)
+class BananaResult:
+    file_id: str
+    task_id: str
+    caption: str = _SUCCESS_CAPTION
+    url: Optional[str] = None
+
+    def to_mapping(self) -> MutableMapping[str, Any]:
+        payload: MutableMapping[str, Any] = {
+            "file_id": self.file_id,
+            "task_id": self.task_id,
+            "caption": self.caption,
+        }
+        if self.url:
+            payload["url"] = self.url
+        return payload
+
+
+def _normalize_state(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip().lower()
+    if isinstance(value, (int, float)):
+        return str(int(value))
+    return ""
+
+
+def _extract_task_id(payload: Mapping[str, Any]) -> Optional[str]:
+    candidates = ("taskId", "task_id", "id")
+    for key in candidates:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    data = payload.get("data")
+    if isinstance(data, Mapping):
+        return _extract_task_id(data)
+    return None
+
+
+def _collect_urls(value: Any) -> list[str]:
+    urls: list[str] = []
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped:
+            urls.append(stripped)
+        return urls
+    if isinstance(value, Mapping):
+        for key in ("url", "resultUrl", "originUrl"):
+            raw = value.get(key)
+            if isinstance(raw, str) and raw.strip():
+                urls.append(raw.strip())
+        return urls
+    if isinstance(value, Sequence):
+        for item in value:
+            urls.extend(_collect_urls(item))
+    return urls
+
+
+def _extract_result_urls(payload: Mapping[str, Any]) -> list[str]:
+    data = payload.get("data")
+    if isinstance(data, Mapping):
+        for key in ("resultUrls", "originUrls", "urls", "imageUrls"):
+            urls = _collect_urls(data.get(key))
+            if urls:
+                return urls
+        result_json = data.get("resultJson")
+        if isinstance(result_json, str):
+            try:
+                nested = json.loads(result_json)
+            except Exception:
+                return []
+            if isinstance(nested, Mapping):
+                for key in ("resultUrls", "urls", "originUrls"):
+                    urls = _collect_urls(nested.get(key))
+                    if urls:
+                        return urls
+    return []
+
+
+def _extract_state(payload: Mapping[str, Any]) -> str:
+    data = payload.get("data")
+    if isinstance(data, Mapping):
+        for key in ("state", "successFlag", "status", "flag"):
+            normalized = _normalize_state(data.get(key))
+            if normalized:
+                return normalized
+    return ""
+
+
+def _extract_error_reason(payload: Mapping[str, Any]) -> str:
+    data = payload.get("data") if isinstance(payload.get("data"), Mapping) else {}
+    fields = ("failMsg", "message", "error", "detail", "reason")
+    for source in (payload, data):
+        if isinstance(source, Mapping):
+            for key in fields:
+                value = source.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+    return "Banana service error"
+
+
+def _build_cache_key(user_id: int, prompt: str, images: Sequence[str]) -> str:
+    normalized_prompt = (prompt or "").strip().lower()
+    digest = hashlib.sha256(
+        "|".join(
+            [
+                "banana",
+                str(int(user_id)),
+                normalized_prompt,
+                *sorted(str(img) for img in images),
+            ]
+        ).encode("utf-8")
+    ).hexdigest()
+    return f"banana:result:{digest}"
+
+
+class BananaAsyncHandler:
+    """Asynchronous Banana pipeline orchestrator."""
+
+    def __init__(
+        self,
+        *,
+        redis: Any = None,
+        client: Optional[KieAPIAsync] = None,
+        bot_logger: Optional[BotLogger] = None,
+        cache_ttl: int = 3600,
+        poll_interval: float = 4.0,
+        poll_timeout: float = 8 * 60.0,
+    ) -> None:
+        self._redis = redis
+        self._client = client or KieAPIAsync()
+        self._cache_ttl = cache_ttl
+        self._poll_interval = poll_interval
+        self._poll_timeout = poll_timeout
+        self._logger = bot_logger or BotLogger(redis=redis)
+
+    async def run(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        chat = update.effective_chat
+        user = update.effective_user
+        if chat is None or user is None:
+            return
+
+        ack_message = await context.bot.send_message(chat.id, _ACK_TEXT)
+
+        try:
+            redis = self._resolve_redis(context)
+        except RuntimeError as exc:
+            await self._handle_failure(context, chat.id, ack_message.message_id, exc, user_id=user.id)
+            return
+
+        try:
+            state = await load(redis, user.id)
+        except Exception as exc:
+            await handle_async_error(exc, "BananaAsync.load_state")
+            await self._handle_failure(context, chat.id, ack_message.message_id, exc, user_id=user.id)
+            return
+
+        if not isinstance(state, BananaState) or not state.ready:
+            await self._notify_invalid_state(context, chat.id, ack_message.message_id)
+            return
+
+        prompt = state.prompt or ""
+        photos = list(state.photos)
+        cache_key = _build_cache_key(user.id, prompt, photos)
+
+        try:
+            result = await get_or_set_cache(
+                cache_key,
+                lambda: self._generate(
+                    context=context,
+                    chat_id=chat.id,
+                    user_id=user.id,
+                    prompt=prompt,
+                    photos=photos,
+                    ack_message_id=ack_message.message_id,
+                ),
+                redis=redis,
+                ttl=self._cache_ttl,
+            )
+        except BananaBadRequest as exc:
+            await handle_async_error(exc, "BananaAsync.bad_request")
+            await self._handle_failure(context, chat.id, ack_message.message_id, exc, user_id=user.id)
+            return
+        except (BananaBackendError, BananaTimeout, KieAPITimeoutError) as exc:
+            await handle_async_error(exc, "BananaAsync.backend_error")
+            await self._handle_failure(context, chat.id, ack_message.message_id, exc, user_id=user.id)
+            return
+        except Exception as exc:
+            await handle_async_error(exc, "BananaAsync.run")
+            await self._handle_failure(context, chat.id, ack_message.message_id, exc, user_id=user.id)
+            return
+
+        cached = bool(result.get("_cached"))
+        if cached:
+            await self._logger.info(f"[BananaAsync] cache hit  | key: {cache_key}", user_id=user.id)
+            await self._send_cached_result(
+                context=context,
+                chat_id=chat.id,
+                message_id=ack_message.message_id,
+                payload=result,
+            )
+
+        try:
+            state.last_job_id = str(result.get("task_id") or state.last_job_id or "") or None
+            state.last_result_id = str(result.get("file_id") or state.last_result_id or "") or None
+            await save(redis, user.id, state)
+        except Exception as exc:
+            await handle_async_error(exc, "BananaAsync.save_state")
+
+    def _resolve_redis(self, context: ContextTypes.DEFAULT_TYPE) -> Any:
+        if self._redis is not None:
+            return self._redis
+        redis = getattr(context, "redis", None)
+        if redis is None:
+            raise RuntimeError("Redis client is not configured")
+        return redis
+
+    async def _generate(
+        self,
+        *,
+        context: ContextTypes.DEFAULT_TYPE,
+        chat_id: int,
+        user_id: int,
+        prompt: str,
+        photos: Sequence[str],
+        ack_message_id: int,
+    ) -> MutableMapping[str, Any]:
+        image_urls = await self._prepare_image_urls(context.bot, photos)
+        if not image_urls:
+            raise BananaBackendError("no_uploads")
+
+        payload = {
+            "taskType": "banana_img2img",
+            "model": _BANANA_MODEL,
+            "prompt": prompt,
+            "enableTranslation": True,
+            "input": {"prompt": prompt, "images": image_urls},
+        }
+
+        try:
+            response = await self._client.request_json("POST", _BANANA_CREATE_PATH, json_payload=payload)
+        except KieAPIHTTPError as exc:
+            if exc.status in {400, 401, 402, 403, 404, 422}:
+                raise BananaBadRequest(_extract_error_reason(exc.payload)) from exc
+            raise BananaBackendError(f"HTTP {exc.status}") from exc
+        except (KieAPITimeoutError, KieAPITransportError) as exc:
+            raise BananaBackendError(str(exc)) from exc
+
+        task_id = _extract_task_id(response)
+        if not task_id:
+            raise BananaBackendError("Banana task id missing")
+
+        await self._logger.info(
+            f"[BananaAsync] start job  | user_id: {user_id}",
+            task_id=task_id,
+            prompt=prompt,
+        )
+
+        async for status_payload in self._client.poll_job(
+            _BANANA_STATUS_PATH,
+            task_id=task_id,
+            interval=self._poll_interval,
+            timeout=self._poll_timeout,
+        ):
+            state = _extract_state(status_payload)
+            if state in _WAIT_STATES:
+                await asyncio.sleep(0)
+                continue
+            if state in _SUCCESS_STATES:
+                urls = _extract_result_urls(status_payload)
+                if not urls:
+                    raise BananaBackendError("Banana returned empty result")
+                url = urls[0]
+                message, caption = await self._publish_result(
+                    context=context,
+                    chat_id=chat_id,
+                    message_id=ack_message_id,
+                    media=url,
+                    prompt=prompt,
+                )
+                file_id = self._extract_file_id(message) or url
+                result = BananaResult(file_id=file_id, task_id=task_id, caption=caption, url=url)
+                return result.to_mapping()
+            if state in _FAIL_STATES:
+                raise BananaBackendError(_extract_error_reason(status_payload))
+            raise BananaBackendError(f"Unexpected Banana state: {state or 'unknown'}")
+
+        raise BananaTimeout("Banana polling timed out")
+
+    async def _prepare_image_urls(self, bot, file_ids: Sequence[str]) -> list[str]:
+        uploads: list[str] = []
+        for idx, file_id in enumerate(file_ids):
+            try:
+                data = await self._fetch_file_bytes(bot, file_id)
+                validate_image(data)
+            except Exception as exc:
+                await handle_async_error(exc, "BananaAsync.prepare_image")
+                continue
+            filename = f"banana_input_{idx + 1}.png"
+            try:
+                url = await self._upload_image_bytes(bytes(data), filename=filename)
+            except BananaBackendError as exc:
+                await handle_async_error(exc, "BananaAsync.upload_image")
+                continue
+            uploads.append(url)
+        return uploads
+
+    async def _fetch_file_bytes(self, bot, file_id: str) -> bytes:
+        tg_file = await bot.get_file(file_id)
+        return await tg_file.download_as_bytearray()
+
+    async def _upload_image_bytes(self, data: bytes, *, filename: str) -> str:
+        payload = {
+            "fileName": filename,
+            "base64": base64.b64encode(data).decode("ascii"),
+        }
+        try:
+            response = await self._client.request_json("POST", _UPLOAD_PATH, json_payload=payload)
+        except (KieAPITimeoutError, KieAPITransportError) as exc:
+            raise BananaBackendError(str(exc)) from exc
+        except KieAPIHTTPError as exc:
+            raise BananaBackendError(f"HTTP {exc.status}") from exc
+
+        if isinstance(response, Mapping):
+            for key in ("public_url", "publicUrl", "url"):
+                value = response.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+            data = response.get("data")
+            if isinstance(data, Mapping):
+                for key in ("public_url", "publicUrl", "url"):
+                    value = data.get(key)
+                    if isinstance(value, str) and value.strip():
+                        return value.strip()
+        raise BananaBackendError("upload_failed")
+
+    async def _publish_result(
+        self,
+        *,
+        context: ContextTypes.DEFAULT_TYPE,
+        chat_id: int,
+        message_id: int,
+        media: str,
+        prompt: str,
+    ) -> tuple[Any, str]:
+        caption = _SUCCESS_CAPTION if not prompt else f"{_SUCCESS_CAPTION}\n{prompt}"
+        try:
+            message = await context.bot.edit_message_media(
+                chat_id=chat_id,
+                message_id=message_id,
+                media=InputMediaDocument(media=media, caption=caption),
+                reply_markup=banana_result_kb(),
+            )
+            return message, caption
+        except Exception as exc:
+            await handle_async_error(exc, "BananaAsync.publish_result")
+            await context.bot.send_message(chat_id, caption)
+            return None, caption
+
+    async def _send_cached_result(
+        self,
+        *,
+        context: ContextTypes.DEFAULT_TYPE,
+        chat_id: int,
+        message_id: int,
+        payload: Mapping[str, Any],
+    ) -> None:
+        file_id = payload.get("file_id") if isinstance(payload, Mapping) else None
+        caption = payload.get("caption") if isinstance(payload, Mapping) else None
+        if not isinstance(file_id, str) or not file_id:
+            await context.bot.edit_message_text(chat_id=chat_id, message_id=message_id, text=_FAILURE_TEXT)
+            return
+        try:
+            await context.bot.edit_message_media(
+                chat_id=chat_id,
+                message_id=message_id,
+                media=InputMediaDocument(media=file_id, caption=caption or _SUCCESS_CAPTION),
+                reply_markup=banana_result_kb(),
+            )
+        except Exception as exc:
+            await handle_async_error(exc, "BananaAsync.cached_edit")
+            await context.bot.send_message(chat_id, caption or _SUCCESS_CAPTION)
+
+    async def _handle_failure(
+        self,
+        context: ContextTypes.DEFAULT_TYPE,
+        chat_id: int,
+        message_id: int,
+        exc: Exception,
+        *,
+        user_id: Optional[int] = None,
+    ) -> None:
+        await self._logger.error(
+            f"[BananaAsync] error      | message: {exc}",
+            user_id=user_id,
+        )
+        try:
+            await context.bot.edit_message_text(chat_id=chat_id, message_id=message_id, text=_FAILURE_TEXT)
+        except Exception as edit_exc:
+            await handle_async_error(edit_exc, "BananaAsync.edit_failure")
+            await context.bot.send_message(chat_id, _FAILURE_TEXT)
+
+    async def _notify_invalid_state(self, context, chat_id: int, message_id: int) -> None:
+        try:
+            await context.bot.edit_message_text(
+                chat_id=chat_id,
+                message_id=message_id,
+                text="Добавьте фото и промпт для редактирования.",
+            )
+        except Exception as exc:
+            await handle_async_error(exc, "BananaAsync.invalid_state")
+            await context.bot.send_message(chat_id, "Добавьте фото и промпт для редактирования.")
+
+    @staticmethod
+    def _extract_file_id(message: Any) -> Optional[str]:
+        if message is None:
+            return None
+        document = getattr(message, "document", None)
+        if document is not None:
+            file_id = getattr(document, "file_id", None)
+            if isinstance(file_id, str) and file_id:
+                return file_id
+        photos = getattr(message, "photo", None)
+        if photos:
+            try:
+                candidate = photos[-1]
+            except Exception:
+                candidate = None
+            if candidate is not None:
+                file_id = getattr(candidate, "file_id", None)
+                if isinstance(file_id, str) and file_id:
+                    return file_id
+        return None
+
+
+__all__ = ["BananaAsyncHandler"]

--- a/handlers/midjourney.py
+++ b/handlers/midjourney.py
@@ -9,6 +9,7 @@ from typing import Any, Iterable, Mapping, MutableMapping, Optional, Sequence
 from telegram import Update
 from telegram.ext import ContextTypes
 
+from error_utils import handle_async_error
 from helpers.errors import send_user_error
 from services.db_async import get_user_balance_async
 from services.kie_api_async import (
@@ -261,8 +262,8 @@ async def _send_gallery(context: ContextTypes.DEFAULT_TYPE, chat_id: int, urls: 
             await context.bot.send_photo(chat_id=chat_id, photo=media[0], caption=caption, parse_mode="HTML")
         else:
             await context.bot.send_message(chat_id=chat_id, text=f"✅ Midjourney: {media[0]}")
-    except Exception:  # pragma: no cover - Telegram edge cases
-        logger.exception("midjourney.send_result_failed", extra={"chat_id": chat_id})
+    except Exception as exc:  # pragma: no cover - Telegram edge cases
+        await handle_async_error(exc, "Midjourney.send_result")
         await context.bot.send_message(chat_id=chat_id, text=f"✅ Midjourney: {urls[0]}")
 
 

--- a/handlers/veo_fast.py
+++ b/handlers/veo_fast.py
@@ -7,6 +7,7 @@ from typing import Any, Awaitable, Callable, Mapping, MutableMapping, Optional
 
 from telegram.ext import ContextTypes
 
+from error_utils import handle_async_error
 from helpers.errors import send_user_error
 from helpers.progress import PROGRESS_STORAGE_KEY, send_progress_message
 
@@ -173,9 +174,13 @@ async def trigger_retry_callback(
     handler = storage.pop(retry_id, None)
     if handler is None:
         return False
-    result = handler()
-    if inspect.isawaitable(result):
-        await result
+    try:
+        result = handler()
+        if inspect.isawaitable(result):
+            await result
+    except Exception as exc:
+        await handle_async_error(exc, "VEOFast.retry_handler")
+        return False
     return True
 
 

--- a/services/kie_api_async.py
+++ b/services/kie_api_async.py
@@ -169,3 +169,28 @@ class KieAPIAsync:
             return payload
         return {"value": payload}
 
+    async def poll_job(
+        self,
+        path: str,
+        *,
+        task_id: Optional[str] = None,
+        params: Optional[Mapping[str, Any]] = None,
+        interval: float = 4.0,
+        timeout: float = 8 * 60.0,
+    ):
+        """Yield status payloads for ``task_id`` until cancelled."""
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + float(timeout)
+        query = dict(params or {})
+        if task_id is not None:
+            query.setdefault("taskId", task_id)
+
+        while True:
+            if loop.time() >= deadline:
+                raise KieAPITimeoutError("KIE polling timed out")
+            payload = await self.request_json("GET", path, params=query)
+            yield payload
+            if interval > 0:
+                await asyncio.sleep(float(interval))
+

--- a/tests/test_banana_e2e.py
+++ b/tests/test_banana_e2e.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+from handlers.banana_async_handler import BananaAsyncHandler, _build_cache_key
+from services.kie_api_async import KieAPITimeoutError
+from utils.banana_state import BananaState, save
+
+_ACK = "🟡 Processing your Banana edit... please wait."
+_FAILURE = "⚠️ Something went wrong on Banana servers. Please try again later."
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.published: list[tuple[str, str]] = []
+
+    async def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        self.store[key] = value
+
+    def publish(self, channel: str, payload: str) -> None:  # pragma: no cover - debug only
+        self.published.append((channel, payload))
+
+
+class DummyBot:
+    def __init__(self) -> None:
+        self.messages: list[dict[str, object]] = []
+        self.media_edits: list[dict[str, object]] = []
+        self.text_edits: list[dict[str, object]] = []
+
+    async def send_message(self, chat_id, text, **kwargs):
+        self.messages.append({"chat_id": chat_id, "text": text, "kwargs": kwargs})
+        return SimpleNamespace(message_id=len(self.messages))
+
+    async def edit_message_media(self, chat_id, message_id, media, reply_markup=None):
+        entry = {
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "media": media,
+            "reply_markup": reply_markup,
+        }
+        self.media_edits.append(entry)
+        return SimpleNamespace(
+            message_id=message_id,
+            document=SimpleNamespace(file_id="banana-file"),
+            photo=[],
+        )
+
+    async def edit_message_text(self, chat_id, message_id, text, **kwargs):
+        entry = {
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "text": text,
+            "kwargs": kwargs,
+        }
+        self.text_edits.append(entry)
+        return SimpleNamespace(message_id=message_id, text=text)
+
+
+class SuccessfulClient:
+    def __init__(self) -> None:
+        self.create_calls: list[dict[str, object]] = []
+
+    async def request_json(self, method, path, json_payload=None, params=None, headers=None):
+        if path == "/api/v1/jobs/createTask":
+            self.create_calls.append({"method": method, "payload": json_payload})
+            return {"taskId": "banana-task"}
+        raise AssertionError(f"Unexpected path {path}")
+
+    async def poll_job(self, path, *, task_id=None, params=None, interval=0.0, timeout=0.0):
+        yield {
+            "data": {
+                "state": "success",
+                "resultUrls": ["https://cdn.example/result.png"],
+            }
+        }
+
+
+class TimeoutClient(SuccessfulClient):
+    async def poll_job(self, path, *, task_id=None, params=None, interval=0.0, timeout=0.0):
+        if False:  # pragma: no cover - satisfy async generator contract
+            yield {}
+        raise KieAPITimeoutError("poll timeout")
+
+
+def test_successful_async_generation_flow(monkeypatch):
+    async def scenario():
+        redis = FakeRedis()
+        bot = DummyBot()
+        handler = BananaAsyncHandler(redis=redis, client=SuccessfulClient())
+
+        async def fake_prepare(self, bot_obj, photos):
+            return ["https://cdn.example/upload.png"]
+
+        monkeypatch.setattr(handler, "_prepare_image_urls", fake_prepare.__get__(handler, BananaAsyncHandler))
+
+        user_id = 42
+        chat_id = 100
+        state = BananaState(photos=["photo-1"], prompt="Clean background")
+        await save(redis, user_id, state)
+
+        update = SimpleNamespace(
+            effective_chat=SimpleNamespace(id=chat_id),
+            effective_user=SimpleNamespace(id=user_id),
+        )
+        context = SimpleNamespace(bot=bot, redis=redis)
+
+        await handler.run(update, context)
+
+        assert bot.messages and bot.messages[0]["text"] == _ACK
+        assert bot.media_edits, "expected result edit"
+        media = bot.media_edits[0]["media"]
+        assert getattr(media, "media", None) == "https://cdn.example/result.png"
+
+        cache_key = _build_cache_key(user_id, state.prompt or "", state.photos)
+        cached_raw = redis.store.get(cache_key)
+        assert cached_raw, "result should be cached"
+        cached = json.loads(cached_raw)
+        assert cached["file_id"] == "banana-file"
+
+    asyncio.run(scenario())
+
+
+def test_cache_hit_reuses_file(monkeypatch):
+    async def scenario():
+        redis = FakeRedis()
+        bot = DummyBot()
+        client = SuccessfulClient()
+        handler = BananaAsyncHandler(redis=redis, client=client)
+
+        user_id = 7
+        chat_id = 55
+        prompt = "Retouch"
+        photos = ["img-1", "img-2"]
+        state = BananaState(photos=list(photos), prompt=prompt)
+        await save(redis, user_id, state)
+
+        cache_key = _build_cache_key(user_id, prompt, photos)
+        await redis.set(
+            cache_key,
+            json.dumps({"file_id": "cached-file", "caption": "✅ Banana edit ready!"}),
+        )
+
+        update = SimpleNamespace(
+            effective_chat=SimpleNamespace(id=chat_id),
+            effective_user=SimpleNamespace(id=user_id),
+        )
+        context = SimpleNamespace(bot=bot, redis=redis)
+
+        await handler.run(update, context)
+
+        assert client.create_calls == [], "backend should not be invoked on cache hit"
+        assert bot.media_edits and bot.media_edits[0]["media"].media == "cached-file"
+        assert bot.messages and bot.messages[0]["text"] == _ACK
+
+    asyncio.run(scenario())
+
+
+def test_backend_failure(monkeypatch):
+    async def scenario():
+        redis = FakeRedis()
+        bot = DummyBot()
+        handler = BananaAsyncHandler(redis=redis, client=TimeoutClient())
+
+        async def fake_prepare(self, bot_obj, photos):
+            return ["https://cdn.example/upload.png"]
+
+        monkeypatch.setattr(handler, "_prepare_image_urls", fake_prepare.__get__(handler, BananaAsyncHandler))
+
+        user_id = 99
+        chat_id = 77
+        state = BananaState(photos=["photo"], prompt="Touch up")
+        await save(redis, user_id, state)
+
+        update = SimpleNamespace(
+            effective_chat=SimpleNamespace(id=chat_id),
+            effective_user=SimpleNamespace(id=user_id),
+        )
+        context = SimpleNamespace(bot=bot, redis=redis)
+
+        await handler.run(update, context)
+
+        assert bot.messages and bot.messages[0]["text"] == _ACK
+        assert bot.text_edits and bot.text_edits[0]["text"] == _FAILURE
+        assert not bot.media_edits, "no media edits expected on failure"
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- add BananaAsyncHandler that drives the async Banana workflow with Redis caching, logging, and Telegram message updates
- introduce shared async error/logging helpers and reuse them in Banana, Midjourney, and VEO handlers while extending the KIE client
- cover the new flow with dedicated Banana e2e tests and ensure cache reuse and failure handling

## Testing
- pytest tests/test_banana_e2e.py -q

------
https://chatgpt.com/codex/tasks/task_e_690a03f14ab88322aecb07896a315ecf