### PR TITLE
feat: rework banana input capture and result delivery

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -161,7 +161,10 @@ from hub_router import (
 )
 from handlers import profile as profile_handlers
 from handlers.banana_async_handler import (
+    clear_card as banana_clear_card,
     new_card as banana_new_card,
+    on_photo as banana_on_photo,
+    on_prompt as banana_on_prompt,
     restart_generation as banana_restart_generation,
     start_generation as banana_start_generation,
 )
@@ -246,6 +249,7 @@ from utils.input_state import (
     set_wait,
     touch_wait,
 )
+from utils.async_input_state import input_state as async_input_state
 from utils.telegram_utils import build_photo_album_media, label_to_command, should_capture_to_prompt
 from utils.text_normalizer import normalize_btn_text
 from utils.sanitize import collapse_spaces, normalize_input, truncate_text
@@ -20887,6 +20891,10 @@ async def on_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     user = update.effective_user
     user_id = user.id if user else None
 
+    if user_id is not None and await async_input_state.is_mode(user_id, "banana"):
+        await banana_on_prompt(update, ctx)
+        return
+
     if user_id is not None and get_wait(user_id) is not None:
         log.debug(
             "wait.skip_text",
@@ -21264,6 +21272,11 @@ async def on_photo(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
 
     chat = update.effective_chat
     chat_id = chat.id if chat else None
+    user = update.effective_user
+    user_id = user.id if user else None
+    if user_id is not None and await async_input_state.is_mode(user_id, "banana"):
+        await banana_on_photo(update, ctx)
+        return
     s = state(ctx)
 
     try:
@@ -21342,6 +21355,12 @@ async def on_document(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         return
     doc = message.document
     if doc is None:
+        return
+
+    user = update.effective_user
+    user_id = user.id if user else None
+    if user_id is not None and await async_input_state.is_mode(user_id, "banana"):
+        await banana_on_photo(update, ctx)
         return
 
     s = state(ctx)
@@ -22502,6 +22521,23 @@ ADDITIONAL_COMMAND_SPECS: List[tuple[tuple[str, ...], Any]] = [
     (("profile_reset",), profile_handlers.profile_reset_command),
 ]
 
+
+async def banana_back_to_photo_menu(
+    update: Update, ctx: ContextTypes.DEFAULT_TYPE, payload=None
+) -> None:
+    user = update.effective_user
+    if user is not None:
+        try:
+            await async_input_state.clear(user.id, reason="banana_exit")
+        except Exception:
+            log.debug(
+                "banana.input_state_clear_failed",
+                extra={"user_id": user.id, "source": "back"},
+                exc_info=True,
+            )
+    await photo_modes_open_menu(update, ctx, payload=payload)
+
+
 CALLBACK_HANDLER_SPECS: List[tuple[Optional[str], Any]] = [
     (r"^dialog_default$", dialog_mode_callback),
     (r"^prompt_master$", prompt_master_mode_callback),
@@ -22509,10 +22545,11 @@ CALLBACK_HANDLER_SPECS: List[tuple[Optional[str], Any]] = [
     (r"^dialog:choose_promptmaster$", dialog_choose_promptmaster_callback),
     (r"^noop$", on_noop_callback),
     (r"^music:(inst|vocal)$", on_music_callback),
+    (r"^banana:clear$", banana_clear_card),
     (r"^banana:start$", banana_start_generation),
-    (r"^banana:restart$", banana_restart_generation),
+    (r"^banana:restart(?::.+)?$", banana_restart_generation),
     (r"^banana:new$", banana_new_card),
-    (r"^banana:back_photo$", photo_modes_open_menu),
+    (r"^banana:back_photo$", banana_back_to_photo_menu),
     (rf"^{CB_PM_INSERT_PREFIX}(veo|mj|banana|animate|suno)$", prompt_master_insert_callback_entry),
     (rf"^{CB_PM_PREFIX}", prompt_master_callback_entry),
     (rf"^{CB_FAQ_PREFIX}", faq_callback_entry),

--- a/handlers/banana.py
+++ b/handlers/banana.py
@@ -354,7 +354,7 @@ async def open_banana_card(update, context) -> None:
     balance_value = await _get_balance_value(user_id)
     text = banana_card_text(balance_value, state)
     await context.bot.send_message(
-        user_id, text, reply_markup=banana_card_kb(state.can_start())
+        user_id, text, reply_markup=banana_card_kb(state)
     )
 
 
@@ -389,7 +389,7 @@ async def on_banana_photo(update, context) -> None:
     balance_value = await _get_balance_value(user_id)
     await message.reply_text(
         banana_card_text(balance_value, state),
-        reply_markup=banana_card_kb(state.can_start()),
+        reply_markup=banana_card_kb(state),
     )
 
 
@@ -405,7 +405,7 @@ async def on_banana_text(update, context) -> None:
     balance_value = await _get_balance_value(user_id)
     await message.reply_text(
         banana_card_text(balance_value, state),
-        reply_markup=banana_card_kb(state.can_start()),
+        reply_markup=banana_card_kb(state),
     )
 
 
@@ -650,7 +650,7 @@ async def on_banana_new(update, context) -> None:
     await context.bot.send_message(
         user_id,
         "Новая карточка 🆕 Отправьте фото и промпт.",
-        reply_markup=banana_card_kb(state.can_start()),
+        reply_markup=banana_card_kb(state),
     )
 
 

--- a/handlers/banana_async_handler.py
+++ b/handlers/banana_async_handler.py
@@ -10,7 +10,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Mapping, MutableMapping, Optional, Sequence
 
-from telegram import InputMediaDocument, Update
+from telegram import Update
 from telegram.ext import ContextTypes
 
 from bot_logger import BotLogger
@@ -23,6 +23,7 @@ from services.kie_api_async import (
     KieAPITransportError,
 )
 from keyboards import banana_result_kb
+from utils.async_input_state import input_state as async_input_state
 from utils.banana_state import BananaState, ensure, load, save
 from utils.files import validate_image
 from utils.redis_client import get_redis
@@ -53,6 +54,14 @@ _UPLOAD_PATH = "/api/v1/upload/base64"
 _WAIT_STATES = {"waiting", "queuing", "queued", "generating", "processing", "running", "pending", "0", 0}
 _SUCCESS_STATES = {"success", "1", 1, "done", "finished", "completed", "ready"}
 _FAIL_STATES = {"fail", "failed", "error", "2", 2, "3", 3, "canceled", "cancelled", "timeout"}
+
+
+def _guess_filename(url: str) -> str:
+    base = (url or "").split("?")[0].lower()
+    for ext in ("mp4", "gif", "jpg", "jpeg", "png", "webp"):
+        if base.endswith(f".{ext}"):
+            return f"result.{ext}"
+    return "result.png"
 
 
 @dataclass(slots=True)
@@ -335,6 +344,7 @@ class BananaAsyncHandler:
                     media=url,
                     prompt=prompt,
                     user_id=user_id,
+                    task_id=task_id,
                 )
                 file_id = self._extract_file_id(message) or url
                 result = BananaResult(file_id=file_id, task_id=task_id, caption=caption, url=url)
@@ -413,26 +423,39 @@ class BananaAsyncHandler:
         media: str,
         prompt: str,
         user_id: int,
+        task_id: str,
     ) -> tuple[Any, str]:
         caption = _SUCCESS_CAPTION if not prompt else f"{_SUCCESS_CAPTION}\n{prompt}"
         try:
-            message = await context.bot.edit_message_media(
-                chat_id=chat_id,
-                message_id=message_id,
-                media=InputMediaDocument(media=media, caption=caption),
-                reply_markup=banana_result_kb(),
+            await context.bot.delete_message(chat_id, message_id)
+        except Exception:
+            pass
+        try:
+            filename = _guess_filename(media)
+            message = await context.bot.send_document(
+                chat_id,
+                media,
+                caption=caption,
+                filename=filename,
+                reply_markup=banana_result_kb(task_id),
             )
             log.info(
-                "banana.result.sent",
-                extra={"chat_id": chat_id, "user_id": user_id, "cached": False},
+                "banana.gen.done",
+                extra={"chat_id": chat_id, "user_id": user_id, "task_id": task_id, "cached": False},
             )
             return message, caption
         except Exception as exc:
             await handle_async_error(exc, "BananaAsync.publish_result")
             await context.bot.send_message(chat_id, caption)
             log.info(
-                "banana.result.sent",
-                extra={"chat_id": chat_id, "user_id": user_id, "cached": False, "fallback": True},
+                "banana.gen.done",
+                extra={
+                    "chat_id": chat_id,
+                    "user_id": user_id,
+                    "task_id": task_id,
+                    "cached": False,
+                    "fallback": True,
+                },
             )
             return None, caption
 
@@ -447,26 +470,31 @@ class BananaAsyncHandler:
     ) -> None:
         file_id = payload.get("file_id") if isinstance(payload, Mapping) else None
         caption = payload.get("caption") if isinstance(payload, Mapping) else None
+        task_id = payload.get("task_id") if isinstance(payload, Mapping) else None
         if not isinstance(file_id, str) or not file_id:
             await context.bot.edit_message_text(chat_id=chat_id, message_id=message_id, text=_FAILURE_TEXT)
             return
         try:
-            await context.bot.edit_message_media(
-                chat_id=chat_id,
-                message_id=message_id,
-                media=InputMediaDocument(media=file_id, caption=caption or _SUCCESS_CAPTION),
-                reply_markup=banana_result_kb(),
+            await context.bot.delete_message(chat_id, message_id)
+        except Exception:
+            pass
+        try:
+            await context.bot.send_document(
+                chat_id,
+                file_id,
+                caption=caption or _SUCCESS_CAPTION,
+                reply_markup=banana_result_kb(task_id if isinstance(task_id, str) else None),
             )
             log.info(
-                "banana.result.sent",
-                extra={"chat_id": chat_id, "user_id": user_id, "cached": True},
+                "banana.gen.done",
+                extra={"chat_id": chat_id, "user_id": user_id, "task_id": task_id, "cached": True},
             )
         except Exception as exc:
             await handle_async_error(exc, "BananaAsync.cached_edit")
             await context.bot.send_message(chat_id, caption or _SUCCESS_CAPTION)
             log.info(
-                "banana.result.sent",
-                extra={"chat_id": chat_id, "user_id": user_id, "cached": True, "fallback": True},
+                "banana.gen.done",
+                extra={"chat_id": chat_id, "user_id": user_id, "task_id": task_id, "cached": True, "fallback": True},
             )
 
     async def _handle_failure(
@@ -636,6 +664,10 @@ async def open_card(update: Update, ctx: ContextTypes.DEFAULT_TYPE, payload=None
         user_id=user.id,
         message=message,
     )
+    try:
+        await async_input_state.set(user.id, mode="banana")
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.input_state_set")
     log.info(
         "banana.card.opened",
         extra={
@@ -661,17 +693,28 @@ async def on_photo(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         await handle_async_error(exc, "BananaAsync.photo_load")
         return
     if len(state.photos) >= _MAX_CARD_IMAGES:
-        await message.reply_text("Максимум 4 фото. Удалите лишнее или начните новую генерацию.")
+        await ctx.bot.send_message(
+            chat.id,
+            "Максимум 4 фото. Удалите лишнее или начните новую генерацию.",
+        )
+        try:
+            await ctx.bot.delete_message(chat.id, message.message_id)
+        except Exception:
+            pass
         return
     state.photos.append(file_id)
     try:
         await _save_state(ctx, user.id, state)
     except Exception as exc:
         await handle_async_error(exc, "BananaAsync.photo_save")
+    try:
+        await ctx.bot.delete_message(chat.id, message.message_id)
+    except Exception:
+        pass
     await _render_card(ctx=ctx, chat_id=chat.id, state=state, user_id=user.id)
 
 
-async def on_text_prompt(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+async def on_prompt(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     message = update.effective_message
     chat = update.effective_chat
     user = update.effective_user
@@ -696,6 +739,42 @@ async def on_text_prompt(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None
     await _render_card(ctx=ctx, chat_id=chat.id, state=state, user_id=user.id)
 
 
+async def clear_card(update: Update, ctx: ContextTypes.DEFAULT_TYPE, payload=None) -> None:
+    query = update.callback_query
+    user = update.effective_user
+    chat = update.effective_chat
+    message = query.message if query else None
+    if query is not None:
+        try:
+            await query.answer()
+        except Exception:
+            pass
+    if user is None or chat is None:
+        return
+    try:
+        state = await _load_state(ctx, user.id)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.clear_load")
+        return
+    state.reset()
+    try:
+        await _save_state(ctx, user.id, state)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.clear_save")
+    await _render_card(
+        ctx=ctx,
+        chat_id=chat.id,
+        state=state,
+        user_id=user.id,
+        message=message if getattr(message, "text", None) else None,
+    )
+    try:
+        await async_input_state.set(user.id, mode="banana")
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.clear_input_state")
+    log.info("banana.clear", extra={"user_id": user.id})
+
+
 async def start_generation(update: Update, ctx: ContextTypes.DEFAULT_TYPE, payload=None) -> None:
     query = update.callback_query
     user = update.effective_user
@@ -713,7 +792,27 @@ async def start_generation(update: Update, ctx: ContextTypes.DEFAULT_TYPE, paylo
         await query.answer()
     except Exception:
         pass
-    log.info("banana.start", extra={"user_id": user.id, "action": "start"})
+    state.last_payload = {
+        "images": list(state.photos),
+        "prompt": state.prompt or "",
+    }
+    try:
+        await _save_state(ctx, user.id, state)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.start_snapshot")
+    try:
+        await async_input_state.set(user.id, mode="banana")
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.start_input_state")
+    log.info(
+        "banana.gen.start",
+        extra={
+            "user_id": user.id,
+            "photos": len(state.photos),
+            "has_prompt": bool(state.prompt),
+            "source": "start",
+        },
+    )
     handler = _get_default_handler()
     await handler.run(update, ctx)
 
@@ -728,14 +827,43 @@ async def restart_generation(update: Update, ctx: ContextTypes.DEFAULT_TYPE, pay
     except Exception as exc:
         await handle_async_error(exc, "BananaAsync.restart_load")
         return
-    if not state.has_photos_or_prompt():
-        await query.answer("Карточка пуста. Добавьте фото или промпт.", show_alert=True)
+    payload_snapshot = state.last_payload or {}
+    photos = payload_snapshot.get("images") or payload_snapshot.get("photos") or []
+    prompt = payload_snapshot.get("prompt") or ""
+    if not photos and not (prompt.strip()):
+        await query.answer("Нет сохранённого запроса для повторной генерации.", show_alert=True)
         return
     try:
         await query.answer()
     except Exception:
         pass
-    log.info("banana.start", extra={"user_id": user.id, "action": "restart"})
+    state.photos = list(map(str, photos))[:_MAX_CARD_IMAGES]
+    normalized_prompt = (prompt or "").strip()
+    state.prompt = normalized_prompt or None
+    state.last_payload = {
+        "images": list(state.photos),
+        "prompt": normalized_prompt,
+    }
+    try:
+        await _save_state(ctx, user.id, state)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.restart_save")
+    data = query.data or ""
+    parts = data.split(":", 2)
+    job_id = parts[2] if len(parts) == 3 else None
+    try:
+        await async_input_state.set(user.id, mode="banana")
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.restart_input_state")
+    log.info(
+        "banana.restart",
+        extra={
+            "user_id": user.id,
+            "photos": len(state.photos),
+            "has_prompt": bool(state.prompt),
+            "job_id": job_id,
+        },
+    )
     handler = _get_default_handler()
     await handler.run(update, ctx)
 
@@ -765,6 +893,10 @@ async def new_card(update: Update, ctx: ContextTypes.DEFAULT_TYPE, payload=None)
         await query.edit_message_reply_markup(reply_markup=None)
     except Exception:
         pass
+    try:
+        await async_input_state.clear(user.id, reason="banana_exit")
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.new_clear_state")
     editable_message = message if getattr(message, "text", None) else None
     await _render_card(
         ctx=ctx,
@@ -773,13 +905,18 @@ async def new_card(update: Update, ctx: ContextTypes.DEFAULT_TYPE, payload=None)
         user_id=user.id,
         message=editable_message,
     )
+    try:
+        await async_input_state.set(user.id, mode="banana")
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.new_set_state")
 
 
 __all__ = [
     "BananaAsyncHandler",
     "open_card",
     "on_photo",
-    "on_text_prompt",
+    "on_prompt",
+    "clear_card",
     "start_generation",
     "restart_generation",
     "new_card",

--- a/keyboards.py
+++ b/keyboards.py
@@ -322,18 +322,26 @@ def build_menu(rows: list[list[tuple[str, str]]]) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(markup_rows)
 
 
-def banana_card_kb(can_start: bool) -> InlineKeyboardMarkup:
+def banana_card_kb(state) -> InlineKeyboardMarkup:
     rows: list[list[InlineKeyboardButton]] = []
-    if can_start:
+    rows.append([InlineKeyboardButton("🧽 Очистить карточку", callback_data="banana:clear")])
+    try:
+        ready = bool(state.has_photos_or_prompt())
+    except AttributeError:
+        ready = bool(getattr(state, "ready", False))
+    if ready:
         rows.append([InlineKeyboardButton("🚀 Начать генерацию", callback_data="banana:start")])
     rows.append([InlineKeyboardButton("⬅️ Назад", callback_data="banana:back_photo")])
     return InlineKeyboardMarkup(rows)
 
 
-def banana_result_kb() -> InlineKeyboardMarkup:
+def banana_result_kb(job_id: Optional[str] = None) -> InlineKeyboardMarkup:
+    restart_data = "banana:restart"
+    if job_id:
+        restart_data = f"banana:restart:{job_id}"
     return InlineKeyboardMarkup(
         [
-            [InlineKeyboardButton("↪️ Повторить генерацию", callback_data="banana:restart")],
+            [InlineKeyboardButton("🔁 Повторить генерацию", callback_data=restart_data)],
             [InlineKeyboardButton("🆕 Новая генерация", callback_data="banana:new")],
         ]
     )

--- a/tests/test_banana_router.py
+++ b/tests/test_banana_router.py
@@ -48,20 +48,26 @@ def test_route_callback_dispatches_banana(monkeypatch):
 
 def test_banana_callback_patterns_registered():
     specs = bot_module.CALLBACK_HANDLER_SPECS
+    assert any(pattern == r"^banana:clear$" and callback is bot_module.banana_clear_card for pattern, callback in specs)
     assert any(pattern == r"^banana:start$" and callback is bot_module.banana_start_generation for pattern, callback in specs)
-    assert any(pattern == r"^banana:restart$" and callback is bot_module.banana_restart_generation for pattern, callback in specs)
+    assert any(
+        pattern == r"^banana:restart(?::.+)?$" and callback is bot_module.banana_restart_generation
+        for pattern, callback in specs
+    )
     assert any(pattern == r"^banana:new$" and callback is bot_module.banana_new_card for pattern, callback in specs)
-    assert any(pattern == r"^banana:back_photo$" and callback is bot_module.photo_modes_open_menu for pattern, callback in specs)
+    assert any(pattern == r"^banana:back_photo$" and callback is bot_module.banana_back_to_photo_menu for pattern, callback in specs)
 
 
 def test_banana_card_keyboard_rendering():
-    without_inputs = banana_card_kb(False)
+    without_inputs = banana_card_kb(SimpleNamespace(has_photos_or_prompt=lambda: False))
     rows = without_inputs.inline_keyboard
-    assert len(rows) == 1
-    assert rows[0][0].text == "⬅️ Назад"
-    assert rows[0][0].callback_data == "banana:back_photo"
-
-    with_inputs = banana_card_kb(True)
-    rows = with_inputs.inline_keyboard
-    assert rows[0][0].callback_data == "banana:start"
+    assert len(rows) == 2
+    assert rows[0][0].text == "🧽 Очистить карточку"
+    assert rows[0][0].callback_data == "banana:clear"
     assert rows[1][0].callback_data == "banana:back_photo"
+
+    with_inputs = banana_card_kb(SimpleNamespace(has_photos_or_prompt=lambda: True))
+    rows = with_inputs.inline_keyboard
+    assert rows[0][0].callback_data == "banana:clear"
+    assert rows[1][0].callback_data == "banana:start"
+    assert rows[2][0].callback_data == "banana:back_photo"

--- a/ui/renderers/banana.py
+++ b/ui/renderers/banana.py
@@ -14,9 +14,9 @@ def banana_card_text(balance: int, state) -> str:
 
 
 def banana_card_kb(state) -> InlineKeyboardMarkup:
-    """Return inline keyboard for Banana card based on readiness."""
+    """Return inline keyboard for Banana card."""
 
-    return build_banana_card_kb(state.can_start())
+    return build_banana_card_kb(state)
 
 
 __all__ = ["banana_card_text", "banana_card_kb"]

--- a/utils/async_input_state.py
+++ b/utils/async_input_state.py
@@ -1,0 +1,89 @@
+"""Asynchronous per-user input state helpers backed by Redis."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from settings import REDIS_PREFIX
+from utils.redis_client import get_redis
+
+_LOG = logging.getLogger("async-input-state")
+
+_KEY_TMPL = f"{REDIS_PREFIX}:input-state:{{user_id}}"
+_TTL_SECONDS = 60 * 60  # 1 hour
+
+
+def _key_for(user_id: int) -> str:
+    return _KEY_TMPL.format(user_id=int(user_id))
+
+
+class _AsyncInputState:
+    """Store lightweight per-user input flags in Redis."""
+
+    async def get(self, user_id: int) -> Dict[str, Any]:
+        key = _key_for(user_id)
+        client = get_redis()
+        try:
+            raw = await client.get(key)
+        except Exception:  # pragma: no cover - best effort
+            _LOG.debug("input_state.get_failed", exc_info=True, extra={"user_id": int(user_id)})
+            return {}
+        if not raw:
+            return {}
+        try:
+            data = json.loads(raw)
+        except Exception:  # pragma: no cover - defensive
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        return data
+
+    async def set(self, user_id: int, **fields: Any) -> None:
+        if not fields:
+            return
+        current = await self.get(user_id)
+        for key, value in fields.items():
+            if value is None:
+                current.pop(key, None)
+            else:
+                current[key] = value
+        payload = json.dumps(current, ensure_ascii=False)
+        client = get_redis()
+        try:
+            await client.set(_key_for(user_id), payload, ex=_TTL_SECONDS)
+        except Exception:  # pragma: no cover - best effort persistence
+            _LOG.debug("input_state.set_failed", exc_info=True, extra={"user_id": int(user_id)})
+
+    async def clear(self, user_id: int, *, reason: str = "manual") -> None:
+        client = get_redis()
+        try:
+            await client.delete(_key_for(user_id))
+        except Exception:  # pragma: no cover - best effort
+            _LOG.debug(
+                "input_state.clear_failed", exc_info=True, extra={"user_id": int(user_id), "reason": reason}
+            )
+
+    async def is_mode(self, user_id: int, mode: str) -> bool:
+        data = await self.get(user_id)
+        value = data.get("mode")
+        return isinstance(value, str) and value == mode
+
+    async def pop(self, user_id: int, key: str) -> Optional[Any]:
+        data = await self.get(user_id)
+        if key not in data:
+            return None
+        value = data.pop(key)
+        payload = json.dumps(data, ensure_ascii=False)
+        client = get_redis()
+        try:
+            await client.set(_key_for(user_id), payload, ex=_TTL_SECONDS)
+        except Exception:  # pragma: no cover - best effort persistence
+            _LOG.debug("input_state.pop_failed", exc_info=True, extra={"user_id": int(user_id), "key": key})
+        return value
+
+
+input_state = _AsyncInputState()
+
+__all__ = ["input_state"]


### PR DESCRIPTION
## Summary
- add an async input state helper to persist the current banana mode across updates
- update banana handlers to capture prompts/photos inside the card, expose clear/start/restart actions, and send generation results as documents with restart/new buttons
- refresh router hooks, keyboards, and tests to align with the new banana card behaviour

## Testing
- pytest tests/test_banana_router.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d32c7ffac832290a6d8803f21d2ab)