### PR TITLE
Restore Nana Banana photo flow

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -156,6 +156,12 @@ from hub_router import (
     set_fallback as set_hub_fallback,
 )
 from handlers import profile as profile_handlers
+from handlers.banana_async_handler import (
+    new_card as banana_new_card,
+    restart_generation as banana_restart_generation,
+    start_generation as banana_start_generation,
+)
+from handlers.photo_modes import open_menu as photo_modes_open_menu
 from handlers.stars import buy as stars_buy_handler, open_stars_menu
 from mj_client import (
     build_status_candidates as mj_status_candidates,
@@ -22499,6 +22505,10 @@ CALLBACK_HANDLER_SPECS: List[tuple[Optional[str], Any]] = [
     (r"^dialog:choose_promptmaster$", dialog_choose_promptmaster_callback),
     (r"^noop$", on_noop_callback),
     (r"^music:(inst|vocal)$", on_music_callback),
+    (r"^banana:start$", banana_start_generation),
+    (r"^banana:restart$", banana_restart_generation),
+    (r"^banana:new$", banana_new_card),
+    (r"^banana:back_photo$", photo_modes_open_menu),
     (rf"^{CB_PM_INSERT_PREFIX}(veo|mj|banana|animate|suno)$", prompt_master_insert_callback_entry),
     (rf"^{CB_PM_PREFIX}", prompt_master_callback_entry),
     (rf"^{CB_FAQ_PREFIX}", faq_callback_entry),

--- a/handlers/banana_async_handler.py
+++ b/handlers/banana_async_handler.py
@@ -26,6 +26,8 @@ from keyboards import banana_result_kb
 from utils.banana_state import BananaState, load, save
 from utils.files import validate_image
 
+from ui.renderers.banana import banana_card_kb as build_banana_card_kb, banana_card_text
+
 from handlers.banana import (
     BananaBackendError,
     BananaBadRequest,
@@ -33,6 +35,10 @@ from handlers.banana import (
 )
 
 log = logging.getLogger("handlers.banana_async")
+
+
+_MAX_CARD_IMAGES = 4
+_DEFAULT_HANDLER: Optional["BananaAsyncHandler"] = None
 
 _ACK_TEXT = "🟡 Processing your Banana edit... please wait."
 _SUCCESS_CAPTION = "✅ Banana edit ready!"
@@ -247,6 +253,7 @@ class BananaAsyncHandler:
                 chat_id=chat.id,
                 message_id=ack_message.message_id,
                 payload=result,
+                user_id=user.id,
             )
 
         try:
@@ -326,6 +333,7 @@ class BananaAsyncHandler:
                     message_id=ack_message_id,
                     media=url,
                     prompt=prompt,
+                    user_id=user_id,
                 )
                 file_id = self._extract_file_id(message) or url
                 result = BananaResult(file_id=file_id, task_id=task_id, caption=caption, url=url)
@@ -403,6 +411,7 @@ class BananaAsyncHandler:
         message_id: int,
         media: str,
         prompt: str,
+        user_id: int,
     ) -> tuple[Any, str]:
         caption = _SUCCESS_CAPTION if not prompt else f"{_SUCCESS_CAPTION}\n{prompt}"
         try:
@@ -412,10 +421,18 @@ class BananaAsyncHandler:
                 media=InputMediaDocument(media=media, caption=caption),
                 reply_markup=banana_result_kb(),
             )
+            log.info(
+                "banana.result.sent",
+                extra={"chat_id": chat_id, "user_id": user_id, "cached": False},
+            )
             return message, caption
         except Exception as exc:
             await handle_async_error(exc, "BananaAsync.publish_result")
             await context.bot.send_message(chat_id, caption)
+            log.info(
+                "banana.result.sent",
+                extra={"chat_id": chat_id, "user_id": user_id, "cached": False, "fallback": True},
+            )
             return None, caption
 
     async def _send_cached_result(
@@ -425,6 +442,7 @@ class BananaAsyncHandler:
         chat_id: int,
         message_id: int,
         payload: Mapping[str, Any],
+        user_id: int,
     ) -> None:
         file_id = payload.get("file_id") if isinstance(payload, Mapping) else None
         caption = payload.get("caption") if isinstance(payload, Mapping) else None
@@ -438,9 +456,17 @@ class BananaAsyncHandler:
                 media=InputMediaDocument(media=file_id, caption=caption or _SUCCESS_CAPTION),
                 reply_markup=banana_result_kb(),
             )
+            log.info(
+                "banana.result.sent",
+                extra={"chat_id": chat_id, "user_id": user_id, "cached": True},
+            )
         except Exception as exc:
             await handle_async_error(exc, "BananaAsync.cached_edit")
             await context.bot.send_message(chat_id, caption or _SUCCESS_CAPTION)
+            log.info(
+                "banana.result.sent",
+                extra={"chat_id": chat_id, "user_id": user_id, "cached": True, "fallback": True},
+            )
 
     async def _handle_failure(
         self,
@@ -494,4 +520,248 @@ class BananaAsyncHandler:
         return None
 
 
-__all__ = ["BananaAsyncHandler"]
+def _get_default_handler() -> "BananaAsyncHandler":
+    global _DEFAULT_HANDLER
+    if _DEFAULT_HANDLER is None:
+        _DEFAULT_HANDLER = BananaAsyncHandler()
+    return _DEFAULT_HANDLER
+
+
+def _resolve_redis(context: ContextTypes.DEFAULT_TYPE):
+    redis = getattr(context, "redis", None)
+    if redis is None:
+        raise RuntimeError("Redis client is not configured")
+    return redis
+
+
+async def _load_state(context: ContextTypes.DEFAULT_TYPE, user_id: int) -> BananaState:
+    redis = _resolve_redis(context)
+    return await load(redis, user_id)
+
+
+async def _save_state(
+    context: ContextTypes.DEFAULT_TYPE, user_id: int, state: BananaState
+) -> None:
+    redis = _resolve_redis(context)
+    await save(redis, user_id, state)
+
+
+def _extract_photo_file_id(message) -> Optional[str]:
+    photos = getattr(message, "photo", None)
+    if photos:
+        try:
+            candidate = photos[-1]
+        except Exception:
+            candidate = None
+        if candidate is not None:
+            file_id = getattr(candidate, "file_id", None)
+            if isinstance(file_id, str) and file_id:
+                return file_id
+    document = getattr(message, "document", None)
+    if document is not None:
+        mime = getattr(document, "mime_type", "") or ""
+        if mime.startswith("image/"):
+            file_id = getattr(document, "file_id", None)
+            if isinstance(file_id, str) and file_id:
+                return file_id
+    return None
+
+
+async def _render_card(
+    *,
+    ctx: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    state: BananaState,
+    user_id: Optional[int],
+    message=None,
+) -> None:
+    text = banana_card_text(0, state)
+    markup = build_banana_card_kb(state)
+    edited = False
+    if message is not None and getattr(message, "text", None):
+        try:
+            await message.edit_text(text, reply_markup=markup)
+            edited = True
+        except Exception as exc:
+            await handle_async_error(exc, "BananaAsync.card_edit")
+    if not edited:
+        try:
+            await ctx.bot.send_message(chat_id, text, reply_markup=markup)
+        except Exception as exc:
+            await handle_async_error(exc, "BananaAsync.card_send")
+            return
+    log.info(
+        "banana.card.update",
+        extra={
+            "user_id": user_id,
+            "photos": len(state.photos),
+            "has_prompt": bool(state.prompt),
+        },
+    )
+
+
+async def open_card(update: Update, ctx: ContextTypes.DEFAULT_TYPE, payload=None) -> None:
+    query = update.callback_query
+    if query is None:
+        return
+    try:
+        await query.answer()
+    except Exception:
+        pass
+    user = update.effective_user
+    message = query.message
+    chat = getattr(message, "chat", None) or update.effective_chat
+    if user is None or chat is None:
+        return
+    try:
+        state = await _load_state(ctx, user.id)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.card_load")
+        return
+    await _render_card(
+        ctx=ctx,
+        chat_id=chat.id,
+        state=state,
+        user_id=user.id,
+        message=message,
+    )
+
+
+async def on_photo(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    message = update.effective_message
+    chat = update.effective_chat
+    user = update.effective_user
+    if message is None or chat is None or user is None:
+        return
+    file_id = _extract_photo_file_id(message)
+    if not file_id:
+        return
+    try:
+        state = await _load_state(ctx, user.id)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.photo_load")
+        return
+    if len(state.photos) >= _MAX_CARD_IMAGES:
+        await message.reply_text("Максимум 4 фото. Удалите лишнее или начните новую генерацию.")
+        return
+    state.photos.append(file_id)
+    try:
+        await _save_state(ctx, user.id, state)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.photo_save")
+    await _render_card(ctx=ctx, chat_id=chat.id, state=state, user_id=user.id)
+
+
+async def on_text_prompt(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    message = update.effective_message
+    chat = update.effective_chat
+    user = update.effective_user
+    text = getattr(message, "text", None)
+    if message is None or chat is None or user is None or text is None:
+        return
+    prompt = text.strip()
+    try:
+        state = await _load_state(ctx, user.id)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.text_load")
+        return
+    state.prompt = prompt or None
+    try:
+        await _save_state(ctx, user.id, state)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.text_save")
+    try:
+        await ctx.bot.delete_message(chat.id, message.message_id)
+    except Exception:
+        pass
+    await _render_card(ctx=ctx, chat_id=chat.id, state=state, user_id=user.id)
+
+
+async def start_generation(update: Update, ctx: ContextTypes.DEFAULT_TYPE, payload=None) -> None:
+    query = update.callback_query
+    user = update.effective_user
+    if query is None or user is None:
+        return
+    try:
+        state = await _load_state(ctx, user.id)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.start_load")
+        return
+    if not state.has_photos_or_prompt():
+        await query.answer("Добавьте фото или промпт", show_alert=True)
+        return
+    try:
+        await query.answer()
+    except Exception:
+        pass
+    log.info("banana.start", extra={"user_id": user.id, "action": "start"})
+    handler = _get_default_handler()
+    await handler.run(update, ctx)
+
+
+async def restart_generation(update: Update, ctx: ContextTypes.DEFAULT_TYPE, payload=None) -> None:
+    query = update.callback_query
+    user = update.effective_user
+    if query is None or user is None:
+        return
+    try:
+        state = await _load_state(ctx, user.id)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.restart_load")
+        return
+    if not state.has_photos_or_prompt():
+        await query.answer("Карточка пуста. Добавьте фото или промпт.", show_alert=True)
+        return
+    try:
+        await query.answer()
+    except Exception:
+        pass
+    log.info("banana.start", extra={"user_id": user.id, "action": "restart"})
+    handler = _get_default_handler()
+    await handler.run(update, ctx)
+
+
+async def new_card(update: Update, ctx: ContextTypes.DEFAULT_TYPE, payload=None) -> None:
+    query = update.callback_query
+    user = update.effective_user
+    chat = update.effective_chat
+    message = query.message if query else None
+    if query is None or user is None or chat is None:
+        return
+    try:
+        state = await _load_state(ctx, user.id)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.new_load")
+        return
+    state.reset()
+    try:
+        await _save_state(ctx, user.id, state)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.new_save")
+    try:
+        await query.answer()
+    except Exception:
+        pass
+    try:
+        await query.edit_message_reply_markup(reply_markup=None)
+    except Exception:
+        pass
+    editable_message = message if getattr(message, "text", None) else None
+    await _render_card(
+        ctx=ctx,
+        chat_id=chat.id,
+        state=state,
+        user_id=user.id,
+        message=editable_message,
+    )
+
+
+__all__ = [
+    "BananaAsyncHandler",
+    "open_card",
+    "on_photo",
+    "on_text_prompt",
+    "start_generation",
+    "restart_generation",
+    "new_card",
+]

--- a/handlers/photo_modes.py
+++ b/handlers/photo_modes.py
@@ -1,0 +1,41 @@
+"""Helpers to show photo engine selection menus."""
+
+from __future__ import annotations
+
+import logging
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from keyboards import photo_engines_kb
+
+log = logging.getLogger("handlers.photo_modes")
+
+_PHOTO_ENGINES_TITLE = "📸 Выберите нейросеть для фотографий:"
+
+
+async def open_menu(update: Update, ctx: ContextTypes.DEFAULT_TYPE, payload=None) -> None:
+    query = update.callback_query
+    if query is not None:
+        try:
+            await query.answer()
+        except Exception:
+            pass
+        message = query.message
+    else:
+        message = update.effective_message
+    chat = update.effective_chat
+    markup = photo_engines_kb()
+    if message is not None and getattr(message, "text", None):
+        try:
+            await message.edit_text(_PHOTO_ENGINES_TITLE, reply_markup=markup)
+            log.debug("photo_modes.menu.edit", extra={"chat_id": getattr(chat, "id", None)})
+            return
+        except Exception:
+            log.debug("photo_modes.menu.edit_failed", exc_info=True)
+    if chat is not None:
+        await ctx.bot.send_message(chat.id, _PHOTO_ENGINES_TITLE, reply_markup=markup)
+        log.debug("photo_modes.menu.sent", extra={"chat_id": chat.id})
+
+
+__all__ = ["open_menu"]

--- a/keyboards.py
+++ b/keyboards.py
@@ -326,15 +326,14 @@ def banana_card_kb(can_start: bool) -> InlineKeyboardMarkup:
     rows: list[list[InlineKeyboardButton]] = []
     if can_start:
         rows.append([InlineKeyboardButton("🚀 Начать генерацию", callback_data="banana:start")])
-    rows.append([InlineKeyboardButton("🧹 Очистить карточку", callback_data="banana:clear")])
-    rows.append([InlineKeyboardButton("⬅️ Назад", callback_data="back_main")])
+    rows.append([InlineKeyboardButton("⬅️ Назад", callback_data="banana:back_photo")])
     return InlineKeyboardMarkup(rows)
 
 
 def banana_result_kb() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         [
-            [InlineKeyboardButton("🔁 Повторить генерацию", callback_data="banana:restart")],
+            [InlineKeyboardButton("↪️ Повторить генерацию", callback_data="banana:restart")],
             [InlineKeyboardButton("🆕 Новая генерация", callback_data="banana:new")],
         ]
     )

--- a/tests/test_banana_card_ui.py
+++ b/tests/test_banana_card_ui.py
@@ -26,8 +26,8 @@ def test_banana_card_compact_summary(bot_module):
     text = bot_module.banana_card_text(state)
 
     assert "Примеры запросов" not in text
-    assert "📸 Фото: 1/4" in text
-    assert "Промпт: нет" in text
+    assert "📷 Фото: 1/4" in text
+    assert "✏️ Промпт: нет" in text
     assert "banana_helper_line" not in state
 
 
@@ -36,13 +36,11 @@ def test_banana_card_shows_prompt(bot_module):
 
     text = bot_module.banana_card_text(state)
 
-    assert "Промпт: есть" in text
+    assert "✏️ Промпт: есть" in text
 
 
 def test_banana_keyboard_layout(bot_module):
     keyboard = bot_module.banana_kb()
     rows = keyboard.inline_keyboard
 
-    assert rows[0][0].text == "✨ Готовые шаблоны"
-    assert rows[1][0].text == "⚙️ Движок"
-    assert rows[1][1].text == "⬅️ Назад"
+    assert rows[0][0].text == "⬅️ Назад"

--- a/tests/test_banana_flow.py
+++ b/tests/test_banana_flow.py
@@ -90,7 +90,7 @@ def test_banana_generate_flow(monkeypatch, tmp_path, bot_module):
     markup = doc_call.get("reply_markup")
     assert isinstance(markup, InlineKeyboardMarkup)
     buttons = markup.inline_keyboard
-    assert buttons and buttons[0][0].text == "🔁 Повторить генерацию"
+    assert buttons and buttons[0][0].text == "↪️ Повторить генерацию"
     assert buttons[0][0].callback_data == "banana:restart"
     assert len(buttons) >= 2
     assert buttons[1][0].callback_data == "banana:new"

--- a/tests/test_banana_router.py
+++ b/tests/test_banana_router.py
@@ -1,0 +1,67 @@
+import asyncio
+import pytest
+
+import bot as bot_module
+from keyboards import banana_card_kb
+from ui.buttons import router as buttons_router
+from types import SimpleNamespace
+
+
+class _FakeMessage:
+    def __init__(self) -> None:
+        self.text = "placeholder"
+
+    async def edit_text(self, *args, **kwargs):
+        return None
+
+    async def reply_text(self, *args, **kwargs):
+        return None
+
+
+class _FakeQuery:
+    def __init__(self, data: str) -> None:
+        self.data = data
+        self.message = _FakeMessage()
+
+    async def answer(self, *args, **kwargs):
+        return None
+
+    async def edit_message_reply_markup(self, *args, **kwargs):
+        return None
+
+
+def test_route_callback_dispatches_banana(monkeypatch):
+    called = {}
+
+    async def fake_open_card(update, ctx, payload=None):
+        called["ok"] = True
+
+    monkeypatch.setattr("handlers.banana_async_handler.open_card", fake_open_card)
+    query = _FakeQuery("img_engine:banana")
+    update = SimpleNamespace(callback_query=query, effective_message=None)
+    context = SimpleNamespace()
+
+    asyncio.run(buttons_router.route_callback(update, context))
+
+    assert called.get("ok") is True
+
+
+def test_banana_callback_patterns_registered():
+    specs = bot_module.CALLBACK_HANDLER_SPECS
+    assert any(pattern == r"^banana:start$" and callback is bot_module.banana_start_generation for pattern, callback in specs)
+    assert any(pattern == r"^banana:restart$" and callback is bot_module.banana_restart_generation for pattern, callback in specs)
+    assert any(pattern == r"^banana:new$" and callback is bot_module.banana_new_card for pattern, callback in specs)
+    assert any(pattern == r"^banana:back_photo$" and callback is bot_module.photo_modes_open_menu for pattern, callback in specs)
+
+
+def test_banana_card_keyboard_rendering():
+    without_inputs = banana_card_kb(False)
+    rows = without_inputs.inline_keyboard
+    assert len(rows) == 1
+    assert rows[0][0].text == "⬅️ Назад"
+    assert rows[0][0].callback_data == "banana:back_photo"
+
+    with_inputs = banana_card_kb(True)
+    rows = with_inputs.inline_keyboard
+    assert rows[0][0].callback_data == "banana:start"
+    assert rows[1][0].callback_data == "banana:back_photo"

--- a/ui/buttons/router.py
+++ b/ui/buttons/router.py
@@ -725,6 +725,13 @@ async def route_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         await open_dialog_mode(update, context)
         return
 
+    if data == "img_engine:banana":
+        from handlers.banana_async_handler import open_card as open_banana_card
+
+        _mark_handled()
+        await open_banana_card(update, context)
+        return
+
     if data == "back_main":
         from handlers.menu import open_main_menu
 

--- a/ui/renderers/banana.py
+++ b/ui/renderers/banana.py
@@ -8,9 +8,9 @@ from keyboards import banana_card_kb as build_banana_card_kb
 def banana_card_text(balance: int, state) -> str:
     """Return the Banana card caption for ``state``."""
 
-    photos = f"📸 Фото: {len(state.images)}/4"
+    photos = f"📷 Фото: {len(state.images)}/4"
     prompt_state = "есть" if state.prompt else "нет"
-    return f"🍌 Карточка Banana\n💎 Баланс: {balance}\n{photos} • Промпт: {prompt_state}"
+    return f"🍌 Карточка Banana\n{photos} • ✏️ Промпт: {prompt_state}"
 
 
 def banana_card_kb(state) -> InlineKeyboardMarkup:

--- a/utils/banana_state.py
+++ b/utils/banana_state.py
@@ -61,7 +61,7 @@ class BananaState:
         self.photos = value
 
 
-_KEY_TMPL = "banana:state:{user_id}"
+_KEY_TMPL = "banana:{user_id}"
 _TTL_SECONDS = 60 * 60 * 24
 
 


### PR DESCRIPTION
## Summary
- rebuild the Banana card UX with conditional launch/back buttons and updated status text
- add async handlers for opening, updating, restarting, and resetting the Banana card plus router wiring
- register Banana callbacks and add regression tests for routing and card keyboard behaviour

## Testing
- pytest tests/test_banana_router.py tests/test_banana_card_ui.py tests/test_banana_flow.py

------
https://chatgpt.com/codex/tasks/task_e_690adae1531c8322abd1e6db26d4883f