### PR TITLE
Switch main menu to inline-only navigation

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -85,8 +85,8 @@ from aiohttp import ClientError, ClientResponseError, ClientTimeout
 import requests
 from telegram import (
     Update, InlineKeyboardButton, InlineKeyboardMarkup,
-    InputFile, InputMediaDocument, InputMediaVideo, LabeledPrice, ReplyKeyboardMarkup,
-    KeyboardButton, BotCommand, User, Message, CallbackQuery
+    InputFile, InputMediaDocument, InputMediaVideo, LabeledPrice, ReplyKeyboardRemove,
+    BotCommand, User, Message, CallbackQuery
 )
 from telegram.constants import ParseMode, ChatAction
 from telegram.ext import (
@@ -255,6 +255,8 @@ from utils.telegram_utils import build_photo_album_media, label_to_command, shou
 from utils.text_normalizer import normalize_btn_text
 from utils.sanitize import collapse_spaces, normalize_input, truncate_text
 
+import keyboards as keyboards_module
+
 from keyboards import (
     AI_MENU_CB,
     AI_TO_PROMPTMASTER_CB,
@@ -288,8 +290,6 @@ from keyboards import (
     PROFILE_MENU_CB,
     VIDEO_MENU_CB,
     TEXT_ACTION_VARIANTS,
-    build_empty_reply_kb,
-    build_main_reply_kb,
     iter_home_menu_buttons,
     mj_upscale_root_keyboard,
     mj_upscale_select_keyboard,
@@ -5582,7 +5582,7 @@ async def safe_send(
     update: Update,
     ctx: ContextTypes.DEFAULT_TYPE,
     text: str,
-    reply_markup: Optional[Union[ReplyKeyboardMarkup, InlineKeyboardMarkup]] = None,
+    reply_markup: Optional[InlineKeyboardMarkup] = None,
 ) -> Optional[Message]:
     """Safely deliver text to the chat, falling back to send_message on edit errors."""
 
@@ -5853,24 +5853,6 @@ MENU_BTN_PM = "🧠 Prompt-Master"
 MENU_BTN_CHAT = "💬 Обычный чат"
 MENU_BTN_BALANCE = TXT_KB_PROFILE
 MENU_BTN_SUPPORT = "🆘 ПОДДЕРЖКА"
-
-# --- Reply keyboard (нижнее меню)
-REPLY_BUTTONS = [
-    [KeyboardButton(TXT_KB_PROFILE), KeyboardButton(TXT_KB_KNOWLEDGE)],
-    [KeyboardButton(TXT_KB_PHOTO), KeyboardButton(TXT_KB_MUSIC)],
-    [KeyboardButton(TXT_KB_VIDEO)],
-    [KeyboardButton(TXT_KB_AI_DIALOG)],
-]
-
-
-def reply_main_kb() -> ReplyKeyboardMarkup:
-    return ReplyKeyboardMarkup(
-        REPLY_BUTTONS,
-        resize_keyboard=True,
-        one_time_keyboard=False,
-        is_persistent=True,
-    )
-
 
 def _norm_btn_text(t: Optional[str]) -> str:
     return normalize_btn_text(t)
@@ -6358,24 +6340,75 @@ async def show_emoji_hub_for_chat(
             await ctx.bot.delete_message(chat_id=chat_id, message_id=hub_msg_id)
         ctx.user_data["hub_msg_id"] = None
 
+    removal_kwargs = {
+        "chat_id": chat_id,
+        "text": card["text"],
+        "reply_markup": ReplyKeyboardRemove(),
+        "parse_mode": card.get("parse_mode", ParseMode.HTML),
+        "disable_web_page_preview": card.get("disable_web_page_preview", True),
+        "disable_notification": True,
+    }
+
     try:
-        message = await tg_safe_send(
+        removal_message = await tg_safe_send(
             ctx.bot.send_message,
             method_name="sendMessage",
             kind="message",
-            chat_id=chat_id,
-            **card,
+            **removal_kwargs,
         )
     except Exception as exc:  # pragma: no cover - network issues
         log.warning("hub.send_failed | user_id=%s err=%s", resolved_uid, exc)
         return None
 
-    message_id = getattr(message, "message_id", None)
-    if isinstance(message_id, int):
-        ctx.user_data["hub_msg_id"] = message_id
+    message_id = getattr(removal_message, "message_id", None)
+    effective_message_id: Optional[int] = None
 
     if isinstance(message_id, int):
-        return message_id
+        try:
+            await safe_edit_message(
+                ctx,
+                chat_id,
+                message_id,
+                card["text"],
+                card["reply_markup"],
+                parse_mode=card.get("parse_mode", ParseMode.HTML),
+                disable_web_page_preview=card.get("disable_web_page_preview", True),
+            )
+        except Exception as exc:
+            log.warning(
+                "hub.edit_failed",
+                extra={"chat_id": chat_id, "message_id": message_id, "error": str(exc)},
+            )
+            try:
+                fallback = await tg_safe_send(
+                    ctx.bot.send_message,
+                    method_name="sendMessage",
+                    kind="message",
+                    chat_id=chat_id,
+                    text=card["text"],
+                    reply_markup=card["reply_markup"],
+                    parse_mode=card.get("parse_mode", ParseMode.HTML),
+                    disable_web_page_preview=card.get("disable_web_page_preview", True),
+                )
+            except Exception as send_exc:  # pragma: no cover - network issues
+                log.warning(
+                    "hub.fallback_failed",
+                    extra={"chat_id": chat_id, "error": str(send_exc)},
+                )
+                fallback = None
+
+            fallback_id = getattr(fallback, "message_id", None)
+            if isinstance(fallback_id, int):
+                effective_message_id = fallback_id
+            with suppress(Exception):
+                await ctx.bot.delete_message(chat_id=chat_id, message_id=message_id)
+        else:
+            effective_message_id = message_id
+
+    if effective_message_id is not None:
+        ctx.user_data["hub_msg_id"] = effective_message_id
+        return effective_message_id
+
     return None
 
 
@@ -23038,8 +23071,8 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-def main_menu_kb() -> ReplyKeyboardMarkup:
-    """Compatibility helper exposing the reply keyboard layout."""
+def main_menu_kb() -> InlineKeyboardMarkup:
+    """Compatibility helper exposing the inline keyboard layout."""
 
-    return build_main_reply_kb()
+    return keyboards_module.main_menu_kb()
 

--- a/faq_content.py
+++ b/faq_content.py
@@ -7,7 +7,7 @@ from telegram import InlineKeyboardMarkup
 
 from telegram_utils import build_inline_kb
 
-FAQ_ROOT_TEXT = "🧾 FAQ\nВыберите раздел:"
+FAQ_ROOT_TEXT = "🧾 FAQ\nВыберите раздел:\n\n💡 Нажмите /menu, если потеряли навигацию."
 
 _FAQ_BACK_ROWS = (
     (("⬅️ Назад", "faq:root"), ("🏠 Меню бота", "faq:home")),

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import Sequence
 
-from telegram import InlineKeyboardButton, Update
+from telegram import InlineKeyboardButton, ReplyKeyboardRemove, Update
+from telegram.constants import ParseMode
 from telegram.ext import ContextTypes
 
 from keyboards import CB, FEATURE_PM_ENABLED, kb_main, main_menu_kb, photo_engines_kb
@@ -20,6 +21,7 @@ from texts import (
 from ui.card import build_card
 
 from logging_utils import get_logger
+from utils.telegram_safe import safe_edit_message
 
 log = get_logger("handlers.menu")
 
@@ -31,7 +33,54 @@ async def open_main_menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     message = update.effective_message
     if message is None:
         return
-    await message.reply_text(text, reply_markup=main_menu_kb(), parse_mode="Markdown")
+    markup = main_menu_kb()
+    removal = await message.reply_text(
+        text,
+        reply_markup=ReplyKeyboardRemove(),
+        parse_mode="Markdown",
+        disable_notification=True,
+    )
+
+    message_id = getattr(removal, "message_id", None)
+    chat_obj = getattr(removal, "chat", getattr(message, "chat", None))
+    chat_id = getattr(chat_obj, "id", getattr(message, "chat_id", None))
+
+    if isinstance(message_id, int) and chat_id is not None:
+        try:
+            await safe_edit_message(
+                context,
+                chat_id,
+                message_id,
+                text,
+                markup,
+                parse_mode=ParseMode.MARKDOWN,
+                disable_web_page_preview=True,
+            )
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            log.warning(
+                "menu.open_main_menu.edit_failed",
+                extra={"chat_id": chat_id, "message_id": message_id, "error": str(exc)},
+            )
+            await context.bot.send_message(
+                chat_id=chat_id,
+                text=text,
+                reply_markup=markup,
+                parse_mode="Markdown",
+            )
+            try:
+                await context.bot.delete_message(chat_id=chat_id, message_id=message_id)
+            except Exception:
+                log.debug(
+                    "menu.open_main_menu.delete_failed",
+                    extra={"chat_id": chat_id, "message_id": message_id},
+                )
+    else:
+        await context.bot.send_message(
+            chat_id=chat_id,
+            text=text,
+            reply_markup=markup,
+            parse_mode="Markdown",
+        )
 
 
 async def show_profile(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/keyboards.py
+++ b/keyboards.py
@@ -4,13 +4,7 @@ import re
 from functools import lru_cache
 from typing import Dict, Iterable, List, Optional, Tuple
 
-from telegram import (
-    InlineKeyboardButton,
-    InlineKeyboardMarkup,
-    KeyboardButton,
-    ReplyKeyboardMarkup,
-    ReplyKeyboardRemove,
-)
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 from utils.text_normalizer import normalize_btn_text
 
@@ -218,23 +212,10 @@ def kb_home_menu() -> InlineKeyboardMarkup:
     return kb_main()
 
 
-def reply_kb_home() -> ReplyKeyboardMarkup:
-    return build_main_reply_kb()
-
-
 def main_menu_buttons() -> List[InlineKeyboardButton]:
     """Return a flat list of inline buttons displayed in the main menu."""
 
     return [button for row in _build_inline_home_rows() for button in row]
-
-
-def build_main_reply_kb() -> ReplyKeyboardMarkup:
-    button = KeyboardButton(text="🧭 МЕНЮ")
-    return ReplyKeyboardMarkup(
-        keyboard=[[button]],
-        resize_keyboard=True,
-        is_persistent=True,
-    )
 
 
 def dialog_picker_inline() -> InlineKeyboardMarkup:
@@ -242,10 +223,6 @@ def dialog_picker_inline() -> InlineKeyboardMarkup:
     if FEATURE_PM_ENABLED:
         buttons.append(InlineKeyboardButton("📝 Prompt-Master", callback_data=DIALOG_PICK_PM))
     return InlineKeyboardMarkup([buttons])
-
-
-def build_empty_reply_kb() -> ReplyKeyboardRemove:
-    return ReplyKeyboardRemove()
 
 
 def _build_inline_home_rows() -> List[List[InlineKeyboardButton]]:

--- a/tests/suno_test_utils.py
+++ b/tests/suno_test_utils.py
@@ -33,12 +33,19 @@ class FakeBot:
         self.edited: list[dict[str, object]] = []
         self.deleted: list[dict[str, object]] = []
         self._next_message_id = 100
+        self._messages: dict[int, dict[str, object]] = {}
 
     async def send_message(self, **kwargs):  # type: ignore[override]
-        self.sent.append(kwargs)
+        payload = dict(kwargs)
+        chat_id = payload.get("chat_id")
         message_id = self._next_message_id
         self._next_message_id += 1
-        return SimpleNamespace(message_id=message_id)
+        payload["message_id"] = message_id
+        if chat_id is not None:
+            payload.setdefault("chat_id", chat_id)
+        self.sent.append(payload)
+        self._messages[message_id] = payload
+        return SimpleNamespace(message_id=message_id, chat=SimpleNamespace(id=chat_id))
 
     async def send_sticker(self, **kwargs):  # type: ignore[override]
         payload = dict(kwargs)
@@ -50,7 +57,15 @@ class FakeBot:
 
     async def edit_message_text(self, **kwargs):  # type: ignore[override]
         self.edited.append(kwargs)
-        return SimpleNamespace(message_id=kwargs.get("message_id"))
+        message_id = kwargs.get("message_id")
+        if isinstance(message_id, int):
+            entry = self._messages.get(message_id)
+            if entry is not None:
+                if "text" in kwargs:
+                    entry["text"] = kwargs["text"]
+                if "reply_markup" in kwargs:
+                    entry["reply_markup"] = kwargs["reply_markup"]
+        return SimpleNamespace(message_id=message_id)
 
     async def delete_message(self, *args, **kwargs):  # type: ignore[override]
         if args:
@@ -60,6 +75,9 @@ class FakeBot:
         else:
             payload = kwargs
         self.deleted.append(payload)
+        message_id = payload.get("message_id")
+        if isinstance(message_id, int):
+            self._messages.pop(message_id, None)
         return True
 
     async def send_chat_action(self, **_kwargs):  # type: ignore[override]

--- a/tests/test_menu_command.py
+++ b/tests/test_menu_command.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 
-from telegram import ReplyKeyboardMarkup
+from telegram import InlineKeyboardMarkup
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -30,16 +30,15 @@ def _build_update(chat_id: int = 123, user_id: int = 555):
 
 def test_main_menu_keyboard_layout():
     markup = bot_module.main_menu_kb()
-    assert isinstance(markup, ReplyKeyboardMarkup)
+    assert isinstance(markup, InlineKeyboardMarkup)
 
-    rows = markup.keyboard
+    rows = markup.inline_keyboard
     labels = [[button.text for button in row] for row in rows]
 
     assert labels == [
         ["👤 Профиль", "📚 База знаний"],
         ["📸 Режим фото", "🎧 Режим музыки"],
-        ["📹 Режим видео"],
-        ["🧠 Диалог с ИИ"],
+        ["📹 Режим видео", "🧠 Диалог с ИИ"],
     ]
 
 

--- a/texts.py
+++ b/texts.py
@@ -69,7 +69,8 @@ HELP_I18N = {
             "Напишите нам, если что-то не работает, есть идея или нужен совет.\n"
             "Ответим как можно скорее.\n\n"
             "• Чат поддержки: @{support_username}\n"
-            "• Язык: автоматически — по языку профиля Telegram"
+            "• Язык: автоматически — по языку профиля Telegram\n"
+            "• Нажмите /menu, если потеряли навигацию"
         ),
         "button": "Написать в поддержку",
     },
@@ -79,7 +80,8 @@ HELP_I18N = {
             "Message us if something breaks, you have an idea, or need guidance.\n"
             "We’ll reply as soon as possible.\n\n"
             "• Support chat: @{support_username}\n"
-            "• Language: auto — from your Telegram profile"
+            "• Language: auto — from your Telegram profile\n"
+            "• Type /menu if you lose navigation"
         ),
         "button": "Message Support",
     },


### PR DESCRIPTION
## Summary
- remove reply keyboard helpers and send a ReplyKeyboardRemove before rendering the main menu inline card
- update the /menu handler and FAQ/help copy to explain that /menu restores navigation
- adjust FakeBot and menu tests to reflect inline-only navigation

## Testing
- pytest tests/test_menu_command.py tests/test_no_quick_keyboard.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910526d48088322960865a8aafc150a)