### PR TITLE
Gracefully handle Redis outages for Banana and profile flows

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -23,6 +23,7 @@ log_environment(logging.getLogger("bot"))
 # Configure Telegram log forwarding as early as possible.
 import logger_to_telegram  # noqa: F401,E402
 import runtime_metrics
+from utils.redis_client import get_redis as _get_shared_redis
 
 try:
     from core.codex_logger import setup_codex_logger
@@ -45,6 +46,9 @@ logging.getLogger("bot").info(
     _codex_max_retry,
     _codex_silent,
 )
+
+# Warm up Redis client (falls back to in-memory store when unavailable).
+_bot_redis = _get_shared_redis()
 
 import json, time, uuid, asyncio, tempfile, subprocess, re, signal, socket, hashlib, html, sys, math, random, copy, io, unicodedata, traceback
 import threading

--- a/handlers/banana_async_handler.py
+++ b/handlers/banana_async_handler.py
@@ -23,8 +23,9 @@ from services.kie_api_async import (
     KieAPITransportError,
 )
 from keyboards import banana_result_kb
-from utils.banana_state import BananaState, load, save
+from utils.banana_state import BananaState, ensure, load, save
 from utils.files import validate_image
+from utils.redis_client import get_redis
 
 from ui.renderers.banana import banana_card_kb as build_banana_card_kb, banana_card_text
 
@@ -530,7 +531,11 @@ def _get_default_handler() -> "BananaAsyncHandler":
 def _resolve_redis(context: ContextTypes.DEFAULT_TYPE):
     redis = getattr(context, "redis", None)
     if redis is None:
-        raise RuntimeError("Redis client is not configured")
+        redis = get_redis()
+        try:
+            setattr(context, "redis", redis)
+        except Exception:
+            pass
     return redis
 
 
@@ -613,6 +618,12 @@ async def open_card(update: Update, ctx: ContextTypes.DEFAULT_TYPE, payload=None
     chat = getattr(message, "chat", None) or update.effective_chat
     if user is None or chat is None:
         return
+    redis = _resolve_redis(ctx)
+    try:
+        await ensure(redis, user.id)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.card_init")
+        return
     try:
         state = await _load_state(ctx, user.id)
     except Exception as exc:
@@ -624,6 +635,14 @@ async def open_card(update: Update, ctx: ContextTypes.DEFAULT_TYPE, payload=None
         state=state,
         user_id=user.id,
         message=message,
+    )
+    log.info(
+        "banana.card.opened",
+        extra={
+            "user_id": user.id,
+            "photos": len(state.photos),
+            "has_prompt": bool(state.prompt),
+        },
     )
 
 

--- a/handlers/profile.py
+++ b/handlers/profile.py
@@ -1174,7 +1174,7 @@ async def open_profile(
     update: Update,
     ctx: ContextTypes.DEFAULT_TYPE,
     *,
-    source: str,
+    source: str = "button",
     suppress_nav: bool = True,
     force_refresh: bool = False,
 ) -> None:
@@ -1243,6 +1243,7 @@ async def open_profile(
             observer and observer.observe(first_paint_ms)
         counter = lbl_safe(profile_open_total, source=source_label, result=result_label)
         counter and counter.inc()
+        log.info("profile.opened", extra={"source": source_label, "result": result_label})
         log.info("profile.open", extra={"source": source_label, "result": result_label})
         if user_id is not None:
             _release_profile_lock(user_id, lock_token)

--- a/tests/test_banana_open_card.py
+++ b/tests/test_banana_open_card.py
@@ -1,0 +1,56 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+from handlers import banana_async_handler
+from utils.redis_client import InMemoryStore
+
+
+class _FakeMessage:
+    def __init__(self) -> None:
+        self.text = "placeholder"
+        self.edited = False
+
+    async def edit_text(self, *args, **kwargs):
+        self.edited = True
+
+
+class _FakeQuery:
+    def __init__(self) -> None:
+        self.data = "img_engine:banana"
+        self.message = _FakeMessage()
+
+    async def answer(self, *args, **kwargs):
+        return None
+
+
+class _FakeBot:
+    def __init__(self) -> None:
+        self.sent = []
+
+    async def send_message(self, chat_id, text, reply_markup=None):
+        self.sent.append((chat_id, text, reply_markup))
+        return SimpleNamespace(message_id=1)
+
+
+def test_open_card_initialises_store(monkeypatch):
+    store = InMemoryStore()
+
+    monkeypatch.setattr("handlers.banana_async_handler.get_redis", lambda: store)
+
+    update = SimpleNamespace(
+        callback_query=_FakeQuery(),
+        effective_user=SimpleNamespace(id=123),
+        effective_chat=SimpleNamespace(id=321),
+    )
+    context = SimpleNamespace(bot=_FakeBot())
+
+    async def _scenario():
+        await banana_async_handler.open_card(update, context)
+        return await store.get("banana:123")
+
+    stored = asyncio.run(_scenario())
+    assert stored is not None
+    payload = json.loads(stored)
+    assert payload["images"] == []
+    assert payload["prompt"] == ""

--- a/tests/test_redis_fallback.py
+++ b/tests/test_redis_fallback.py
@@ -1,0 +1,25 @@
+import asyncio
+import importlib
+import sys
+
+
+def test_get_redis_returns_memory_store_when_url_missing(monkeypatch):
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    sys.modules.pop("utils.redis_client", None)
+    module = importlib.import_module("utils.redis_client")
+    importlib.reload(module)
+
+    store = module.get_redis()
+
+    assert isinstance(store, module.InMemoryStore)
+
+    async def _scenario() -> None:
+        ok = await store.set("example", "value", ex=5)
+        assert ok is True
+        assert await store.exists("example") is True
+        assert await store.get("example") == "value"
+        removed = await store.delete("example")
+        assert removed == 1
+        assert await store.get("example") is None
+
+    asyncio.run(_scenario())

--- a/tests/test_router_callbacks.py
+++ b/tests/test_router_callbacks.py
@@ -1,0 +1,47 @@
+import asyncio
+from types import SimpleNamespace
+
+from ui.buttons import router
+
+
+class _FakeQuery:
+    def __init__(self, data: str) -> None:
+        self.data = data
+        self.message = None
+
+    async def answer(self, *args, **kwargs):  # pragma: no cover - behaviour mocked
+        return None
+
+
+def test_route_callback_dispatches_banana(monkeypatch):
+    called = {}
+
+    async def fake_open_card(update, ctx):
+        called["banana"] = (update, ctx)
+
+    monkeypatch.setattr("handlers.banana_async_handler.open_card", fake_open_card)
+
+    query = _FakeQuery("img_engine:banana")
+    update = SimpleNamespace(callback_query=query)
+    context = SimpleNamespace()
+
+    asyncio.run(router.route_callback(update, context))
+
+    assert "banana" in called
+
+
+def test_route_callback_dispatches_profile(monkeypatch):
+    called = {}
+
+    async def fake_open_profile(update, ctx):
+        called["profile"] = (update, ctx)
+
+    monkeypatch.setattr("handlers.profile.open_profile", fake_open_profile)
+
+    query = _FakeQuery("btn:profile")
+    update = SimpleNamespace(callback_query=query)
+    context = SimpleNamespace()
+
+    asyncio.run(router.route_callback(update, context))
+
+    assert "profile" in called

--- a/ui/buttons/router.py
+++ b/ui/buttons/router.py
@@ -51,7 +51,9 @@ _LAST_CALLBACK_AT: dict[tuple[int, str], float] = {}
 
 
 # Allowed menu callback payloads handled by ``route_callback`` below.
-MENU_PAT = re.compile(r"^(btn:profile|kb_open|menu:(photo|music|video|dialog)|img_engine:.+|back_main)$")
+MENU_PAT = re.compile(
+    r"^(btn:profile|kb_open|menu:(photo|music|video|dialog)|img_engine:.+|banana:back_photo|back_main)$"
+)
 
 
 def _legacy_bridge_enabled() -> bool:
@@ -684,10 +686,11 @@ async def route_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         return
 
     if data == "btn:profile":
-        from handlers.menu import show_profile
+        from handlers.profile import open_profile as open_profile_card
 
         _mark_handled()
-        await show_profile(update, context)
+        await open_profile_card(update, context)
+        log.info("profile.opened")
         return
 
     if data == "kb_open":
@@ -730,6 +733,12 @@ async def route_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
         _mark_handled()
         await open_banana_card(update, context)
+        return
+    if data == "banana:back_photo":
+        from handlers.photo_modes import open_menu as open_photo_modes
+
+        _mark_handled()
+        await open_photo_modes(update, context)
         return
 
     if data == "back_main":

--- a/utils/banana_state.py
+++ b/utils/banana_state.py
@@ -80,7 +80,11 @@ async def load(redis, user_id: int) -> BananaState:
         photos = data.get("images") or []
         data["photos"] = photos
     data.pop("images", None)
-    data.setdefault("prompt", None)
+    prompt = data.get("prompt", None)
+    if isinstance(prompt, str) and not prompt.strip():
+        data["prompt"] = None
+    else:
+        data.setdefault("prompt", None)
     data.setdefault("last_job_id", None)
     data.setdefault("last_payload", None)
     data.setdefault("last_result_msg_id", None)
@@ -91,7 +95,12 @@ async def load(redis, user_id: int) -> BananaState:
 async def save(redis, user_id: int, state: BananaState) -> None:
     """Persist ``state`` for ``user_id`` with a one-day TTL."""
 
-    await redis.set(_key_for(user_id), json.dumps(asdict(state)), ex=_TTL_SECONDS)
+    payload = asdict(state)
+    payload["images"] = list(payload.get("photos", []))
+    prompt = payload.get("prompt")
+    if prompt is None:
+        payload["prompt"] = ""
+    await redis.set(_key_for(user_id), json.dumps(payload), ex=_TTL_SECONDS)
 
 
 async def clear(redis, user_id: int) -> None:

--- a/utils/redis_client.py
+++ b/utils/redis_client.py
@@ -1,0 +1,216 @@
+"""Utility helpers for accessing Redis with a safe in-memory fallback."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any, Optional
+
+try:  # pragma: no cover - optional dependency in some environments
+    import redis.asyncio as redis_asyncio
+except Exception:  # pragma: no cover - gracefully degrade when redis is missing
+    redis_asyncio = None  # type: ignore
+
+try:  # pragma: no cover - optional settings module is always available in runtime
+    import settings as app_settings
+except Exception:  # pragma: no cover - tests may stub settings lazily
+    app_settings = None  # type: ignore
+
+log = logging.getLogger("utils.redis_client")
+
+
+def _resolve_url() -> Optional[str]:
+    env_value = os.getenv("REDIS_URL")
+    if env_value:
+        return env_value
+    if app_settings is not None:
+        try:
+            url = getattr(app_settings, "REDIS_URL", None)
+            if url:
+                return str(url)
+        except Exception:  # pragma: no cover - defensive guard for dynamic settings
+            return None
+    return None
+
+
+def _resolve_prefix() -> str:
+    if app_settings is not None:
+        try:
+            prefix = getattr(app_settings, "REDIS_PREFIX", "")
+            if prefix:
+                return str(prefix)
+        except Exception:  # pragma: no cover - defensive
+            return ""
+    return ""
+
+
+def _ttl_seconds(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if numeric <= 0:
+        return 0.0
+    return numeric
+
+
+def _ttl_from_kwargs(*, ex: Any = None, px: Any = None) -> Optional[float]:
+    px_value = _ttl_seconds(px)
+    if px_value is not None:
+        return max(px_value / 1000.0, 0.0)
+    ex_value = _ttl_seconds(ex)
+    if ex_value is not None:
+        return max(ex_value, 0.0)
+    return None
+
+
+def _now() -> float:
+    return time.monotonic()
+
+
+class InMemoryStore:
+    """Simple async-friendly key/value store used when Redis is unavailable."""
+
+    __slots__ = ("_data", "_lock")
+
+    def __init__(self) -> None:
+        self._data: dict[str, tuple[Optional[float], str]] = {}
+        self._lock = asyncio.Lock()
+
+    async def get(self, key: str) -> Optional[str]:
+        async with self._lock:
+            record = self._data.get(key)
+            if record is None:
+                return None
+            expires_at, value = record
+            if expires_at is not None and expires_at <= _now():
+                self._data.pop(key, None)
+                return None
+            return value
+
+    async def set(
+        self,
+        key: str,
+        value: Any,
+        *,
+        ex: Any = None,
+        px: Any = None,
+        nx: bool = False,
+    ) -> bool:
+        ttl = _ttl_from_kwargs(ex=ex, px=px)
+        expires_at = None if ttl is None else (_now() + max(ttl, 0.0))
+        serialized = "" if value is None else str(value)
+        async with self._lock:
+            record = self._data.get(key)
+            if record is not None:
+                current_expiry, _ = record
+                if current_expiry is not None and current_expiry <= _now():
+                    record = None
+                    self._data.pop(key, None)
+            if nx and record is not None:
+                return False
+            self._data[key] = (expires_at, serialized)
+        return True
+
+    async def setex(self, key: str, ttl: Any, value: Any) -> bool:
+        return await self.set(key, value, ex=ttl)
+
+    async def delete(self, key: str) -> int:
+        async with self._lock:
+            existed = key in self._data
+            self._data.pop(key, None)
+        return 1 if existed else 0
+
+    async def expire(self, key: str, ttl: Any) -> bool:
+        ttl_seconds = _ttl_seconds(ttl)
+        if ttl_seconds is None:
+            return False
+        async with self._lock:
+            record = self._data.get(key)
+            if record is None:
+                return False
+            expires_at = _now() + max(ttl_seconds, 0.0)
+            self._data[key] = (expires_at, record[1])
+            return True
+
+    async def exists(self, key: str) -> bool:
+        async with self._lock:
+            record = self._data.get(key)
+            if record is None:
+                return False
+            expires_at, _ = record
+            if expires_at is not None and expires_at <= _now():
+                self._data.pop(key, None)
+                return False
+            return True
+
+
+@dataclass(slots=True)
+class RedisHandle:
+    client: Any
+    memory: bool = False
+
+
+_lock = Lock()
+_cached: Optional[RedisHandle] = None
+_fallback_logged = False
+
+
+def _log_memory_fallback() -> None:
+    global _fallback_logged
+    if not _fallback_logged:
+        _fallback_logged = True
+        log.info("redis.fallback=memory", extra={"prefix": _resolve_prefix()})
+
+
+def get_redis() -> Any:
+    """Return the configured Redis client or a safe in-memory fallback."""
+
+    global _cached
+    if _cached is not None:
+        return _cached.client
+
+    with _lock:
+        if _cached is not None:
+            return _cached.client
+
+        url = _resolve_url()
+        if not url or str(url).strip().lower().startswith("memory://"):
+            store = InMemoryStore()
+            _cached = RedisHandle(client=store, memory=True)
+            _log_memory_fallback()
+            return store
+
+        if redis_asyncio is None:
+            store = InMemoryStore()
+            _cached = RedisHandle(client=store, memory=True)
+            _log_memory_fallback()
+            return store
+
+        try:
+            client = redis_asyncio.from_url(
+                url,
+                encoding="utf-8",
+                decode_responses=True,
+                health_check_interval=30,
+                socket_keepalive=True,
+            )
+        except Exception as exc:  # pragma: no cover - network/config issues
+            log.warning("redis.connect_failed url=%s err=%s", url, exc)
+            store = InMemoryStore()
+            _cached = RedisHandle(client=store, memory=True)
+            _log_memory_fallback()
+            return store
+
+        _cached = RedisHandle(client=client, memory=False)
+        return client
+
+
+__all__ = ["get_redis", "InMemoryStore"]
+


### PR DESCRIPTION
## Summary
- add a lazy Redis client with an in-memory fallback and warm it up at startup
- harden the Banana card handler and router callbacks to use the shared store and log card openings
- route the profile button through the profile handler and add focused regression tests

## Testing
- pytest tests/test_redis_fallback.py tests/test_router_callbacks.py tests/test_banana_open_card.py

------
https://chatgpt.com/codex/tasks/task_e_690c51ed43e083228fc0585166e1f67b