### PR TITLE
Refine Banana uploads and menu cards with feature flags

### DIFF
--- a/banana/uploader.py
+++ b/banana/uploader.py
@@ -1,0 +1,285 @@
+"""Utilities to upload Telegram files to Banana storage using presigned URLs."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+import httpx
+
+from settings import KIE_API_KEY, UPLOAD_BASE_URL, UPLOAD_URL_PATH
+
+__all__ = [
+    "BananaUploadError",
+    "BananaUploadExpiredError",
+    "BananaUploadFailedError",
+    "BananaUploader",
+    "UploadResult",
+]
+
+
+_LOGGER = logging.getLogger("banana.uploader")
+_RETRY_DELAYS = (0.8, 2.0)
+_TIMEOUT = httpx.Timeout(20.0, connect=20.0)
+
+
+class BananaUploadError(RuntimeError):
+    """Base class for upload errors."""
+
+    def __init__(self, message: str, *, status: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+class BananaUploadExpiredError(BananaUploadError):
+    """Raised when a presigned URL is no longer valid (HTTP 403/404)."""
+
+
+class BananaUploadFailedError(BananaUploadError):
+    """Raised when the upload failed after retries."""
+
+
+@dataclass(slots=True)
+class UploadTicket:
+    """Ticket describing a single upload attempt."""
+
+    upload_url: str
+    upload_id: Optional[str]
+    confirm_url: Optional[str]
+    public_url: Optional[str]
+
+
+@dataclass(slots=True)
+class UploadResult:
+    """Result of a successful upload."""
+
+    public_url: str
+    upload_id: Optional[str]
+
+
+def _auth_header() -> Optional[str]:
+    token = (KIE_API_KEY or "").strip()
+    if not token:
+        return None
+    if not token.lower().startswith("bearer "):
+        token = f"Bearer {token}"
+    return token
+
+
+def _build_endpoint() -> Optional[str]:
+    base = (UPLOAD_BASE_URL or "").strip()
+    path = (UPLOAD_URL_PATH or "").strip() or "/api/v1/upload/url"
+    if path.startswith("http://") or path.startswith("https://"):
+        return path
+    if not base:
+        return None
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return f"{base}{path}"
+
+
+def _extract(payload: Mapping[str, Any], *candidates: str) -> Optional[str]:
+    for key in candidates:
+        value = payload.get(key)
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped:
+                return stripped
+    return None
+
+
+def _extract_nested(payload: Mapping[str, Any], *candidates: str) -> Optional[str]:
+    value = _extract(payload, *candidates)
+    if value:
+        return value
+    data = payload.get("data")
+    if isinstance(data, Mapping):
+        return _extract_nested(data, *candidates)
+    return None
+
+
+class BananaUploader:
+    """Upload helper interacting with Banana presigned upload API."""
+
+    def __init__(self) -> None:
+        endpoint = _build_endpoint()
+        if not endpoint:
+            raise RuntimeError("Banana upload endpoint is not configured")
+        self._endpoint = endpoint
+        self._auth = _auth_header()
+
+    async def _request_ticket(
+        self,
+        *,
+        filename: str,
+        content_type: str,
+        size: int,
+        user_id: Optional[int],
+    ) -> UploadTicket:
+        payload = {
+            "filename": filename,
+            "contentType": content_type,
+            "size": int(size),
+        }
+        headers = {"Content-Type": "application/json"}
+        if self._auth:
+            headers["Authorization"] = self._auth
+
+        _LOGGER.info(
+            "ns=banana action=start_upload file=%s size=%s", filename, size, extra={"user_id": user_id}
+        )
+
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            try:
+                response = await client.post(self._endpoint, headers=headers, json=payload)
+            except httpx.RequestError as exc:  # pragma: no cover - network/timeout
+                raise BananaUploadFailedError(str(exc)) from exc
+
+        if response.status_code >= 400:
+            raise BananaUploadFailedError(
+                f"HTTP {response.status_code} while requesting upload ticket",
+                status=response.status_code,
+            )
+
+        try:
+            payload_json: Mapping[str, Any] = response.json()
+        except json.JSONDecodeError as exc:  # pragma: no cover - unexpected
+            raise BananaUploadFailedError("invalid-json") from exc
+
+        upload_url = _extract_nested(payload_json, "uploadUrl", "upload_url", "url", "presignedUrl")
+        if not upload_url:
+            raise BananaUploadFailedError("missing-upload-url")
+
+        upload_id = _extract_nested(payload_json, "uploadId", "upload_id", "id")
+        confirm_url = _extract_nested(payload_json, "confirmUrl", "confirm_url", "completeUrl")
+        public_url = _extract_nested(payload_json, "publicUrl", "public_url", "fileUrl", "resultUrl")
+
+        return UploadTicket(
+            upload_url=upload_url,
+            upload_id=upload_id,
+            confirm_url=confirm_url,
+            public_url=public_url,
+        )
+
+    async def _confirm_upload(
+        self,
+        *,
+        ticket: UploadTicket,
+        filename: str,
+        content_type: str,
+        size: int,
+        user_id: Optional[int],
+    ) -> Optional[str]:
+        if not ticket.confirm_url:
+            return ticket.public_url
+
+        payload = {
+            "uploadId": ticket.upload_id,
+            "filename": filename,
+            "contentType": content_type,
+            "size": int(size),
+        }
+        headers = {"Content-Type": "application/json"}
+        if self._auth:
+            headers["Authorization"] = self._auth
+
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            try:
+                response = await client.post(ticket.confirm_url, headers=headers, json=payload)
+            except httpx.RequestError as exc:  # pragma: no cover - network
+                raise BananaUploadFailedError(str(exc)) from exc
+
+        if response.status_code >= 400:
+            raise BananaUploadFailedError(
+                f"HTTP {response.status_code} while confirming upload",
+                status=response.status_code,
+            )
+
+        try:
+            payload_json: Mapping[str, Any] = response.json()
+        except json.JSONDecodeError as exc:  # pragma: no cover - unexpected
+            raise BananaUploadFailedError("invalid-json") from exc
+
+        public_url = _extract_nested(payload_json, "publicUrl", "public_url", "fileUrl", "url")
+        if public_url:
+            return public_url
+        return ticket.public_url
+
+    async def upload(
+        self,
+        data: bytes,
+        *,
+        filename: str,
+        content_type: str,
+        user_id: Optional[int],
+    ) -> UploadResult:
+        size = len(data)
+        ticket = await self._request_ticket(
+            filename=filename,
+            content_type=content_type,
+            size=size,
+            user_id=user_id,
+        )
+
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                await self._put_bytes(ticket.upload_url, data, content_type)
+            except BananaUploadExpiredError:
+                raise
+            except BananaUploadFailedError as exc:
+                if attempt > len(_RETRY_DELAYS) + 1:
+                    raise
+                delay = _RETRY_DELAYS[min(attempt - 1, len(_RETRY_DELAYS) - 1)]
+                _LOGGER.warning(
+                    "ns=banana action=upload_retry file=%s attempt=%s delay=%.1f reason=%s",
+                    filename,
+                    attempt,
+                    delay,
+                    str(exc),
+                    extra={"user_id": user_id},
+                )
+                await asyncio.sleep(delay)
+                continue
+            else:
+                break
+
+        public_url = await self._confirm_upload(
+            ticket=ticket,
+            filename=filename,
+            content_type=content_type,
+            size=size,
+            user_id=user_id,
+        )
+
+        if not public_url:
+            raise BananaUploadFailedError("missing-public-url")
+
+        _LOGGER.info(
+            "ns=banana action=upload_done file=%s size=%s",
+            filename,
+            size,
+            extra={"user_id": user_id},
+        )
+        return UploadResult(public_url=public_url, upload_id=ticket.upload_id)
+
+    @staticmethod
+    async def _put_bytes(url: str, data: bytes, content_type: str) -> None:
+        headers = {"Content-Type": content_type}
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            try:
+                response = await client.put(url, headers=headers, content=data)
+            except httpx.TimeoutException as exc:  # pragma: no cover - network
+                raise BananaUploadFailedError("timeout") from exc
+            except httpx.RequestError as exc:  # pragma: no cover - network
+                raise BananaUploadFailedError(str(exc)) from exc
+
+        status = response.status_code
+        if status in {403, 404}:
+            raise BananaUploadExpiredError(f"HTTP {status}", status=status)
+        if status >= 400:
+            raise BananaUploadFailedError(f"HTTP {status}", status=status)

--- a/core/settings.py
+++ b/core/settings.py
@@ -94,6 +94,9 @@ class Settings(BaseSettings):
     BANANA_SEND_AS_DOCUMENT: bool = Field(default=True)
     BANANA_CARD_REUSE: bool = Field(default=True)
     TG_FILE_DIRECT_URL: bool = Field(default=False)
+    FEATURE_BANANA: bool = Field(default=True)
+    FEATURE_SUNO: bool = Field(default=True)
+    FEATURE_VIDEO: bool = Field(default=True)
     MJ_SEND_AS_ALBUM: bool = Field(default=True)
 
     KIE_BASE_URL: str = Field(default="https://api.kie.ai")

--- a/handlers/banana.py
+++ b/handlers/banana.py
@@ -62,6 +62,10 @@ class BananaBackendError(BananaError):
     """Raised for unexpected backend failures."""
 
 
+class BananaUploadRetry(BananaBackendError):
+    """Raised when an upload attempt should be retried with a new URL."""
+
+
 def _log_task_exception(task: asyncio.Task[Any]) -> None:
     try:
         exc = task.exception()

--- a/handlers/banana_async_handler.py
+++ b/handlers/banana_async_handler.py
@@ -3,21 +3,21 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import hashlib
 import json
 import logging
 import mimetypes
 import time
+import uuid
 from io import BytesIO
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, MutableMapping, Optional, Sequence
 
-import httpx
 from telegram import Update
 from telegram.ext import ContextTypes
 
+from banana.uploader import BananaUploadExpiredError, BananaUploadFailedError, BananaUploader
 from bot_logger import BotLogger
 from cache_helper import get_or_set_cache
 from error_utils import handle_async_error
@@ -48,6 +48,7 @@ from handlers.banana import (
     BananaBackendError,
     BananaBadRequest,
     BananaTimeout,
+    BananaUploadRetry,
 )
 
 log = logging.getLogger("handlers.banana_async")
@@ -63,15 +64,12 @@ _FAILURE_TEXT = "⚠️ Something went wrong on Banana servers. Please try again
 _BANANA_MODEL = "google/nano-banana-edit"
 _BANANA_CREATE_PATH = "/api/v1/jobs/createTask"
 _BANANA_STATUS_PATH = "/api/v1/jobs/recordInfo"
-_UPLOAD_PATH = "/api/v1/upload/base64"
 
-_CARD_MESSAGE_KEY = "banana:card_msg_id:{chat_id}:{user_id}"
-_CARD_SNAPSHOT_KEY = "banana:card_snapshot:{chat_id}:{user_id}"
+_CARD_MESSAGE_KEY = "banana:card:{user_id}"
+_CARD_SNAPSHOT_KEY = "banana:card_snapshot:{user_id}"
 _SESSION_KEY = "banana:session:{user_id}"
 _CARD_STORAGE_TTL = 60 * 60 * 24
 _SESSION_TTL = 60 * 60 * 24
-_UPLOAD_TIMEOUT = httpx.Timeout(20.0, connect=20.0)
-_UPLOAD_RETRIES = (2, 5, 10)
 _EXTENSION_MAP = {"JPEG": "jpg", "PNG": "png", "WEBP": "webp"}
 _IMAGE_DOC_MIME_WHITELIST = {
     "image/jpeg",
@@ -95,6 +93,15 @@ _ALBUM_BUFFER_KEY = "banana:album:{media_group_id}:{user_id}"
 _ALBUM_LOCK_KEY = "banana:album:lock:{media_group_id}:{user_id}"
 _ALBUM_BUFFER_TTL = 60
 _ALBUM_DEBOUNCE_SECONDS = 0.9
+
+_OPEN_LOCK_KEY = "banana:open:{user_id}"
+_OPEN_LOCK_TTL = 2
+
+_NETWORK_RETRY_DELAYS = (0.8, 2.0)
+
+
+def _open_lock_key(user_id: int) -> str:
+    return _OPEN_LOCK_KEY.format(user_id=int(user_id))
 
 
 def _guess_filename(url: str) -> str:
@@ -283,6 +290,7 @@ class BananaAsyncHandler:
         self._poll_interval = poll_interval
         self._poll_timeout = poll_timeout
         self._logger = bot_logger or BotLogger(redis=redis)
+        self._uploader: Optional[BananaUploader] = None
 
     async def run(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         chat = update.effective_chat
@@ -382,6 +390,14 @@ class BananaAsyncHandler:
         if redis is None:
             raise RuntimeError("Redis client is not configured")
         return redis
+
+    def _get_uploader(self) -> BananaUploader:
+        if self._uploader is None:
+            try:
+                self._uploader = BananaUploader()
+            except RuntimeError as exc:
+                raise BananaBackendError(str(exc)) from exc
+        return self._uploader
 
     async def _generate(
         self,
@@ -483,6 +499,7 @@ class BananaAsyncHandler:
         except Exception as exc:
             await handle_async_error(exc, "BananaAsync.upload_get_file")
             return None
+
         file_path = getattr(tg_file, "file_path", "") or ""
         if (
             file_path
@@ -490,13 +507,25 @@ class BananaAsyncHandler:
             and str(file_path).startswith(("http://", "https://"))
         ):
             file_path = Path(file_path).name
+
         try:
-            data = await tg_file.download_as_bytearray()
+            raw_bytes = bytes(await tg_file.download_as_bytearray())
         except Exception as exc:
             await handle_async_error(exc, "BananaAsync.upload_download")
             return None
 
-        raw_bytes = bytes(data)
+        source_name = Path(file_path or file_id).name or f"banana_{file_id}"
+        temp_dir = Path("/tmp/banana") / str(user_id or "anon")
+        try:
+            temp_dir.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            temp_dir = Path("/tmp")
+        original_path = temp_dir / f"{Path(source_name).stem or 'banana_input'}_orig"
+        try:
+            original_path.write_bytes(raw_bytes)
+        except Exception:
+            pass
+
         ok, fmt, mime = validate_image(raw_bytes, allowed=_ALLOWED_IMAGE_FORMATS)
         if not ok:
             detected_fmt, detected_mime = identify_image(raw_bytes)
@@ -513,7 +542,6 @@ class BananaAsyncHandler:
             return None
 
         fmt_upper = (fmt or "").upper()
-        source_name = Path(file_path or file_id).name or f"banana_{file_id}"
         target_ext = _resolve_extension(source_name, fmt_upper)
         target_mime = mime or mimetypes.guess_type(source_name)[0] or "application/octet-stream"
         upload_bytes = raw_bytes
@@ -542,22 +570,44 @@ class BananaAsyncHandler:
             target_ext = "png"
             target_mime = "image/png"
 
-        size = len(upload_bytes)
-        filename = f"{Path(source_name).stem or 'banana_input'}.{target_ext}"
+        final_name = f"{Path(source_name).stem or 'banana_input'}.{target_ext}"
+        final_path = temp_dir / final_name
+        try:
+            final_path.write_bytes(upload_bytes)
+        except Exception:
+            pass
 
-        url = await self._upload_image_bytes(
-            upload_bytes,
-            filename=filename,
-            mime_type=target_mime,
-            ext=target_ext,
-            size=size,
-            user_id=user_id,
-        )
-        log.info(
-            "banana.upload.ok",
-            extra={"user_id": user_id, "ext": target_ext.lower(), "size": size},
-        )
-        return {"type": "image", "url": url}
+        uploader = self._get_uploader()
+        for attempt, delay in enumerate((0.0, *_NETWORK_RETRY_DELAYS), start=1):
+            try:
+                result = await uploader.upload(
+                    upload_bytes,
+                    filename=final_name,
+                    content_type=target_mime,
+                    user_id=user_id,
+                )
+            except BananaUploadExpiredError as exc:
+                raise BananaUploadRetry(str(exc)) from exc
+            except BananaUploadFailedError as exc:
+                if attempt >= len(_NETWORK_RETRY_DELAYS) + 1:
+                    raise BananaBackendError("upload_failed") from exc
+                await asyncio.sleep(delay)
+                continue
+            else:
+                log.info(
+                    "banana.upload.ok",
+                    extra={
+                        "user_id": user_id,
+                        "ext": target_ext.lower(),
+                        "size": len(upload_bytes),
+                    },
+                )
+                return {
+                    "type": "image",
+                    "url": result.public_url,
+                    "upload_id": result.upload_id,
+                }
+        return None
 
     async def _prepare_image_urls(
         self, bot, file_ids: Sequence[str], *, user_id: Optional[int] = None
@@ -584,194 +634,6 @@ class BananaAsyncHandler:
             if "user_id" not in str(exc):
                 raise
             return await self._prepare_image_urls(bot, file_ids)
-
-    async def _fetch_file_bytes(self, bot, file_id: str) -> bytes:
-        tg_file = await bot.get_file(file_id)
-        return await tg_file.download_as_bytearray()
-
-    async def _upload_image_bytes(
-        self,
-        data: bytes,
-        *,
-        filename: str,
-        mime_type: str,
-        ext: str,
-        size: int,
-        user_id: Optional[int] = None,
-    ) -> str:
-        last_error: Optional[BananaBackendError] = None
-        stream_endpoint = _build_upload_url(UPLOAD_STREAM_PATH or "/api/file-stream-upload")
-        if stream_endpoint:
-            try:
-                url = await self._upload_via_stream(
-                    data,
-                    filename=filename,
-                    mime_type=mime_type,
-                    endpoint=stream_endpoint,
-                    user_id=user_id,
-                )
-            except BananaBackendError as exc:
-                last_error = exc
-            else:
-                return url
-
-        base64_endpoint = _build_upload_url(UPLOAD_BASE64_PATH or _UPLOAD_PATH)
-        if base64_endpoint:
-            try:
-                url = await self._upload_via_base64(
-                    data,
-                    filename=filename,
-                    endpoint=base64_endpoint,
-                    user_id=user_id,
-                )
-            except BananaBackendError as exc:
-                last_error = exc
-            else:
-                return url
-
-        if last_error is not None:
-            raise last_error
-        raise BananaBackendError("upload_failed")
-
-    async def _upload_via_stream(
-        self,
-        data: bytes,
-        *,
-        filename: str,
-        mime_type: str,
-        endpoint: str,
-        user_id: Optional[int] = None,
-    ) -> str:
-        for attempt, delay in enumerate(_UPLOAD_RETRIES, start=1):
-            retry = False
-            try:
-                async with httpx.AsyncClient(timeout=_UPLOAD_TIMEOUT) as client:
-                    response = await client.post(
-                        endpoint,
-                        files={"file": (filename, data, mime_type)},
-                    )
-            except httpx.RequestError as exc:
-                log.warning(
-                    "banana.upload.err",
-                    extra={
-                        "user_id": user_id,
-                        "status": 0,
-                        "path": endpoint,
-                        "attempt": attempt,
-                        "reason": str(exc),
-                    },
-                )
-                retry = attempt < len(_UPLOAD_RETRIES)
-            else:
-                status = response.status_code
-                body_preview = (response.text or "")[:200]
-                if 200 <= status < 300:
-                    try:
-                        payload = response.json()
-                    except ValueError:
-                        payload = {}
-                    url = _extract_upload_url(payload if isinstance(payload, Mapping) else {})
-                    if url:
-                        return url
-                    log.warning(
-                        "banana.upload.err",
-                        extra={
-                            "user_id": user_id,
-                            "status": status,
-                            "path": endpoint,
-                            "attempt": attempt,
-                            "reason": "missing-url",
-                        },
-                    )
-                    break
-                if status >= 500 or status == 429:
-                    log.warning(
-                        "banana.upload.err",
-                        extra={
-                            "user_id": user_id,
-                            "status": status,
-                            "path": endpoint,
-                            "attempt": attempt,
-                            "reason": body_preview,
-                        },
-                    )
-                    retry = attempt < len(_UPLOAD_RETRIES)
-                else:
-                    log.warning(
-                        "banana.upload.err",
-                        extra={
-                            "user_id": user_id,
-                            "status": status,
-                            "path": endpoint,
-                            "attempt": attempt,
-                            "reason": body_preview,
-                        },
-                    )
-                    break
-            if retry and attempt < len(_UPLOAD_RETRIES):
-                await asyncio.sleep(delay)
-                continue
-            if not retry:
-                break
-        raise BananaBackendError("upload_failed")
-
-    async def _upload_via_base64(
-        self,
-        data: bytes,
-        *,
-        filename: str,
-        endpoint: str,
-        user_id: Optional[int] = None,
-    ) -> str:
-        payload = {
-            "fileName": filename,
-            "base64": base64.b64encode(data).decode("ascii"),
-        }
-        try:
-            async with httpx.AsyncClient(timeout=_UPLOAD_TIMEOUT) as client:
-                response = await client.post(endpoint, json=payload)
-        except httpx.RequestError as exc:
-            log.warning(
-                "banana.upload.err",
-                extra={
-                    "user_id": user_id,
-                    "status": 0,
-                    "path": endpoint,
-                    "reason": str(exc),
-                },
-            )
-            raise BananaBackendError("upload_failed") from exc
-        if 200 <= response.status_code < 300:
-            try:
-                payload_json: Any = response.json()
-            except ValueError as exc:
-                raise BananaBackendError("upload_failed") from exc
-            if isinstance(payload_json, Mapping):
-                url = _extract_upload_url(payload_json)
-            else:
-                url = None
-            if url:
-                return url
-            log.warning(
-                "banana.upload.err",
-                extra={
-                    "user_id": user_id,
-                    "status": response.status_code,
-                    "path": endpoint,
-                    "reason": "missing-url",
-                },
-            )
-            raise BananaBackendError("upload_failed")
-        log.warning(
-            "banana.upload.err",
-            extra={
-                "user_id": user_id,
-                "status": response.status_code,
-                "path": endpoint,
-                "reason": (response.text or "")[:200],
-            },
-        )
-        raise BananaBackendError("upload_failed")
 
     async def _publish_result(
         self,
@@ -1070,8 +932,8 @@ async def _acknowledge_callback(query, ctx, *, text: str = "✓", show_alert: bo
         pass
 
 
-def _card_key(key_tmpl: str, *, chat_id: int, user_id: int) -> str:
-    return key_tmpl.format(chat_id=int(chat_id), user_id=int(user_id))
+def _card_key(key_tmpl: str, *, user_id: int) -> str:
+    return key_tmpl.format(user_id=int(user_id))
 
 
 def _album_buffer_key_for(media_group_id: str, user_id: int) -> str:
@@ -1088,7 +950,7 @@ async def _store_card_message_id(
     try:
         redis = _resolve_redis(ctx)
         await redis.set(
-            _card_key(_CARD_MESSAGE_KEY, chat_id=chat_id, user_id=user_id),
+            _card_key(_CARD_MESSAGE_KEY, user_id=user_id),
             int(message_id),
             ex=_CARD_STORAGE_TTL,
         )
@@ -1105,9 +967,7 @@ async def _load_card_message_id(
         await handle_async_error(exc, "BananaAsync.card_load_id_redis")
         return None
     try:
-        raw = await redis.get(
-            _card_key(_CARD_MESSAGE_KEY, chat_id=chat_id, user_id=user_id)
-        )
+        raw = await redis.get(_card_key(_CARD_MESSAGE_KEY, user_id=user_id))
     except Exception as exc:
         await handle_async_error(exc, "BananaAsync.card_load_id")
         return None
@@ -1129,11 +989,55 @@ async def _clear_card_storage(
         return
     try:
         await redis.delete(
-            _card_key(_CARD_MESSAGE_KEY, chat_id=chat_id, user_id=user_id),
-            _card_key(_CARD_SNAPSHOT_KEY, chat_id=chat_id, user_id=user_id),
+            _card_key(_CARD_MESSAGE_KEY, user_id=user_id),
+            _card_key(_CARD_SNAPSHOT_KEY, user_id=user_id),
         )
     except Exception as exc:
         await handle_async_error(exc, "BananaAsync.card_clear_id")
+
+
+async def _acquire_open_lock(
+    ctx: ContextTypes.DEFAULT_TYPE, user_id: int
+) -> Optional[str]:
+    token = uuid.uuid4().hex
+    try:
+        redis = _resolve_redis(ctx)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.open_lock_redis")
+        return token
+    try:
+        acquired = await redis.set(_open_lock_key(user_id), token, ex=_OPEN_LOCK_TTL, nx=True)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.open_lock_set")
+        return token
+    if acquired:
+        return token
+    return None
+
+
+async def _release_open_lock(
+    ctx: ContextTypes.DEFAULT_TYPE, user_id: int, token: Optional[str]
+) -> None:
+    if not token:
+        return
+    try:
+        redis = _resolve_redis(ctx)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.open_lock_release_redis")
+        return
+    key = _open_lock_key(user_id)
+    try:
+        raw = await redis.get(key)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.open_lock_get")
+        return
+    current = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+    if current != token:
+        return
+    try:
+        await redis.delete(key)
+    except Exception as exc:
+        await handle_async_error(exc, "BananaAsync.open_lock_delete")
 
 
 async def _schedule_album_finalize(
@@ -1354,9 +1258,7 @@ async def _load_card_snapshot(
         await handle_async_error(exc, "BananaAsync.card_snapshot_load_redis")
         return None
     try:
-        raw = await redis.get(
-            _card_key(_CARD_SNAPSHOT_KEY, chat_id=chat_id, user_id=user_id)
-        )
+        raw = await redis.get(_card_key(_CARD_SNAPSHOT_KEY, user_id=user_id))
     except Exception as exc:
         await handle_async_error(exc, "BananaAsync.card_snapshot_load")
         return None
@@ -1373,7 +1275,7 @@ async def _store_card_snapshot(
     try:
         redis = _resolve_redis(ctx)
         await redis.set(
-            _card_key(_CARD_SNAPSHOT_KEY, chat_id=chat_id, user_id=user_id),
+            _card_key(_CARD_SNAPSHOT_KEY, user_id=user_id),
             snapshot,
             ex=_CARD_STORAGE_TTL,
         )
@@ -1472,50 +1374,60 @@ async def open_card(update: Update, ctx: ContextTypes.DEFAULT_TYPE, payload=None
     chat = getattr(message, "chat", None) or update.effective_chat
     if user is None or chat is None:
         return
-    redis = _resolve_redis(ctx)
+    lock_token: Optional[str] = None
     try:
-        await ensure(redis, user.id)
-    except Exception as exc:
-        await handle_async_error(exc, "BananaAsync.card_init")
+        lock_token = await _acquire_open_lock(ctx, user.id)
+    except Exception:
+        lock_token = None
+    if lock_token is None:
         return
     try:
-        state = await _load_state(ctx, user.id)
-    except Exception as exc:
-        await handle_async_error(exc, "BananaAsync.card_load")
-        return
-    stored_message_id: Optional[int] = None
-    reused = False
-    if _CARD_REUSE_ENABLED and user is not None:
-        stored_message_id = await _load_card_message_id(ctx, chat.id, user.id)
-        reused = stored_message_id is not None
-    if (
-        _CARD_REUSE_ENABLED
-        and message is not None
-        and getattr(message, "message_id", None)
-    ):
-        await _store_card_message_id(ctx, chat.id, user.id, message.message_id)
-        if stored_message_id == message.message_id:
-            reused = True
-    await _render_card(
-        ctx=ctx,
-        chat_id=chat.id,
-        state=state,
-        user_id=user.id,
-        message=message,
-    )
-    try:
-        await async_input_state.set(user.id, mode="banana")
-    except Exception as exc:
-        await handle_async_error(exc, "BananaAsync.input_state_set")
-    log.info(
-        "banana.card.opened",
-        extra={
-            "user_id": user.id,
-            "photos": len(state.photos),
-            "has_prompt": bool(state.prompt),
-            "reused_msg": reused,
-        },
-    )
+        redis = _resolve_redis(ctx)
+        try:
+            await ensure(redis, user.id)
+        except Exception as exc:
+            await handle_async_error(exc, "BananaAsync.card_init")
+            return
+        try:
+            state = await _load_state(ctx, user.id)
+        except Exception as exc:
+            await handle_async_error(exc, "BananaAsync.card_load")
+            return
+        stored_message_id: Optional[int] = None
+        reused = False
+        if _CARD_REUSE_ENABLED and user is not None:
+            stored_message_id = await _load_card_message_id(ctx, chat.id, user.id)
+            reused = stored_message_id is not None
+        if (
+            _CARD_REUSE_ENABLED
+            and message is not None
+            and getattr(message, "message_id", None)
+        ):
+            await _store_card_message_id(ctx, chat.id, user.id, message.message_id)
+            if stored_message_id == message.message_id:
+                reused = True
+        await _render_card(
+            ctx=ctx,
+            chat_id=chat.id,
+            state=state,
+            user_id=user.id,
+            message=message,
+        )
+        try:
+            await async_input_state.set(user.id, mode="banana")
+        except Exception as exc:
+            await handle_async_error(exc, "BananaAsync.input_state_set")
+        log.info(
+            "banana.card.opened",
+            extra={
+                "user_id": user.id,
+                "photos": len(state.photos),
+                "has_prompt": bool(state.prompt),
+                "reused_msg": reused,
+            },
+        )
+    finally:
+        await _release_open_lock(ctx, user.id, lock_token)
 
 
 async def on_photo(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
@@ -1649,7 +1561,7 @@ async def start_generation(update: Update, ctx: ContextTypes.DEFAULT_TYPE, paylo
     chat = getattr(message, "chat", None) or update.effective_chat
     if query is None or user is None or chat is None:
         return
-    await _acknowledge_callback(query, ctx, text="Запускаю…")
+    await _acknowledge_callback(query, ctx, text="Стартуем…")
     try:
         state = await _load_state(ctx, user.id)
     except Exception as exc:
@@ -1664,39 +1576,86 @@ async def start_generation(update: Update, ctx: ContextTypes.DEFAULT_TYPE, paylo
     normalized_prompt = (prompt_text or "").strip()
     has_prompt = bool(normalized_prompt)
     handler = _get_default_handler()
-    uploads: list[dict[str, Any]] = []
-    upload_failures = False
-    for file_id in session_images:
-        try:
-            upload_result = await handler.upload_image(ctx.bot, file_id, user_id=user.id)
-        except BananaBackendError as exc:
-            await handle_async_error(exc, "BananaAsync.start_upload_image")
-            upload_failures = True
-            continue
-        if not upload_result:
-            upload_failures = True
-            continue
-        uploads.append(upload_result)
-    if session_images and not uploads:
-        feedback = "Не удалось загрузить фото. Попробуйте ещё раз" if upload_failures else "Добавьте фото или промпт"
+    if not session_images and not has_prompt:
         await _render_card(
             ctx=ctx,
             chat_id=chat.id,
             state=state,
             user_id=user.id,
             message=message if getattr(message, "text", None) else None,
-            text_override=feedback,
+            text_override="Не добавлены фото. Пришлите 1–4 фото одним или несколькими сообщениями.",
         )
         return
-    if not uploads and not has_prompt:
+
+    status_target = message if getattr(message, "text", None) else None
+    status_text: Optional[str] = None
+
+    async def _set_status(text: str, *, generating: bool = True) -> None:
+        nonlocal status_text
+        if status_text == text and generating:
+            return
+        status_text = text
         await _render_card(
             ctx=ctx,
             chat_id=chat.id,
             state=state,
             user_id=user.id,
-            message=message if getattr(message, "text", None) else None,
-            text_override="Добавьте фото или промпт",
+            message=status_target,
+            generating=generating,
+            text_override=text,
         )
+
+    await _set_status("🚀 Отправляю в Banana…")
+
+    uploads: list[dict[str, Any]] = []
+    upload_failed = False
+    for file_index, file_id in enumerate(session_images):
+        presigned_retry_used = False
+        network_delays = list(_NETWORK_RETRY_DELAYS)
+        success = False
+        while True:
+            try:
+                upload_result = await handler.upload_image(ctx.bot, file_id, user_id=user.id)
+            except BananaUploadRetry:
+                if presigned_retry_used:
+                    upload_failed = True
+                    break
+                presigned_retry_used = True
+                await _set_status("⚠️ Не удалось загрузить фото. Пробуем ещё раз…")
+                await asyncio.sleep(_NETWORK_RETRY_DELAYS[0] if _NETWORK_RETRY_DELAYS else 0.8)
+                await _set_status("🚀 Отправляю в Banana…")
+                continue
+            except BananaBackendError as exc:
+                if network_delays:
+                    delay = network_delays.pop(0)
+                    await asyncio.sleep(delay)
+                    continue
+                await handle_async_error(exc, "BananaAsync.start_upload_image")
+                upload_failed = True
+                break
+            else:
+                if upload_result:
+                    uploads.append(upload_result)
+                    success = True
+                break
+        if not success:
+            break
+
+    if session_images:
+        if not uploads:
+            await _set_status(
+                "Не удалось прикрепить фото. Пришлите ещё раз (JPEG/PNG, до 15 МБ).",
+                generating=False,
+            )
+            return
+        if len(uploads) < len(session_images) or upload_failed:
+            await _set_status(
+                "❌ Сбой загрузки на Banana. Попробуйте ещё раз.",
+                generating=False,
+            )
+            return
+    if not uploads and not has_prompt:
+        await _set_status("Добавьте фото или промпт", generating=False)
         return
     state.photos = list(session_images)
     state.prompt = normalized_prompt or None
@@ -1713,15 +1672,8 @@ async def start_generation(update: Update, ctx: ContextTypes.DEFAULT_TYPE, paylo
         await async_input_state.set(user.id, mode="banana")
     except Exception as exc:
         await handle_async_error(exc, "BananaAsync.start_input_state")
-
-    await _render_card(
-        ctx=ctx,
-        chat_id=chat.id,
-        state=state,
-        user_id=user.id,
-        message=message if getattr(message, "text", None) else None,
-        generating=True,
-    )
+    status_text = None
+    await _set_status("🚀 Отправляю в Banana…")
 
     log.info(
         "banana.gen.start",

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
-from typing import Sequence
+from typing import MutableMapping, Optional, Sequence
 
-from telegram import InlineKeyboardButton, ReplyKeyboardRemove, Update
-from telegram.constants import ParseMode
+from telegram import InlineKeyboardButton, Update
 from telegram.ext import ContextTypes
+from telegram.error import BadRequest, Forbidden, TelegramError
 
-from keyboards import CB, FEATURE_PM_ENABLED, kb_main, main_menu_kb, photo_engines_kb
+from keyboards import CB, kb_main, photo_engines_kb
 from texts import (
-    TXT_AI_DIALOG_CHOOSE,
-    TXT_AI_DIALOG_NORMAL,
-    TXT_AI_DIALOG_PM,
     TXT_KB_AI_DIALOG,
     TXT_KB_MUSIC,
     TXT_KB_PHOTO,
@@ -19,72 +16,268 @@ from texts import (
     TXT_MENU_TITLE,
 )
 from ui.card import build_card
+from ui.card_store import load_card_message_id, store_card_message_id
 
 from logging_utils import get_logger
-from utils.telegram_safe import safe_edit_message
+from settings import FEATURE_BANANA, FEATURE_SUNO, FEATURE_VIDEO
 
 log = get_logger("handlers.menu")
 
 _MAIN_MENU_SUBTITLE = "Выберите раздел:"
 
+_MENU_NAMESPACE = "menu"
+_VIDEO_NAMESPACE = "video"
+_SUNO_NAMESPACE = "suno"
+_DIALOG_NAMESPACE = "dialog"
 
-async def open_main_menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    text = "📋 *Главное меню*\n_Выберите раздел:_"
-    message = update.effective_message
-    if message is None:
-        return
-    markup = main_menu_kb()
-    removal = await message.reply_text(
-        text,
-        reply_markup=ReplyKeyboardRemove(),
-        parse_mode="Markdown",
-        disable_notification=True,
-    )
+_CHATDATA_KEY = "ui_card_message_ids"
 
-    message_id = getattr(removal, "message_id", None)
-    chat_obj = getattr(removal, "chat", getattr(message, "chat", None))
-    chat_id = getattr(chat_obj, "id", getattr(message, "chat_id", None))
 
-    if isinstance(message_id, int) and chat_id is not None:
+def _chat_card_mapping(
+    ctx: ContextTypes.DEFAULT_TYPE,
+) -> MutableMapping[str, int] | None:
+    mapping = getattr(ctx, "chat_data", None)
+    if not isinstance(mapping, MutableMapping):
+        return None
+    store = mapping.get(_CHATDATA_KEY)
+    if isinstance(store, MutableMapping):
+        return store
+    store_dict: dict[str, int] = {}
+    mapping[_CHATDATA_KEY] = store_dict
+    return store_dict
+
+
+def _to_int(value: object) -> Optional[int]:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+async def _load_card_id(
+    ctx: ContextTypes.DEFAULT_TYPE,
+    *,
+    namespace: str,
+    user_id: int,
+) -> Optional[int]:
+    local_store = _chat_card_mapping(ctx)
+    if local_store is not None:
+        cached = _to_int(local_store.get(namespace))
+        if cached:
+            return cached
+
+    redis = getattr(ctx, "redis", None)
+    if redis is not None:
         try:
-            await safe_edit_message(
-                context,
-                chat_id,
-                message_id,
-                text,
-                markup,
-                parse_mode=ParseMode.MARKDOWN,
-                disable_web_page_preview=True,
+            stored = await load_card_message_id(redis, namespace, user_id)
+        except Exception as exc:  # pragma: no cover - diagnostics
+            log.debug(
+                "menu.card.load_failed",
+                extra={"namespace": namespace, "user_id": user_id, "error": str(exc)},
             )
-        except Exception as exc:  # pragma: no cover - defensive fallback
-            log.warning(
-                "menu.open_main_menu.edit_failed",
-                extra={"chat_id": chat_id, "message_id": message_id, "error": str(exc)},
+        else:
+            if stored:
+                if local_store is not None:
+                    local_store[namespace] = int(stored)
+                return stored
+    return None
+
+
+async def _store_card_id(
+    ctx: ContextTypes.DEFAULT_TYPE,
+    *,
+    namespace: str,
+    user_id: int,
+    message_id: int,
+) -> None:
+    local_store = _chat_card_mapping(ctx)
+    if local_store is not None:
+        local_store[namespace] = int(message_id)
+
+    redis = getattr(ctx, "redis", None)
+    if redis is not None:
+        try:
+            await store_card_message_id(redis, namespace, user_id, int(message_id))
+        except Exception as exc:  # pragma: no cover - diagnostics
+            log.debug(
+                "menu.card.store_failed",
+                extra={"namespace": namespace, "user_id": user_id, "error": str(exc)},
             )
-            await context.bot.send_message(
+
+
+async def _answer_callback(query) -> None:
+    if query is None:
+        return
+    try:
+        await query.answer()
+    except Exception:  # pragma: no cover - best effort ack
+        pass
+
+
+async def _ensure_card(
+    update: Update,
+    ctx: ContextTypes.DEFAULT_TYPE,
+    *,
+    namespace: str,
+    card: dict,
+) -> Optional[int]:
+    chat = getattr(update, "effective_chat", None)
+    user = getattr(update, "effective_user", None)
+    if chat is None or user is None:
+        return None
+
+    chat_id = getattr(chat, "id", None)
+    user_id = getattr(user, "id", None)
+    if chat_id is None or user_id is None:
+        return None
+
+    message_id = await _load_card_id(ctx, namespace=namespace, user_id=int(user_id))
+    text = card.get("text") or ""
+    reply_markup = card.get("reply_markup")
+    parse_mode = card.get("parse_mode")
+    disable_web_page_preview = bool(card.get("disable_web_page_preview", True))
+
+    if message_id is not None:
+        try:
+            await ctx.bot.edit_message_text(
                 chat_id=chat_id,
+                message_id=message_id,
                 text=text,
-                reply_markup=markup,
-                parse_mode="Markdown",
+                reply_markup=reply_markup,
+                parse_mode=parse_mode,
+                disable_web_page_preview=disable_web_page_preview,
             )
-            try:
-                await context.bot.delete_message(chat_id=chat_id, message_id=message_id)
-            except Exception:
-                log.debug(
-                    "menu.open_main_menu.delete_failed",
-                    extra={"chat_id": chat_id, "message_id": message_id},
-                )
-    else:
-        await context.bot.send_message(
+        except BadRequest as exc:
+            message = str(exc)
+            lowered = message.lower()
+            if "message is not modified" in lowered:
+                try:
+                    await ctx.bot.edit_message_reply_markup(
+                        chat_id=chat_id,
+                        message_id=message_id,
+                        reply_markup=reply_markup,
+                    )
+                except BadRequest as markup_exc:
+                    if "message is not modified" not in str(markup_exc).lower():
+                        log.debug(
+                            "menu.card.markup_failed",
+                            extra={
+                                "namespace": namespace,
+                                "chat_id": chat_id,
+                                "message_id": message_id,
+                                "error": str(markup_exc),
+                            },
+                        )
+                except TelegramError as markup_exc:  # pragma: no cover - defensive
+                    log.debug(
+                        "menu.card.markup_error",
+                        extra={
+                            "namespace": namespace,
+                            "chat_id": chat_id,
+                            "message_id": message_id,
+                            "error": str(markup_exc),
+                        },
+                    )
+                await _store_card_id(ctx, namespace=namespace, user_id=int(user_id), message_id=message_id)
+                return message_id
+
+            log.debug(
+                "menu.card.edit_failed",
+                extra={
+                    "namespace": namespace,
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "error": message,
+                },
+            )
+            message_id = None
+        except (Forbidden, TelegramError) as exc:
+            log.debug(
+                "menu.card.edit_error",
+                extra={
+                    "namespace": namespace,
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "error": str(exc),
+                },
+            )
+            message_id = None
+        else:
+            await _store_card_id(ctx, namespace=namespace, user_id=int(user_id), message_id=message_id)
+            return message_id
+
+    try:
+        sent = await ctx.bot.send_message(
             chat_id=chat_id,
             text=text,
-            reply_markup=markup,
-            parse_mode="Markdown",
+            reply_markup=reply_markup,
+            parse_mode=parse_mode,
+            disable_web_page_preview=disable_web_page_preview,
+        )
+    except TelegramError as exc:
+        log.warning(
+            "menu.card.send_failed",
+            extra={"namespace": namespace, "chat_id": chat_id, "error": str(exc)},
+        )
+        return None
+
+    await _store_card_id(
+        ctx,
+        namespace=namespace,
+        user_id=int(user_id),
+        message_id=sent.message_id,
+    )
+    return sent.message_id
+
+
+def _filter_menu_rows(rows: Sequence[Sequence[InlineKeyboardButton]]) -> list[list[InlineKeyboardButton]]:
+    filtered: list[list[InlineKeyboardButton]] = []
+    for row in rows:
+        new_row: list[InlineKeyboardButton] = []
+        for button in row:
+            data = (button.callback_data or "").strip().lower()
+            if not FEATURE_VIDEO and data == "menu:video":
+                continue
+            if not FEATURE_SUNO and data == "menu:music":
+                continue
+            if not FEATURE_BANANA and data in {"menu:photo", "img_engine:banana"}:
+                continue
+            new_row.append(button)
+        if new_row:
+            filtered.append(new_row)
+    return filtered
+
+
+async def open_main_menu(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    *,
+    skip_ack: bool = False,
+) -> None:
+    query = update.callback_query if not skip_ack else None
+    await _answer_callback(query)
+
+    card = build_main_menu_card()
+    message_id = await _ensure_card(update, context, namespace=_MENU_NAMESPACE, card=card)
+
+    chat = getattr(update, "effective_chat", None)
+    chat_id = getattr(chat, "id", None)
+    if message_id is not None and chat_id is not None:
+        log.debug(
+            "menu.card.rendered",
+            extra={
+                "namespace": _MENU_NAMESPACE,
+                "chat_id": chat_id,
+                "message_id": message_id,
+            },
         )
 
 
 async def show_profile(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     query = update.callback_query
+    await _answer_callback(query)
     target = query.message if query else update.effective_message
     if target is None:
         return
@@ -93,6 +286,7 @@ async def show_profile(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
 async def show_kb(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     query = update.callback_query
+    await _answer_callback(query)
     target = query.message if query else update.effective_message
     if target is None:
         return
@@ -101,6 +295,7 @@ async def show_kb(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def open_photo_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     query = update.callback_query
+    await _answer_callback(query)
     target = query.message if query else update.effective_message
     if target is None:
         return
@@ -112,29 +307,142 @@ async def open_photo_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
 async def open_music_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     query = update.callback_query
-    target = query.message if query else update.effective_message
-    if target is None:
+    if not FEATURE_SUNO:
+        chat = getattr(update, "effective_chat", None)
+        chat_id = getattr(chat, "id", None)
+        if chat_id is not None:
+            try:
+                await context.bot.send_message(
+                    chat_id,
+                    "Музыкальный режим временно недоступен.",
+                )
+            except TelegramError:
+                log.debug("menu.music.disabled.notify_failed", exc_info=True)
+        await _answer_callback(query)
         return
-    await target.reply_text("🎧 Музыка: Suno / загрузка каппеллы / инструкции (скоро).")
+
+    await _answer_callback(query)
+
+    card = build_music_card()
+    message_id = await _ensure_card(update, context, namespace=_SUNO_NAMESPACE, card=card)
+
+    chat = getattr(update, "effective_chat", None)
+    chat_id = getattr(chat, "id", None)
+    if message_id is not None and chat_id is not None:
+        log.debug(
+            "menu.card.rendered",
+            extra={
+                "namespace": _SUNO_NAMESPACE,
+                "chat_id": chat_id,
+                "message_id": message_id,
+            },
+        )
 
 
 async def open_video_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     query = update.callback_query
-    target = query.message if query else update.effective_message
-    if target is None:
+    if not FEATURE_VIDEO:
+        chat = getattr(update, "effective_chat", None)
+        chat_id = getattr(chat, "id", None)
+        if chat_id is not None:
+            try:
+                await context.bot.send_message(
+                    chat_id,
+                    "Видео сейчас недоступно. Загляните позже!",
+                )
+            except TelegramError:
+                log.debug("menu.video.disabled.notify_failed", exc_info=True)
+        await _answer_callback(query)
         return
-    await target.reply_text("📹 Видео: Kling / VEO (скоро выбор).")
+
+    await _answer_callback(query)
+
+    card = build_video_card()
+    message_id = await _ensure_card(update, context, namespace=_VIDEO_NAMESPACE, card=card)
+
+    chat = getattr(update, "effective_chat", None)
+    chat_id = getattr(chat, "id", None)
+    if message_id is not None and chat_id is not None:
+        log.debug(
+            "menu.card.rendered",
+            extra={
+                "namespace": _VIDEO_NAMESPACE,
+                "chat_id": chat_id,
+                "message_id": message_id,
+            },
+        )
 
 
 async def open_dialog_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     query = update.callback_query
-    target = query.message if query else update.effective_message
-    if target is None:
-        return
-    context.user_data["dialog_mode"] = "plain"
-    await target.reply_text(
-        "🧠 Обычный диалог включён. Пишите текст — отвечу без дополнительных меню."
-    )
+    await _answer_callback(query)
+
+    chat = getattr(update, "effective_chat", None)
+    chat_id = getattr(chat, "id", None)
+    user = getattr(update, "effective_user", None)
+    user_id = getattr(user, "id", None)
+
+    try:
+        from bot import enable_chat_mode  # type: ignore
+    except Exception as exc:  # pragma: no cover - fallback when bot not initialized
+        log.debug(
+            "menu.dialog.enable_import_failed",
+            extra={"chat_id": chat_id, "user_id": user_id, "error": str(exc)},
+        )
+    else:
+        try:
+            await enable_chat_mode(update, context, "normal")
+        except Exception as exc:  # pragma: no cover - diagnostics
+            log.warning(
+                "menu.dialog.enable_failed",
+                extra={"chat_id": chat_id, "user_id": user_id, "error": str(exc)},
+            )
+
+    card = build_dialog_card()
+    message_id = await _ensure_card(update, context, namespace=_DIALOG_NAMESPACE, card=card)
+
+    if message_id is not None and chat_id is not None:
+        log.debug(
+            "menu.card.rendered",
+            extra={
+                "namespace": _DIALOG_NAMESPACE,
+                "chat_id": chat_id,
+                "message_id": message_id,
+            },
+        )
+
+
+async def close_dialog_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await _answer_callback(query)
+
+    chat = getattr(update, "effective_chat", None)
+    chat_id = getattr(chat, "id", None)
+    user = getattr(update, "effective_user", None)
+    user_id = getattr(user, "id", None)
+
+    try:
+        from bot import disable_chat_mode  # type: ignore
+    except Exception as exc:  # pragma: no cover - diagnostics only
+        log.debug(
+            "menu.dialog.disable_import_failed",
+            extra={"chat_id": chat_id, "user_id": user_id, "error": str(exc)},
+        )
+    else:
+        try:
+            await disable_chat_mode(
+                context,
+                chat_id=chat_id,
+                user_id=user_id,
+                notify=False,
+            )
+        except Exception as exc:  # pragma: no cover - diagnostics only
+            log.warning(
+                "menu.dialog.disable_failed",
+                extra={"chat_id": chat_id, "user_id": user_id, "error": str(exc)},
+            )
+
+    await open_main_menu(update, context, skip_ack=True)
 
 
 async def on_menu_dialog(update, context) -> None:
@@ -157,7 +465,8 @@ def build_main_menu_card() -> dict:
     """Return the unified card used for the /menu screen."""
 
     markup = kb_main()
-    return build_card(TXT_MENU_TITLE, _MAIN_MENU_SUBTITLE, markup.inline_keyboard)
+    rows = _filter_menu_rows(markup.inline_keyboard)
+    return build_card(TXT_MENU_TITLE, _MAIN_MENU_SUBTITLE, rows)
 
 
 def build_profile_card(balance: str, warning: str | None = None) -> dict:
@@ -179,51 +488,72 @@ def build_photo_card() -> dict:
 
 def build_music_card() -> dict:
     rows = [
-        [InlineKeyboardButton("🎼 Инструментал", callback_data="music:inst")],
-        [InlineKeyboardButton("🎙 Вокал", callback_data="music:vocal")],
-        [InlineKeyboardButton("⬅️ Назад", callback_data="back")],
+        [InlineKeyboardButton("🚀 Начать генерацию", callback_data="suno:start")],
+        [InlineKeyboardButton("🎙 Прикрепить аудио", callback_data="suno:attach")],
+        [InlineKeyboardButton("⬅️ В меню", callback_data="back")],
     ]
-    return build_card(TXT_KB_MUSIC, "Выберите режим:", rows)
+    body = [
+        "1. Опишите трек: жанр, настроение, длительность.",
+        "2. Прикрепите референс (voice/audio до 15 МБ) или нажмите «Прикрепить аудио».",
+    ]
+    return build_card(
+        TXT_KB_MUSIC,
+        "Suno создаёт музыку по вашему описанию и каппелле.",
+        rows,
+        body_lines=body,
+    )
 
 
 def build_video_card(*, veo_fast_cost: int, veo_photo_cost: int, sora2_cost: int) -> dict:
     rows = [
+        [InlineKeyboardButton("🎞 Kling — скоро", callback_data="video:kling")],
         [
             InlineKeyboardButton(
-                f"Генерация видео (Veo Fast) — 💎 {veo_fast_cost}",
+                f"VEO Fast — текст → видео • 💎 {veo_fast_cost}",
                 callback_data="mode:veo_text_fast",
             )
         ],
         [
             InlineKeyboardButton(
-                f"Оживить изображение (Veo) — 💎 {veo_photo_cost}",
+                f"VEO Animate — фото → видео • 💎 {veo_photo_cost}",
                 callback_data=CB.VIDEO_VEO_ANIMATE,
             )
         ],
         [
             InlineKeyboardButton(
-                f"🎬 Sora2 — генерация по тексту — 💎 {sora2_cost}",
+                f"🎬 Sora2 — текст → видео • 💎 {sora2_cost}",
                 callback_data="video:type:sora2",
             )
         ],
-        [InlineKeyboardButton("⬅️ Назад", callback_data="back")],
+        [InlineKeyboardButton("⬅️ В меню", callback_data="back")],
     ]
-    return build_card(TXT_KB_VIDEO, "Выберите действие:", rows)
+    body = [
+        "Kling в разработке — скоро откроем доступ.",
+        "Для VEO пришлите текст или 1–4 фото, затем нажмите «Начать генерацию».",
+    ]
+    return build_card(
+        TXT_KB_VIDEO,
+        "Выберите движок для генерации видео.",
+        rows,
+        body_lines=body,
+    )
 
 
 def build_dialog_card() -> dict:
-    subtitle = TXT_AI_DIALOG_CHOOSE if FEATURE_PM_ENABLED else "Напиши запрос — это обычный чат с ИИ."
-    if FEATURE_PM_ENABLED:
-        rows = [
-            [
-                InlineKeyboardButton(TXT_AI_DIALOG_NORMAL, callback_data="mode:chat"),
-                InlineKeyboardButton(TXT_AI_DIALOG_PM, callback_data="mode:prompt_master"),
-            ],
-            [InlineKeyboardButton("⬅️ Назад", callback_data="back")],
-        ]
-    else:
-        rows = [[InlineKeyboardButton("⬅️ Назад", callback_data="back")]]
-    return build_card(TXT_KB_AI_DIALOG, subtitle, rows)
+    rows = [
+        [InlineKeyboardButton("✖️ Выкл диалог", callback_data="dialog:off")],
+        [InlineKeyboardButton("⬅️ В меню", callback_data="back")],
+    ]
+    body = [
+        "Диалог включён. Пишите сообщения — я отвечу сразу, без карточек.",
+        "Команда /reset очищает историю переписки.",
+    ]
+    return build_card(
+        TXT_KB_AI_DIALOG,
+        "Свободный чат активирован.",
+        rows,
+        body_lines=body,
+    )
 
 
 __all__ = [
@@ -234,6 +564,7 @@ __all__ = [
     "open_music_mode",
     "open_video_mode",
     "open_dialog_mode",
+    "close_dialog_mode",
     "on_menu_dialog",
     "build_dialog_card",
     "build_main_menu_card",

--- a/handlers/profile_simple.py
+++ b/handlers/profile_simple.py
@@ -1,327 +1,330 @@
-"""Simplified profile handlers focused on stability."""
+"""Lightweight profile card handlers with single-message storage."""
 
 from __future__ import annotations
 
 import inspect
 import logging
-from contextlib import suppress
-from dataclasses import dataclass
-from typing import Any, Iterable, MutableMapping, Optional
+from typing import Iterable, MutableMapping, Optional, Sequence
 
-import redis
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
-from telegram.error import BadRequest, TelegramError
+from telegram.error import BadRequest
 from telegram.ext import ContextTypes
 
-from billing import get_history
-from core.balance_provider import get_balance_snapshot
-from redis_utils import rds
 import settings as app_settings
+from services.db_async import get_user_balance_async
+from ui.card_store import clear_card_message_id, load_card_message_id, store_card_message_id
+
+try:  # pragma: no cover - optional billing module
+    from billing import get_history as _billing_history
+except Exception:  # pragma: no cover - fallback in tests
+    _billing_history = None  # type: ignore[assignment]
+
 from .stars import open_stars_menu
 
 log = logging.getLogger(__name__)
 
-
-_LAST_PROFILE_KEY_TMPL = f"{app_settings.REDIS_PREFIX}:profile_simple:last_msg:{{chat_id}}"
-_LAST_PROFILE_TTL = 6 * 60 * 60
-_memory_last_ids: dict[int, int] = {}
+_NAMESPACE = "profile"
+_CHATDATA_KEY = "profile_card_message_id"
 
 
-@dataclass
-class _ProfileContext:
-    chat_id: Optional[int]
-    user_id: Optional[int]
+async def get_history(user_id: int) -> Sequence[dict[str, object]]:
+    """Return recent billing entries for ``user_id``.
+
+    The default implementation proxies to :mod:`billing`. Tests can monkeypatch
+    this coroutine to provide custom data.
+    """
+
+    if _billing_history is None:
+        return []
+    result = _billing_history(int(user_id))
+    if inspect.isawaitable(result):
+        return await result  # type: ignore[return-value]
+    return list(result or [])  # type: ignore[arg-type]
 
 
-def _profile_key(chat_id: int) -> str:
-    return _LAST_PROFILE_KEY_TMPL.format(chat_id=int(chat_id))
+async def _load_history_entries(user_id: int) -> Sequence[dict[str, object]]:
+    result = get_history(int(user_id))
+    if inspect.isawaitable(result):
+        result = await result  # type: ignore[awaited-non-awaitable]
+    if not result:
+        return []
+    return list(result)
 
 
-def _load_last_message_id(chat_id: int) -> Optional[int]:
-    if chat_id is None:
-        return None
-    if rds is not None:
-        try:
-            value = rds.get(_profile_key(chat_id))
-        except redis.RedisError as exc:  # pragma: no cover - defensive
-            log.debug("profile_simple.redis_get_failed", extra={"chat_id": chat_id, "error": str(exc)})
-        else:
-            if value is None:
-                return None
-            try:
-                return int(value)
-            except (TypeError, ValueError):
-                return None
-    return _memory_last_ids.get(int(chat_id))
+def _profile_keyboard() -> InlineKeyboardMarkup:
+    rows = [
+        [InlineKeyboardButton("💎 Пополнить баланс", callback_data="btn:profile|view=topup")],
+        [InlineKeyboardButton("🧾 История операций", callback_data="btn:profile|view=history")],
+        [InlineKeyboardButton("👥 Пригласить друга", callback_data="btn:profile|view=invite")],
+        [InlineKeyboardButton("⬅️ Назад", callback_data="btn:profile|view=back")],
+    ]
+    return InlineKeyboardMarkup(rows)
 
 
-def _store_last_message_id(chat_id: int, message_id: Optional[int]) -> None:
-    if chat_id is None:
-        return
-    if message_id is None:
-        if rds is not None:
-            with suppress(redis.RedisError):
-                rds.delete(_profile_key(chat_id))
-        _memory_last_ids.pop(int(chat_id), None)
-        return
-
-    payload = int(message_id)
-    if rds is not None:
-        try:
-            rds.setex(_profile_key(chat_id), _LAST_PROFILE_TTL, payload)
-        except redis.RedisError as exc:  # pragma: no cover - defensive
-            log.debug("profile_simple.redis_set_failed", extra={"chat_id": chat_id, "error": str(exc)})
-        else:
-            _memory_last_ids[int(chat_id)] = payload
-            return
-    _memory_last_ids[int(chat_id)] = payload
-
-
-async def _delete_previous_profile_message(ctx: ContextTypes.DEFAULT_TYPE, chat_id: Optional[int]) -> None:
-    if chat_id is None:
-        return
-    last_message_id = _load_last_message_id(chat_id)
-    if not last_message_id:
-        return
-    bot_obj = getattr(ctx, "bot", None)
-    chat_data = getattr(ctx, "chat_data", None)
-    if not hasattr(bot_obj, "delete_message"):
-        _store_last_message_id(chat_id, None)
-        if isinstance(chat_data, MutableMapping):
-            chat_data.pop("profile_msg_id", None)
-        return
-    try:
-        await bot_obj.delete_message(chat_id=chat_id, message_id=last_message_id)
-    except (BadRequest, TelegramError):
-        pass
-    finally:
-        _store_last_message_id(chat_id, None)
-        if isinstance(chat_data, MutableMapping):
-            chat_data.pop("profile_msg_id", None)
+def _back_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup([[InlineKeyboardButton("⬅️ Назад", callback_data="btn:profile")]])
 
 
 async def _answer_callback(update: Update) -> None:
     query = getattr(update, "callback_query", None)
     if query is None:
         return
-    with suppress(BadRequest):
+    try:
         await query.answer()
+    except Exception:  # pragma: no cover - best effort acknowledgement
+        pass
 
 
-def _extract_context(update: Update) -> _ProfileContext:
-    chat = getattr(update, "effective_chat", None)
-    message = getattr(update, "effective_message", None)
-    user = getattr(update, "effective_user", None)
-
-    chat_id: Optional[int] = getattr(chat, "id", None)
-    if chat_id is None and message is not None:
-        chat_id = getattr(message, "chat_id", None)
-
-    user_id: Optional[int] = getattr(user, "id", None)
-    if user_id is None and chat_id is not None:
-        user_id = chat_id
-
-    return _ProfileContext(chat_id=chat_id, user_id=user_id)
+def _chat_storage(ctx: ContextTypes.DEFAULT_TYPE) -> MutableMapping[str, object] | None:
+    mapping = getattr(ctx, "chat_data", None)
+    return mapping if isinstance(mapping, MutableMapping) else None
 
 
-def _profile_keyboard() -> InlineKeyboardMarkup:
-    buttons = [
-        [InlineKeyboardButton("💎 Пополнить баланс", callback_data="btn:profile|view=topup")],
-        [InlineKeyboardButton("🧾 История операций", callback_data="btn:profile|view=history")],
-        [InlineKeyboardButton("👥 Пригласить друга", callback_data="btn:profile|view=invite")],
-        [InlineKeyboardButton("⬅️ Назад", callback_data="btn:profile|view=back")],
-    ]
-    return InlineKeyboardMarkup(buttons)
+async def _load_stored_message_id(ctx: ContextTypes.DEFAULT_TYPE, user_id: int) -> Optional[int]:
+    redis = getattr(ctx, "redis", None)
+    if redis is not None:
+        try:
+            stored = await load_card_message_id(redis, _NAMESPACE, user_id)
+        except Exception as exc:  # pragma: no cover - diagnostics
+            log.debug(
+                "profile.card.load_failed",
+                extra={"user_id": user_id, "error": str(exc)},
+            )
+        else:
+            if stored is not None:
+                return stored
+    mapping = _chat_storage(ctx)
+    if mapping is not None:
+        raw = mapping.get(_CHATDATA_KEY)
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return None
+    return None
 
 
-def _back_keyboard() -> InlineKeyboardMarkup:
-    return InlineKeyboardMarkup([[InlineKeyboardButton("⬅️ Назад в профиль", callback_data="btn:profile")]])
-
-
-async def _send_profile_message(
-    update: Update,
-    ctx: ContextTypes.DEFAULT_TYPE,
-    *,
-    text: str,
-    reply_markup: InlineKeyboardMarkup,
+async def _store_message_id(
+    ctx: ContextTypes.DEFAULT_TYPE, user_id: int, message_id: Optional[int]
 ) -> None:
-    context = _extract_context(update)
-    if context.chat_id is None:
-        log.debug("profile_simple.missing_chat_id")
+    if message_id is None:
         return
-    await _delete_previous_profile_message(ctx, context.chat_id)
-    bot_obj = getattr(ctx, "bot", None)
-    if not hasattr(bot_obj, "send_message"):
-        log.debug("profile_simple.missing_bot")
+    redis = getattr(ctx, "redis", None)
+    if redis is not None:
+        try:
+            await store_card_message_id(redis, _NAMESPACE, user_id, int(message_id))
+        except Exception as exc:  # pragma: no cover - diagnostics
+            log.debug(
+                "profile.card.store_failed",
+                extra={"user_id": user_id, "error": str(exc)},
+            )
+    mapping = _chat_storage(ctx)
+    if mapping is not None:
+        mapping[_CHATDATA_KEY] = int(message_id)
+
+
+async def _clear_message_id(ctx: ContextTypes.DEFAULT_TYPE, user_id: int) -> None:
+    redis = getattr(ctx, "redis", None)
+    if redis is not None:
+        try:
+            await clear_card_message_id(redis, _NAMESPACE, user_id)
+        except Exception as exc:  # pragma: no cover - diagnostics
+            log.debug(
+                "profile.card.clear_failed",
+                extra={"user_id": user_id, "error": str(exc)},
+            )
+    mapping = _chat_storage(ctx)
+    if mapping is not None:
+        mapping.pop(_CHATDATA_KEY, None)
+
+
+def _format_balance(value: Optional[int]) -> str:
+    if value is None:
+        return "0"
+    return f"{int(value):,}".replace(",", " ")
+
+
+async def _balance_display(user_id: int) -> str:
+    try:
+        raw = await get_user_balance_async(int(user_id))
+    except Exception as exc:
+        log.warning(
+            "profile.balance_unavailable",
+            extra={"user_id": user_id, "error": str(exc)},
+        )
+        return "—"
+    return _format_balance(raw)
+
+
+async def _delete_stored_message(
+    ctx: ContextTypes.DEFAULT_TYPE, chat_id: Optional[int], user_id: Optional[int]
+) -> None:
+    if chat_id is None or user_id is None:
         return
-    message = await bot_obj.send_message(
-        chat_id=context.chat_id,
-        text=text,
-        reply_markup=reply_markup,
-        parse_mode=None,
-        disable_web_page_preview=True,
+    message_id = await _load_stored_message_id(ctx, user_id)
+    if message_id is None:
+        return
+    bot = getattr(ctx, "bot", None)
+    if bot is None:
+        await _clear_message_id(ctx, user_id)
+        return
+    try:
+        await bot.delete_message(chat_id=chat_id, message_id=message_id)
+    except BadRequest:
+        pass
+    except Exception as exc:  # pragma: no cover - diagnostics
+        log.debug(
+            "profile.card.delete_failed",
+            extra={"chat_id": chat_id, "message_id": message_id, "error": str(exc)},
+        )
+    await _clear_message_id(ctx, user_id)
+
+
+def _invite_text() -> str:
+    bot_name = (app_settings.BOT_NAME or "").strip()
+    username = (app_settings.BOT_USERNAME or "").strip()
+    if not bot_name and not username:
+        return "Скоро включим приглашения."
+    handle = bot_name or username
+    return (
+        "Поделитесь ссылкой с друзьями и получайте бонусы!\n"
+        f"Ваш бот: @{handle}"
     )
-    if hasattr(message, "message_id") and context.chat_id is not None:
-        msg_id = getattr(message, "message_id")
-        _store_last_message_id(context.chat_id, msg_id)
-        chat_data = getattr(ctx, "chat_data", None)
-        if isinstance(chat_data, MutableMapping):
-            chat_data["profile_msg_id"] = msg_id
+
+
+def _render_history_lines(entries: Iterable[dict[str, object]]) -> str:
+    rendered: list[str] = []
+    for entry in entries:
+        if isinstance(entry, dict):
+            label = str(entry.get("label") or entry.get("title") or "Операция")
+            amount = entry.get("amount")
+            balance = entry.get("balance")
+            pieces = [label]
+            if amount is not None:
+                pieces.append(f"Δ {amount}")
+            if balance is not None:
+                pieces.append(f"Баланс: {balance}")
+            rendered.append(" • ".join(pieces))
+        else:
+            rendered.append(str(entry))
+    return "\n".join(rendered)
 
 
 async def profile_open(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     await _answer_callback(update)
-    context = _extract_context(update)
-    balance_display = "0"
-    user_id = context.user_id
-    if user_id is not None:
-        try:
-            snapshot = get_balance_snapshot(int(user_id))
-        except Exception:
-            log.exception("profile_simple.balance_failed", extra={"user_id": user_id})
-        else:
-            if snapshot.display:
-                balance_display = snapshot.display
-            elif snapshot.value is not None:
-                balance_display = str(snapshot.value)
+    chat = getattr(update, "effective_chat", None)
+    message = getattr(update, "effective_message", None)
+    chat_id = getattr(chat, "id", None) or getattr(message, "chat_id", None)
+    user = getattr(update, "effective_user", None)
+    user_id = getattr(user, "id", None)
+    if chat_id is None or user_id is None:
+        return
 
-    lines = [
+    balance_display = await _balance_display(user_id)
+    text = "\n".join([
         "👤 Профиль",
         f"Баланс: {balance_display} 💎",
-    ]
-    if user_id is not None:
-        lines.append(f"ID: {user_id}")
-    lines.extend([
-        "",
-        "Выберите действие:",
     ])
+    markup = _profile_keyboard()
 
-    await _send_profile_message(
-        update,
-        ctx,
-        text="\n".join(lines),
-        reply_markup=_profile_keyboard(),
+    bot = getattr(ctx, "bot", None)
+    if bot is None:
+        log.debug("profile.open.no_bot", extra={"chat_id": chat_id})
+        return
+
+    stored_message_id = await _load_stored_message_id(ctx, user_id)
+    sent = None
+    if stored_message_id is not None:
+        try:
+            sent = await bot.edit_message_text(
+                chat_id=chat_id,
+                message_id=stored_message_id,
+                text=text,
+                reply_markup=markup,
+                disable_web_page_preview=True,
+            )
+        except BadRequest as exc:
+            log.debug(
+                "profile.card.edit_failed",
+                extra={"chat_id": chat_id, "message_id": stored_message_id, "error": str(exc)},
+            )
+            sent = None
+            await _clear_message_id(ctx, user_id)
+        except Exception as exc:  # pragma: no cover - diagnostics
+            log.debug(
+                "profile.card.edit_error",
+                exc_info=True,
+                extra={"chat_id": chat_id, "message_id": stored_message_id, "error": str(exc)},
+            )
+            sent = None
+    if sent is None:
+        sent = await bot.send_message(
+            chat_id=chat_id,
+            text=text,
+            reply_markup=markup,
+            disable_web_page_preview=True,
+        )
+    await _store_message_id(ctx, user_id, getattr(sent, "message_id", None))
+
+
+async def profile_history(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    await _answer_callback(update)
+    chat = getattr(update, "effective_chat", None)
+    user = getattr(update, "effective_user", None)
+    chat_id = getattr(chat, "id", None)
+    user_id = getattr(user, "id", None)
+    await _delete_stored_message(ctx, chat_id, user_id)
+
+    entries = await _load_history_entries(int(user_id)) if user_id is not None else []
+    lines = list(entries or [])
+    if not lines:
+        text = "📜 История операций пока пуста."
+    else:
+        text = "📜 История операций:\n" + _render_history_lines(lines[:5])
+
+    bot = getattr(ctx, "bot", None)
+    if bot is None or chat_id is None:
+        return
+    await bot.send_message(
+        chat_id=chat_id,
+        text=text,
+        reply_markup=_back_keyboard(),
+        disable_web_page_preview=True,
+    )
+
+
+async def profile_invite(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    await _answer_callback(update)
+    chat = getattr(update, "effective_chat", None)
+    user = getattr(update, "effective_user", None)
+    chat_id = getattr(chat, "id", None)
+    user_id = getattr(user, "id", None)
+    await _delete_stored_message(ctx, chat_id, user_id)
+
+    bot = getattr(ctx, "bot", None)
+    if bot is None or chat_id is None:
+        return
+    await bot.send_message(
+        chat_id=chat_id,
+        text=_invite_text(),
+        reply_markup=_back_keyboard(),
+        disable_web_page_preview=True,
     )
 
 
 async def profile_topup(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     await _answer_callback(update)
-    context = _extract_context(update)
-    chat_id = context.chat_id
-    message = getattr(update, "effective_message", None)
-    query = getattr(update, "callback_query", None)
-    if query is not None and getattr(query, "message", None) is not None:
-        message = query.message
-
-    message_id = getattr(message, "message_id", None)
-
-    try:
-        await open_stars_menu(
-            ctx,
-            chat_id=chat_id,
-            message_id=message_id,
-            edit_message=True,
-            source="profile",
-        )
-    except Exception:
-        log.exception("profile_simple.topup_stars_failed", extra={"chat_id": chat_id})
-
-    text = "\n".join(
-        [
-            "💎 Пополнение — скоро.",
-            "Мы работаем над запуском оплаты прямо в боте.",
-        ]
-    )
-    await _send_profile_message(update, ctx, text=text, reply_markup=_back_keyboard())
-
-
-def _format_history_entry(entry: Any) -> str:
-    if isinstance(entry, dict):
-        title = entry.get("title") or entry.get("description") or entry.get("type")
-        amount = entry.get("amount")
-        pieces: list[str] = []
-        if title:
-            pieces.append(str(title))
-        if amount not in (None, ""):
-            pieces.append(str(amount))
-        extra = entry.get("status") or entry.get("note")
-        if extra:
-            pieces.append(str(extra))
-        if pieces:
-            return " — ".join(pieces[:2]) if len(pieces) == 2 else " — ".join(pieces)
-    if isinstance(entry, str):
-        return entry
-    return str(entry)
-
-
-async def profile_history(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
-    await _answer_callback(update)
-    context = _extract_context(update)
-    entries: Iterable[Any] = []
-    if context.user_id is not None:
-        try:
-            result = get_history(int(context.user_id))
-        except Exception:
-            log.exception("profile_simple.history_failed", extra={"user_id": context.user_id})
-        else:
-            if inspect.isawaitable(result):
-                result = await result
-            try:
-                entries = list(result)[:10]
-            except TypeError:
-                entries = []
-
-    if entries:
-        lines = ["🧾 История операций:"]
-        for idx, item in enumerate(entries, start=1):
-            text = _format_history_entry(item)
-            if text:
-                lines.append(f"{idx}. {text}")
-    else:
-        lines = ["🧾 История операций", "История операций пока пуста."]
-
-    await _send_profile_message(update, ctx, text="\n".join(lines), reply_markup=_back_keyboard())
-
-
-async def profile_invite(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
-    await _answer_callback(update)
-    context = _extract_context(update)
-    bot_name = (app_settings.BOT_NAME or "").strip()
-
-    if bot_name and context.user_id is not None:
-        invite_link = f"https://t.me/{bot_name}?start={context.user_id}"
-        text = "\n".join(
-            [
-                "👥 Пригласить друга",
-                "Поделитесь ссылкой:",
-                invite_link,
-            ]
-        )
-        keyboard = InlineKeyboardMarkup(
-            [
-                [InlineKeyboardButton("Скопировать ссылку", url=invite_link)],
-                [InlineKeyboardButton("⬅️ Назад в профиль", callback_data="btn:profile")],
-            ]
-        )
-    else:
-        text = "\n".join(
-            [
-                "👥 Пригласить друга",
-                "Скоро включим приглашения.",
-            ]
-        )
-        keyboard = _back_keyboard()
-
-    await _send_profile_message(update, ctx, text=text, reply_markup=keyboard)
+    await open_stars_menu(update, ctx, edit_message=True, source="profile")
 
 
 async def profile_back(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     await _answer_callback(update)
-    context = _extract_context(update)
-    await _delete_previous_profile_message(ctx, context.chat_id)
-    _store_last_message_id(context.chat_id, None)
+    chat = getattr(update, "effective_chat", None)
+    user = getattr(update, "effective_user", None)
+    chat_id = getattr(chat, "id", None)
+    user_id = getattr(user, "id", None)
+    await _delete_stored_message(ctx, chat_id, user_id)
 
-    from bot import handle_menu  # Avoid circular import at module load
+    from bot import handle_menu  # avoid circular import at module load
 
     await handle_menu(update, ctx, notify_chat_off=False)
 

--- a/settings.py
+++ b/settings.py
@@ -114,6 +114,9 @@ def _populate_from_settings() -> None:
     g["BANANA_SEND_AS_DOCUMENT"] = bool(settings.BANANA_SEND_AS_DOCUMENT)
     g["BANANA_CARD_REUSE"] = bool(settings.BANANA_CARD_REUSE)
     g["TG_FILE_DIRECT_URL"] = bool(settings.TG_FILE_DIRECT_URL)
+    g["FEATURE_BANANA"] = bool(settings.FEATURE_BANANA)
+    g["FEATURE_SUNO"] = bool(settings.FEATURE_SUNO)
+    g["FEATURE_VIDEO"] = bool(settings.FEATURE_VIDEO)
     g["MJ_SEND_AS_ALBUM"] = bool(settings.MJ_SEND_AS_ALBUM)
 
     g["DIALOG_ENABLED"] = settings.DIALOG_ENABLED

--- a/tests/test_profile_simple.py
+++ b/tests/test_profile_simple.py
@@ -10,6 +10,8 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from unittest.mock import AsyncMock
+
 from tests.suno_test_utils import FakeBot, bot_module  # noqa: E402
 import handlers.profile_simple as profile_simple  # noqa: E402
 
@@ -19,14 +21,13 @@ def _make_context(bot: FakeBot) -> SimpleNamespace:
 
 
 def test_open_profile_sends_message_without_html_and_callbacks(monkeypatch):
-    profile_simple._memory_last_ids.clear()
     bot = FakeBot()
     ctx = _make_context(bot)
 
     monkeypatch.setattr(
         profile_simple,
-        "get_balance_snapshot",
-        lambda _uid: SimpleNamespace(display="123", value=123),
+        "get_user_balance_async",
+        AsyncMock(return_value=123),
     )
 
     message = SimpleNamespace(chat=SimpleNamespace(id=101), chat_id=101)
@@ -48,14 +49,13 @@ def test_open_profile_sends_message_without_html_and_callbacks(monkeypatch):
 
 
 def test_history_empty(monkeypatch):
-    profile_simple._memory_last_ids.clear()
     bot = FakeBot()
     ctx = _make_context(bot)
 
     monkeypatch.setattr(profile_simple, "get_history", lambda _uid: [])
 
     chat_id = 202
-    profile_simple._store_last_message_id(chat_id, 555)
+    ctx.chat_data["profile_card_message_id"] = 555
 
     answered = {"value": False}
 
@@ -81,7 +81,6 @@ def test_history_empty(monkeypatch):
 
 
 def test_invite_without_botname_fallback(monkeypatch):
-    profile_simple._memory_last_ids.clear()
     bot = FakeBot()
     ctx = _make_context(bot)
 
@@ -103,6 +102,8 @@ def test_invite_without_botname_fallback(monkeypatch):
         effective_message=message,
     )
 
+    ctx.chat_data["profile_card_message_id"] = 10
+
     asyncio.run(profile_simple.profile_invite(update, ctx))
 
     assert answered["value"], "Callback query should be answered"
@@ -110,12 +111,22 @@ def test_invite_without_botname_fallback(monkeypatch):
     assert "Скоро включим приглашения." in payload["text"]
     keyboard = payload["reply_markup"].inline_keyboard
     assert keyboard[0][0].callback_data == "btn:profile"
+    assert "profile_card_message_id" not in ctx.chat_data
 
 
 def test_topup_stub(monkeypatch):
-    profile_simple._memory_last_ids.clear()
     bot = FakeBot()
     ctx = _make_context(bot)
+
+    async def fake_open(update, inner_ctx, *, edit_message, source):
+        assert edit_message is True
+        assert source == "profile"
+        await inner_ctx.bot.send_message(
+            chat_id=update.effective_chat.id,
+            text="💎 Пополнение — скоро.",
+        )
+
+    monkeypatch.setattr(profile_simple, "open_stars_menu", fake_open)
 
     answered = {"value": False}
 
@@ -135,13 +146,10 @@ def test_topup_stub(monkeypatch):
     asyncio.run(profile_simple.profile_topup(update, ctx))
 
     assert answered["value"], "Callback query should be answered"
-    payload = bot.sent[-1]
-    assert payload["text"].startswith("💎 Пополнение — скоро.")
-    assert payload["reply_markup"].inline_keyboard[0][0].callback_data == "btn:profile"
+    assert bot.sent[-1]["text"].startswith("💎 Пополнение — скоро.")
 
 
 def test_back_returns_to_menu(monkeypatch):
-    profile_simple._memory_last_ids.clear()
     bot = FakeBot()
     ctx = _make_context(bot)
 
@@ -158,7 +166,7 @@ def test_back_returns_to_menu(monkeypatch):
         answered["value"] = True
 
     chat_id = 505
-    profile_simple._store_last_message_id(chat_id, 900)
+    ctx.chat_data["profile_card_message_id"] = 900
 
     message = SimpleNamespace(chat=SimpleNamespace(id=chat_id), chat_id=chat_id, message_id=900)
     query = SimpleNamespace(data="btn:profile|view=back", message=message, answer=fake_answer)
@@ -174,4 +182,4 @@ def test_back_returns_to_menu(monkeypatch):
     assert answered["value"], "Callback query should be answered"
     assert called["value"] and called["value"][2] is False
     assert bot.deleted and bot.deleted[-1]["message_id"] == 900
-    assert profile_simple._load_last_message_id(chat_id) is None
+    assert "profile_card_message_id" not in ctx.chat_data

--- a/ui/buttons/router.py
+++ b/ui/buttons/router.py
@@ -52,7 +52,8 @@ _LAST_CALLBACK_AT: dict[tuple[int, str], float] = {}
 
 # Allowed menu callback payloads handled by ``route_callback`` below.
 MENU_PAT = re.compile(
-    r"^(btn:profile|kb_open|menu:(photo|music|video|dialog)|img_engine:.+|banana:back_photo|back_main)$"
+    r"^(btn:profile|kb_open|menu:(photo|music|video|dialog)|img_engine:.+|"
+    r"banana:back_photo|back_main|back|dialog:off|video:kling|suno:(start|attach))$"
 )
 
 
@@ -693,6 +694,13 @@ async def route_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         log.info("profile.opened")
         return
 
+    if data == "back":
+        from handlers.menu import open_main_menu
+
+        _mark_handled()
+        await open_main_menu(update, context)
+        return
+
     if data == "kb_open":
         from handlers.menu import show_kb
 
@@ -714,11 +722,53 @@ async def route_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         await open_music_mode(update, context)
         return
 
+    if data == "suno:start":
+        _mark_handled()
+        chat = getattr(update, "effective_chat", None)
+        chat_id = getattr(chat, "id", None)
+        if chat_id is not None:
+            try:
+                await context.bot.send_message(
+                    chat_id,
+                    "Опишите трек: жанр, настроение, длительность. После текста можно приложить аудио.",
+                )
+            except Exception:
+                log.debug("ui.suno.start.notify_failed", exc_info=True)
+        return
+
+    if data == "suno:attach":
+        _mark_handled()
+        chat = getattr(update, "effective_chat", None)
+        chat_id = getattr(chat, "id", None)
+        if chat_id is not None:
+            try:
+                await context.bot.send_message(
+                    chat_id,
+                    "Пришлите voice или аудио-файл (до 15 МБ) — добавим в заявку Suno.",
+                )
+            except Exception:
+                log.debug("ui.suno.attach.notify_failed", exc_info=True)
+        return
+
     if data == "menu:video":
         from handlers.menu import open_video_mode
 
         _mark_handled()
         await open_video_mode(update, context)
+        return
+
+    if data == "video:kling":
+        _mark_handled()
+        chat = getattr(update, "effective_chat", None)
+        chat_id = getattr(chat, "id", None)
+        if chat_id is not None:
+            try:
+                await context.bot.send_message(
+                    chat_id,
+                    "Kling в разработке — уведомим, когда раздел откроется.",
+                )
+            except Exception:
+                log.debug("ui.video.kling.notify_failed", exc_info=True)
         return
 
     if data == "menu:dialog":
@@ -728,7 +778,28 @@ async def route_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         await open_dialog_mode(update, context)
         return
 
+    if data == "dialog:off":
+        from handlers.menu import close_dialog_mode
+
+        _mark_handled()
+        await close_dialog_mode(update, context)
+        return
+
     if data == "img_engine:banana":
+        if not getattr(app_settings, "FEATURE_BANANA", True):
+            _mark_handled()
+            chat = getattr(update, "effective_chat", None)
+            chat_id = getattr(chat, "id", None)
+            if chat_id is not None:
+                try:
+                    await context.bot.send_message(
+                        chat_id,
+                        "Режим Banana временно недоступен.",
+                    )
+                except Exception:
+                    log.debug("ui.banana.disabled.notify_failed", exc_info=True)
+            return
+
         from handlers.banana_async_handler import open_card as open_banana_card
 
         _mark_handled()

--- a/ui/card_store.py
+++ b/ui/card_store.py
@@ -1,0 +1,42 @@
+"""Helpers for storing per-user UI card message identifiers."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+_CARD_KEY_TEMPLATE = "ui:card:{namespace}:{user_id}"
+_CARD_TTL_SECONDS = 24 * 60 * 60
+
+
+def _card_key(namespace: str, user_id: int) -> str:
+    normalized_ns = (namespace or "").strip().lower()
+    return _CARD_KEY_TEMPLATE.format(namespace=normalized_ns, user_id=int(user_id))
+
+
+async def store_card_message_id(redis, namespace: str, user_id: int, message_id: int) -> None:
+    await redis.set(
+        _card_key(namespace, user_id),
+        int(message_id),
+        ex=_CARD_TTL_SECONDS,
+    )
+
+
+async def load_card_message_id(redis, namespace: str, user_id: int) -> Optional[int]:
+    raw = await redis.get(_card_key(namespace, user_id))
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+async def clear_card_message_id(redis, namespace: str, user_id: int) -> None:
+    await redis.delete(_card_key(namespace, user_id))
+
+
+__all__ = [
+    "store_card_message_id",
+    "load_card_message_id",
+    "clear_card_message_id",
+]

--- a/ui/renderers/banana.py
+++ b/ui/renderers/banana.py
@@ -8,9 +8,16 @@ from keyboards import banana_card_kb as build_banana_card_kb
 def banana_card_text(balance: int, state) -> str:
     """Return the Banana card caption for ``state``."""
 
-    photos = f"📷 Фото: {len(state.images)}/4"
-    prompt_state = "есть" if state.prompt else "нет"
-    return f"🍌 Карточка Banana\n{photos} • ✏️ Промпт: {prompt_state}"
+    count = len(getattr(state, "images", getattr(state, "photos", [])))
+    prompt_value = (getattr(state, "prompt", None) or "").strip()
+    prompt_state = "есть" if prompt_value else "нет"
+    lines = [
+        "🍌 Карточка Banana",
+        f"📷 Фото: {count}/4 • ✏️ Промпт: {prompt_state}",
+    ]
+    if count == 0 and not prompt_value:
+        lines.append("— Пришлите 1–4 фото (JPEG/PNG) или текст-промпт.")
+    return "\n".join(lines)
 
 
 def banana_card_kb(state, *, generating: bool = False) -> InlineKeyboardMarkup:

--- a/utils/banana_state.py
+++ b/utils/banana_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional
 
@@ -17,6 +18,7 @@ class BananaState:
     last_payload: Optional[Dict[str, Any]] = None
     last_result_msg_id: Optional[int] = None
     last_result_id: Optional[str] = None  # legacy alias for stored message id
+    updated_at: Optional[float] = None
 
     def _normalized_prompt(self) -> Optional[str]:
         if self.prompt is None:
@@ -49,6 +51,12 @@ class BananaState:
         self.last_payload = None
         self.last_result_msg_id = None
         self.last_result_id = None
+        self.updated_at = time.time()
+
+    def touch(self) -> None:
+        """Update ``updated_at`` timestamp to the current time."""
+
+        self.updated_at = time.time()
 
     # ---- Legacy aliases ----
 
@@ -89,12 +97,14 @@ async def load(redis, user_id: int) -> BananaState:
     data.setdefault("last_payload", None)
     data.setdefault("last_result_msg_id", None)
     data.setdefault("last_result_id", None)
+    data.setdefault("updated_at", None)
     return BananaState(**data)
 
 
 async def save(redis, user_id: int, state: BananaState) -> None:
     """Persist ``state`` for ``user_id`` with a one-day TTL."""
 
+    state.touch()
     payload = asdict(state)
     payload["images"] = list(payload.get("photos", []))
     prompt = payload.get("prompt")


### PR DESCRIPTION
## Summary
- add a presigned Banana uploader with retry logging and wire it into the async handler and state helpers
- persist UI card message ids via Redis, refactor the main menu/video/music/dialog flows, and introduce feature flags for those sections
- update the callback router, profile tests, and supporting utilities to cover the new single-card behaviour

## Testing
- pytest tests/test_profile_simple.py
- pytest tests/test_banana_async_handler.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911a2d169ec8322bebb0764c3fd4dd8)