### PR TITLE
Stabilize home menu idempotency and free chat routing

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -160,6 +160,8 @@ from hub_router import (
     set_fallback as set_hub_fallback,
 )
 from handlers import profile as profile_handlers
+from handlers import chat_free as chat_free_handlers
+from handlers import home as home_handler
 from handlers.banana_async_handler import (
     clear_card as banana_clear_card,
     generation_busy as banana_generation_busy,
@@ -3222,6 +3224,63 @@ def _set_cached_balance(ctx: ContextTypes.DEFAULT_TYPE, value: Optional[int]) ->
 _BALANCE_MEMO_KEY = "balance_snapshot"
 _BALANCE_MEMO_TTL = 5.0
 
+_PROFILE_FRESH_CACHE_KEY = "profile_fresh_snapshot"
+_PROFILE_FRESH_CACHE_TTL = 30.0
+
+
+def _store_fresh_profile_snapshot(
+    ctx: ContextTypes.DEFAULT_TYPE, user_id: int, snapshot: BalanceSnapshot
+) -> None:
+    state_dict = state(ctx)
+    state_dict[_PROFILE_FRESH_CACHE_KEY] = {
+        "user_id": int(user_id),
+        "ts": time.time(),
+        "value": snapshot.value,
+        "display": snapshot.display,
+        "warning": snapshot.warning,
+    }
+
+
+def _load_fresh_profile_snapshot(
+    ctx: ContextTypes.DEFAULT_TYPE, user_id: int
+) -> Optional[BalanceSnapshot]:
+    state_dict = state(ctx)
+    payload = state_dict.get(_PROFILE_FRESH_CACHE_KEY)
+    if not isinstance(payload, dict):
+        return None
+
+    try:
+        cached_user = int(payload.get("user_id", 0))
+        ts_value = float(payload.get("ts", 0.0))
+    except (TypeError, ValueError):
+        return None
+
+    if cached_user != int(user_id):
+        return None
+    if (time.time() - ts_value) > _PROFILE_FRESH_CACHE_TTL:
+        return None
+
+    raw_value = payload.get("value")
+    value: Optional[int]
+    if raw_value is None:
+        value = None
+    else:
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError):
+            value = None
+
+    display_raw = payload.get("display")
+    if isinstance(display_raw, str) and display_raw:
+        display = display_raw
+    else:
+        display = str(value) if value is not None else BALANCE_PLACEHOLDER
+
+    warning_raw = payload.get("warning")
+    warning = warning_raw if isinstance(warning_raw, str) and warning_raw.strip() else None
+
+    return BalanceSnapshot(value=value, display=display, warning=warning)
+
 
 def _cache_balance_snapshot(
     ctx: ContextTypes.DEFAULT_TYPE, user_id: int, snapshot: BalanceSnapshot
@@ -3292,6 +3351,43 @@ def _resolve_balance_snapshot(
     snapshot = get_balance_snapshot(user_id)
     _cache_balance_snapshot(ctx, user_id, snapshot)
     _set_cached_balance(ctx, snapshot.value)
+    return snapshot
+
+
+async def _fetch_profile_snapshot(
+    ctx: ContextTypes.DEFAULT_TYPE, user_id: int
+) -> BalanceSnapshot:
+    cached = _load_fresh_profile_snapshot(ctx, user_id)
+    if cached is not None:
+        return cached
+
+    snapshot: BalanceSnapshot
+    if hasattr(ledger_storage, "get_balance"):
+        try:
+            balance_value = await asyncio.to_thread(
+                ledger_storage.get_balance, int(user_id)
+            )
+        except Exception as exc:
+            log.warning(
+                "profile.balance.postgres_failed",
+                extra={"user_id": user_id, "error": str(exc)},
+            )
+        else:
+            if balance_value is None:
+                snapshot = BalanceSnapshot(value=None, display=BALANCE_PLACEHOLDER, warning=None)
+            else:
+                try:
+                    normalized = int(balance_value)
+                except (TypeError, ValueError):
+                    normalized = 0
+                snapshot = BalanceSnapshot(value=normalized, display=str(normalized), warning=None)
+            _store_fresh_profile_snapshot(ctx, user_id, snapshot)
+            _cache_balance_snapshot(ctx, user_id, snapshot)
+            _set_cached_balance(ctx, snapshot.value)
+            return snapshot
+
+    snapshot = _resolve_balance_snapshot(ctx, user_id, prefer_cached=False)
+    _store_fresh_profile_snapshot(ctx, user_id, snapshot)
     return snapshot
 
 
@@ -7009,7 +7105,11 @@ async def show_music_menu(chat_id: int, ctx: ContextTypes.DEFAULT_TYPE) -> None:
 
 async def show_dialog_menu(chat_id: int, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     log.info("[Dialog] chooser opened", extra={"chat_id": chat_id})
-    await ctx.bot.send_message(chat_id, **build_dialog_card())
+    try:
+        enabled = await chat_free_handlers.is_enabled(chat_id)
+    except Exception:
+        enabled = False
+    await ctx.bot.send_message(chat_id, **build_dialog_card(enabled=enabled))
 
 
 MAIN_MENU_GUARD_TTL = 3
@@ -7405,7 +7505,11 @@ async def _dispatch_home_action(
     if action == "ai_modes":
         if message is None or chat_id is None:
             return
-        card = build_dialog_card()
+        try:
+            enabled = await chat_free_handlers.is_enabled(chat_id)
+        except Exception:
+            enabled = False
+        card = build_dialog_card(enabled=enabled)
         text = card["text"]
         session_disable_chat(ctx)
         keyboard = card.get("reply_markup") or dialog_picker_inline()
@@ -9781,7 +9885,7 @@ def _suno_result_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         [
             [InlineKeyboardButton("🔁 Повторить", callback_data="suno:repeat")],
-            [InlineKeyboardButton("⬅️ В меню", callback_data="back")],
+            [InlineKeyboardButton("⬅️ В меню", callback_data="home:open")],
         ]
     )
 
@@ -21024,6 +21128,41 @@ async def on_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     ):
         chat_autoswitch_total.labels(outcome="skip_active").inc()
 
+    free_chat_enabled = False
+    if chat_id is not None:
+        try:
+            free_chat_enabled = await chat_free_handlers.is_enabled(int(chat_id))
+        except Exception:
+            free_chat_enabled = False
+    waiting_card_input = chat_free_handlers.is_waiting_card_input(user_id)
+
+    if free_chat_enabled and user_id:
+        if waiting_for_input or waiting_card_input:
+            log.info(
+                "router.text", extra={"route": "card", "chat_id": chat_id, "user_id": user_id}
+            )
+        else:
+            log.info(
+                "router.text", extra={"route": "free", "chat_id": chat_id, "user_id": user_id}
+            )
+            if not chat_mode_is_on(user_id):
+                chat_mode_turn_on(user_id)
+            if chat_id is not None:
+                _mode_set(chat_id, MODE_CHAT)
+            s["mode"] = None
+            await _ensure_active_mode(user_id, "dialog_default")
+            await _handle_chat_message(
+                ctx=ctx,
+                chat_id=chat_id,
+                user_id=user_id,
+                state_dict=s,
+                raw_text=raw_text,
+                text=text,
+                send_typing_action=True,
+                send_hint=False,
+            )
+            return
+
     mapped_command = label_to_command(text)
     if mapped_command:
         handler = LABEL_COMMAND_ROUTES.get(mapped_command)
@@ -22691,13 +22830,13 @@ def register_handlers(application: Any) -> None:
     kb_text_handler.block = False
     application.add_handler(kb_text_handler, group=0)
 
-    application.add_handler(CommandHandler("menu", open_main_menu))
+    application.add_handler(CommandHandler("menu", home_handler.open_handler))
 
     from ui.buttons.router import route_callback  # local import to avoid cycles
 
     menu_router = CallbackQueryHandler(
         route_callback,
-        pattern=r"^(btn:profile|kb_open|menu:(photo|music|video|dialog)|img_engine:.+|back_main)$",
+        pattern=r"^(btn:profile|kb_open|menu:(photo|music|video|dialog)|img_engine:.+|back_main|home:open)$",
     )
     menu_router.block = False
     application.add_handler(menu_router, group=0)

--- a/handlers/chat_free.py
+++ b/handlers/chat_free.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+from texts import TXT_KB_AI_DIALOG
+from ui.card import build_card
+from utils.input_state import is_waiting as is_waiting_input
+
+try:  # pragma: no cover - optional dependency during tests
+    from redis_utils import rds as redis_client
+except Exception:  # pragma: no cover - fallback when redis is unavailable
+    redis_client = None
+
+log = logging.getLogger(__name__)
+
+_STATE_KEY_TMPL = "chat:free:{chat_id}"
+_MEMORY_STATE: dict[int, str] = {}
+
+
+def _state_key(chat_id: int) -> str:
+    return _STATE_KEY_TMPL.format(chat_id=int(chat_id))
+
+
+def _memory_get(chat_id: int) -> Optional[str]:
+    return _MEMORY_STATE.get(int(chat_id))
+
+
+def _memory_set(chat_id: int, value: Optional[str]) -> None:
+    if value is None:
+        _MEMORY_STATE.pop(int(chat_id), None)
+        return
+    _MEMORY_STATE[int(chat_id)] = str(value)
+
+
+async def is_enabled(chat_id: int | None) -> bool:
+    try:
+        chat_key = int(chat_id) if chat_id is not None else None
+    except (TypeError, ValueError):
+        return False
+    if chat_key is None:
+        return False
+
+    key = _state_key(chat_key)
+    if redis_client is not None:
+        try:
+            raw = redis_client.get(key)
+        except Exception:  # pragma: no cover - diagnostics only
+            log.debug("chat.free.state_load_failed", exc_info=True, extra={"chat_id": chat_key})
+        else:
+            if raw is not None:
+                if isinstance(raw, bytes):
+                    raw = raw.decode("utf-8", "ignore")
+                text = str(raw).strip().lower()
+                _memory_set(chat_key, text)
+                return text == "on"
+    cached = _memory_get(chat_key)
+    return (cached or "off").strip().lower() == "on"
+
+
+async def set_enabled(chat_id: int | None, enabled: bool) -> None:
+    try:
+        chat_key = int(chat_id) if chat_id is not None else None
+    except (TypeError, ValueError):
+        return
+    if chat_key is None:
+        return
+
+    value = "on" if enabled else "off"
+    _memory_set(chat_key, value)
+    if redis_client is None:
+        return
+    try:
+        redis_client.set(_state_key(chat_key), value)
+    except Exception:  # pragma: no cover - diagnostics only
+        log.debug("chat.free.state_store_failed", exc_info=True, extra={"chat_id": chat_key})
+
+
+def render_status_card(*, enabled: bool) -> dict:
+    if enabled:
+        subtitle = "Свободный чат активирован."
+        body_lines = (
+            "Пишите сообщения — бот ответит сразу, без карточек.",
+            "Команда /reset очищает историю переписки.",
+        )
+        toggle_label = "✖️ Выкл диалог"
+    else:
+        subtitle = "Свободный чат выключен."
+        body_lines = (
+            "Нажмите «Вкл диалог», чтобы перейти в обычное общение.",
+            "Карточки режимов продолжат работать как раньше.",
+        )
+        toggle_label = "🧠 Вкл диалог"
+
+    rows = [
+        [InlineKeyboardButton(toggle_label, callback_data="dialog:toggle")],
+        [InlineKeyboardButton("⬅️ В меню", callback_data="home:open")],
+    ]
+    return build_card(TXT_KB_AI_DIALOG, subtitle, rows, body_lines=body_lines)
+
+
+def is_waiting_card_input(user_id: Optional[int]) -> bool:
+    if user_id is None:
+        return False
+    return bool(is_waiting_input(int(user_id)))
+
+
+__all__ = ["is_enabled", "set_enabled", "render_status_card", "is_waiting_card_input"]

--- a/handlers/dialog.py
+++ b/handlers/dialog.py
@@ -5,6 +5,7 @@ from typing import Any, Awaitable, Callable, MutableMapping, Optional
 
 from telegram.ext import ContextTypes
 
+from handlers import chat_free
 from handlers.menu import build_dialog_card
 
 log = logging.getLogger(__name__)
@@ -38,7 +39,11 @@ async def open_menu(
         raise RuntimeError("dialog menu handler is not configured")
 
     state_dict = _state_getter(ctx)
-    card = build_dialog_card()
+    try:
+        enabled = await chat_free.is_enabled(chat_id)
+    except Exception:
+        enabled = False
+    card = build_dialog_card(enabled=enabled)
 
     message_id = await _send_menu(
         ctx,

--- a/handlers/home.py
+++ b/handlers/home.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import logging
+import secrets
+import time
+from contextlib import suppress
+from typing import Optional, Tuple
+
+from telegram import Update
+from telegram.constants import ParseMode
+from telegram.ext import ContextTypes
+from telegram.error import BadRequest
+
+from keyboards import kb_main
+from texts import TXT_MENU_TITLE
+from ui.card import build_card
+from utils.input_state import clear_wait_states
+from utils.telegram_safe import safe_edit_message
+from telegram_utils import safe_send
+
+try:  # pragma: no cover - optional dependency in tests
+    from redis_utils import rds as redis_client
+except Exception:  # pragma: no cover - fallback when redis is unavailable
+    redis_client = None
+
+log = logging.getLogger(__name__)
+
+_HOME_MSG_KEY_TMPL = "ui:home:{chat_id}"
+_HOME_LOCK_KEY_TMPL = "lock:home:{chat_id}"
+_HOME_LOCK_TTL_SEC = 2.0
+_HOME_MSG_TTL_SEC = 7 * 24 * 60 * 60
+
+_memory_msg: dict[int, Tuple[float, int]] = {}
+_memory_locks: dict[int, Tuple[float, str]] = {}
+
+
+def _msg_key(chat_id: int) -> str:
+    return _HOME_MSG_KEY_TMPL.format(chat_id=int(chat_id))
+
+
+def _lock_key(chat_id: int) -> str:
+    return _HOME_LOCK_KEY_TMPL.format(chat_id=int(chat_id))
+
+
+def render_home() -> Tuple[str, object, ParseMode, bool]:
+    """Render the home menu card text and markup."""
+
+    markup = kb_main()
+    rows = markup.inline_keyboard
+    card = build_card(TXT_MENU_TITLE, "Выберите раздел:", rows)
+    text = card.get("text", "")
+    reply_markup = card.get("reply_markup") or markup
+    parse_mode = card.get("parse_mode", ParseMode.HTML)
+    disable_preview = bool(card.get("disable_web_page_preview", True))
+    return text, reply_markup, parse_mode, disable_preview
+
+
+def _memory_get_msg(chat_id: int) -> Optional[int]:
+    entry = _memory_msg.get(int(chat_id))
+    if not entry:
+        return None
+    expires_at, message_id = entry
+    if expires_at <= time.monotonic():
+        _memory_msg.pop(int(chat_id), None)
+        return None
+    return message_id
+
+
+def _memory_set_msg(chat_id: int, message_id: Optional[int]) -> None:
+    if message_id is None:
+        _memory_msg.pop(int(chat_id), None)
+        return
+    _memory_msg[int(chat_id)] = (
+        time.monotonic() + _HOME_MSG_TTL_SEC,
+        int(message_id),
+    )
+
+
+def _load_message_id(chat_id: int) -> Optional[int]:
+    if redis_client is not None:
+        try:
+            raw = redis_client.get(_msg_key(chat_id))
+        except Exception:  # pragma: no cover - diagnostics only
+            log.debug("home.msg.load_failed", exc_info=True, extra={"chat_id": chat_id})
+        else:
+            if raw is not None:
+                try:
+                    msg_id = int(raw)
+                except (TypeError, ValueError):
+                    msg_id = None
+                else:
+                    _memory_set_msg(chat_id, msg_id)
+                    return msg_id
+    return _memory_get_msg(chat_id)
+
+
+def _store_message_id(chat_id: int, message_id: Optional[int]) -> None:
+    _memory_set_msg(chat_id, message_id)
+    if redis_client is None:
+        return
+    try:
+        if message_id is None:
+            redis_client.delete(_msg_key(chat_id))
+        else:
+            redis_client.setex(_msg_key(chat_id), _HOME_MSG_TTL_SEC, int(message_id))
+    except Exception:  # pragma: no cover - diagnostics only
+        log.debug("home.msg.store_failed", exc_info=True, extra={"chat_id": chat_id})
+
+
+def _acquire_lock(chat_id: int) -> Optional[str]:
+    token = secrets.token_hex(8)
+    if redis_client is not None:
+        try:
+            stored = redis_client.set(
+                _lock_key(chat_id),
+                token,
+                nx=True,
+                ex=max(1, int(_HOME_LOCK_TTL_SEC)),
+            )
+        except Exception:  # pragma: no cover - diagnostics only
+            log.debug("home.lock.redis_failed", exc_info=True, extra={"chat_id": chat_id})
+        else:
+            if stored:
+                return token
+    now = time.monotonic()
+    entry = _memory_locks.get(int(chat_id))
+    if entry and entry[0] > now:
+        return None
+    _memory_locks[int(chat_id)] = (now + _HOME_LOCK_TTL_SEC, token)
+    return token
+
+
+def _release_lock(chat_id: int, token: Optional[str]) -> None:
+    if not token:
+        return
+    if redis_client is not None:
+        try:
+            stored = redis_client.get(_lock_key(chat_id))
+        except Exception:  # pragma: no cover - diagnostics only
+            log.debug("home.lock.redis_get_failed", exc_info=True, extra={"chat_id": chat_id})
+        else:
+            if stored == token:
+                with suppress(Exception):  # pragma: no cover - best effort
+                    redis_client.delete(_lock_key(chat_id))
+    entry = _memory_locks.get(int(chat_id))
+    if entry and entry[1] == token:
+        _memory_locks.pop(int(chat_id), None)
+
+
+async def open_home(
+    ctx: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    *,
+    force_send: bool = False,
+    fallback_message_id: Optional[int] = None,
+) -> Optional[int]:
+    """Render the home menu for ``chat_id`` in an idempotent manner."""
+
+    lock_token = _acquire_lock(chat_id)
+    if lock_token is None:
+        log.warning("error.menu.duplicate", extra={"chat_id": chat_id})
+        return _load_message_id(chat_id)
+
+    try:
+        stored_msg_id = _load_message_id(chat_id)
+        if force_send:
+            stored_msg_id = None
+        if stored_msg_id is None and fallback_message_id is not None:
+            stored_msg_id = int(fallback_message_id)
+
+        text, reply_markup, parse_mode, disable_preview = render_home()
+
+        reused = False
+        current_msg_id: Optional[int] = stored_msg_id
+
+        if current_msg_id is not None:
+            try:
+                edited = await safe_edit_message(
+                    ctx,
+                    chat_id,
+                    current_msg_id,
+                    text,
+                    reply_markup=reply_markup,
+                    parse_mode=parse_mode,
+                    disable_web_page_preview=disable_preview,
+                )
+            except BadRequest as exc:
+                lowered = str(exc).lower()
+                if "message to edit not found" not in lowered:
+                    log.debug(
+                        "home.edit.failed",
+                        extra={"chat_id": chat_id, "msg_id": current_msg_id, "error": str(exc)},
+                    )
+                current_msg_id = None
+            except Exception as exc:  # pragma: no cover - unexpected runtime errors
+                log.warning(
+                    "home.edit.error",
+                    extra={"chat_id": chat_id, "msg_id": stored_msg_id, "error": str(exc)},
+                )
+                current_msg_id = None
+            else:
+                reused = True
+                _store_message_id(chat_id, current_msg_id)
+                log.info(
+                    "ui.home.open",
+                    extra={"chat_id": chat_id, "reused": True, "msg_id": current_msg_id},
+                )
+                return current_msg_id
+
+        result_msg_id: Optional[int] = current_msg_id
+        if current_msg_id is None:
+            try:
+                result = await safe_send(
+                    ctx.bot.send_message,
+                    method_name="send_message",
+                    kind="home_send",
+                    chat_id=chat_id,
+                    text=text,
+                    reply_markup=reply_markup,
+                    parse_mode=parse_mode,
+                    disable_web_page_preview=disable_preview,
+                )
+            except Exception as exc:  # pragma: no cover - network or API errors
+                log.warning(
+                    "home.send.failed",
+                    extra={"chat_id": chat_id, "error": str(exc)},
+                )
+                return None
+            else:
+                result_msg_id = getattr(result, "message_id", None)
+                if isinstance(result_msg_id, int):
+                    _store_message_id(chat_id, int(result_msg_id))
+                else:
+                    result_msg_id = None
+                reused = False
+
+        log.info(
+            "ui.home.open",
+            extra={"chat_id": chat_id, "reused": reused, "msg_id": result_msg_id},
+        )
+        return result_msg_id
+    finally:
+        _release_lock(chat_id, lock_token)
+
+
+async def _resolve_chat_user(update: Update) -> Tuple[Optional[int], Optional[int]]:
+    chat = getattr(update, "effective_chat", None)
+    user = getattr(update, "effective_user", None)
+    chat_id = getattr(chat, "id", None)
+    user_id = getattr(user, "id", None)
+    if chat_id is None and user_id is not None:
+        chat_id = user_id
+    return chat_id, user_id
+
+
+async def _prepare_navigation(
+    update: Update,
+    ctx: ContextTypes.DEFAULT_TYPE,
+    *,
+    clear_wait: bool = True,
+) -> Tuple[Optional[int], Optional[int]]:
+    chat_id, user_id = await _resolve_chat_user(update)
+    if clear_wait and user_id is not None:
+        try:
+            cleared = clear_wait_states(user_id, reason="home_nav")
+            if cleared:
+                log.debug(
+                    "home.wait.cleared",
+                    extra={"chat_id": chat_id, "user_id": user_id},
+                )
+        except Exception:  # pragma: no cover - defensive logging
+            log.debug(
+                "home.wait.clear_failed",
+                exc_info=True,
+                extra={"chat_id": chat_id, "user_id": user_id},
+            )
+    return chat_id, user_id
+
+
+async def open_from_update(
+    update: Update,
+    ctx: ContextTypes.DEFAULT_TYPE,
+    *,
+    skip_ack: bool = False,
+) -> Optional[int]:
+    query = getattr(update, "callback_query", None)
+    if query is not None and not skip_ack:
+        with suppress(Exception):  # pragma: no cover - defensive
+            await query.answer()
+
+    chat_id, _ = await _prepare_navigation(update, ctx)
+    if chat_id is None:
+        log.debug("home.open.no_chat")
+        return None
+
+    fallback_mid = None
+    if query is not None and getattr(query, "message", None) is not None:
+        fallback_mid = getattr(query.message, "message_id", None)
+
+    return await open_home(ctx, int(chat_id), fallback_message_id=fallback_mid)
+
+
+async def open_handler(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> Optional[int]:
+    return await open_from_update(update, ctx)
+
+
+async def cb_open(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> Optional[int]:
+    return await open_from_update(update, ctx)
+
+
+__all__ = [
+    "cb_open",
+    "open_from_update",
+    "open_handler",
+    "open_home",
+    "render_home",
+]

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import MutableMapping, Optional, Sequence
 
 from telegram import InlineKeyboardButton, Update
+from telegram.constants import ParseMode
 from telegram.ext import ContextTypes
 from telegram.error import BadRequest, Forbidden, TelegramError
 
@@ -20,6 +21,9 @@ from ui.card_store import load_card_message_id, store_card_message_id
 
 from logging_utils import get_logger
 from settings import FEATURE_BANANA, FEATURE_SUNO, FEATURE_VIDEO
+
+from . import chat_free
+from . import home as home_handler
 
 log = get_logger("handlers.menu")
 
@@ -255,24 +259,8 @@ async def open_main_menu(
     context: ContextTypes.DEFAULT_TYPE,
     *,
     skip_ack: bool = False,
-) -> None:
-    query = update.callback_query if not skip_ack else None
-    await _answer_callback(query)
-
-    card = build_main_menu_card()
-    message_id = await _ensure_card(update, context, namespace=_MENU_NAMESPACE, card=card)
-
-    chat = getattr(update, "effective_chat", None)
-    chat_id = getattr(chat, "id", None)
-    if message_id is not None and chat_id is not None:
-        log.debug(
-            "menu.card.rendered",
-            extra={
-                "namespace": _MENU_NAMESPACE,
-                "chat_id": chat_id,
-                "message_id": message_id,
-            },
-        )
+) -> Optional[int]:
+    return await home_handler.open_from_update(update, context, skip_ack=skip_ack)
 
 
 async def show_profile(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -379,26 +367,12 @@ async def open_dialog_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) -
 
     chat = getattr(update, "effective_chat", None)
     chat_id = getattr(chat, "id", None)
-    user = getattr(update, "effective_user", None)
-    user_id = getattr(user, "id", None)
+    if not isinstance(chat_id, int):
+        return
 
-    try:
-        from bot import enable_chat_mode  # type: ignore
-    except Exception as exc:  # pragma: no cover - fallback when bot not initialized
-        log.debug(
-            "menu.dialog.enable_import_failed",
-            extra={"chat_id": chat_id, "user_id": user_id, "error": str(exc)},
-        )
-    else:
-        try:
-            await enable_chat_mode(update, context, "normal")
-        except Exception as exc:  # pragma: no cover - diagnostics
-            log.warning(
-                "menu.dialog.enable_failed",
-                extra={"chat_id": chat_id, "user_id": user_id, "error": str(exc)},
-            )
+    enabled = await chat_free.is_enabled(chat_id)
 
-    card = build_dialog_card()
+    card = build_dialog_card(enabled=enabled)
     message_id = await _ensure_card(update, context, namespace=_DIALOG_NAMESPACE, card=card)
 
     if message_id is not None and chat_id is not None:
@@ -420,29 +394,41 @@ async def close_dialog_mode(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     chat_id = getattr(chat, "id", None)
     user = getattr(update, "effective_user", None)
     user_id = getattr(user, "id", None)
+    if not isinstance(chat_id, int):
+        return
+
+    current_state = await chat_free.is_enabled(chat_id)
+    new_state = not current_state
+    await chat_free.set_enabled(chat_id, new_state)
 
     try:
-        from bot import disable_chat_mode  # type: ignore
-    except Exception as exc:  # pragma: no cover - diagnostics only
-        log.debug(
-            "menu.dialog.disable_import_failed",
-            extra={"chat_id": chat_id, "user_id": user_id, "error": str(exc)},
-        )
-    else:
-        try:
+        if new_state:
+            from bot import enable_chat_mode  # type: ignore
+
+            await enable_chat_mode(update, context, "normal")
+        else:
+            from bot import disable_chat_mode  # type: ignore
+
             await disable_chat_mode(
                 context,
                 chat_id=chat_id,
                 user_id=user_id,
                 notify=False,
             )
-        except Exception as exc:  # pragma: no cover - diagnostics only
-            log.warning(
-                "menu.dialog.disable_failed",
-                extra={"chat_id": chat_id, "user_id": user_id, "error": str(exc)},
-            )
+    except Exception as exc:  # pragma: no cover - diagnostics only
+        log.warning(
+            "menu.dialog.toggle_failed",
+            extra={"chat_id": chat_id, "user_id": user_id, "error": str(exc)},
+        )
 
-    await open_main_menu(update, context, skip_ack=True)
+    card = build_dialog_card(enabled=new_state)
+    message_id = await _ensure_card(update, context, namespace=_DIALOG_NAMESPACE, card=card)
+
+    log.info(
+        "chat.free.state %s",
+        "on" if new_state else "off",
+        extra={"chat_id": chat_id, "user_id": user_id, "msg_id": message_id},
+    )
 
 
 async def on_menu_dialog(update, context) -> None:
@@ -490,7 +476,7 @@ def build_music_card() -> dict:
     rows = [
         [InlineKeyboardButton("🚀 Начать генерацию", callback_data="suno:start")],
         [InlineKeyboardButton("🎙 Прикрепить аудио", callback_data="suno:attach")],
-        [InlineKeyboardButton("⬅️ В меню", callback_data="back")],
+        [InlineKeyboardButton("⬅️ В меню", callback_data="home:open")],
     ]
     body = [
         "1. Опишите трек: жанр, настроение, длительность.",
@@ -525,7 +511,7 @@ def build_video_card(*, veo_fast_cost: int, veo_photo_cost: int, sora2_cost: int
                 callback_data="video:type:sora2",
             )
         ],
-        [InlineKeyboardButton("⬅️ В меню", callback_data="back")],
+        [InlineKeyboardButton("⬅️ В меню", callback_data="home:open")],
     ]
     body = [
         "Kling в разработке — скоро откроем доступ.",
@@ -539,21 +525,8 @@ def build_video_card(*, veo_fast_cost: int, veo_photo_cost: int, sora2_cost: int
     )
 
 
-def build_dialog_card() -> dict:
-    rows = [
-        [InlineKeyboardButton("✖️ Выкл диалог", callback_data="dialog:off")],
-        [InlineKeyboardButton("⬅️ В меню", callback_data="back")],
-    ]
-    body = [
-        "Диалог включён. Пишите сообщения — я отвечу сразу, без карточек.",
-        "Команда /reset очищает историю переписки.",
-    ]
-    return build_card(
-        TXT_KB_AI_DIALOG,
-        "Свободный чат активирован.",
-        rows,
-        body_lines=body,
-    )
+def build_dialog_card(*, enabled: bool) -> dict:
+    return chat_free.render_status_card(enabled=enabled)
 
 
 __all__ = [

--- a/handlers/profile.py
+++ b/handlers/profile.py
@@ -461,20 +461,17 @@ def _render_root_view(
         state_payload = None
 
     if snapshot is None:
-        from bot import _resolve_balance_snapshot, get_user_id
+        from bot import get_user_id
 
         target = payload.get("snapshot_target")
         if target is None and state_payload is not None:
             target = state_payload.get("snapshot_target")
         if target is None:
             target = get_user_id(ctx)
-        chat_id = payload.get("chat_id")
-        if chat_id is None and state_payload is not None:
-            chat_id = state_payload.get("chat_id")
-        if target is None and chat_id is not None:
-            target = chat_id
+        if target is None and payload.get("chat_id") is not None:
+            target = payload.get("chat_id")
         if target is not None:
-            snapshot = _resolve_balance_snapshot(ctx, int(target), prefer_cached=True)
+            payload["snapshot_target"] = int(target)
 
     if snapshot is not None:
         from bot import _profile_balance_text
@@ -1004,9 +1001,9 @@ async def _prepare_root_payload(
 
     snapshot = None
     if snapshot_target is not None:
-        from bot import _resolve_balance_snapshot
+        from bot import _fetch_profile_snapshot
 
-        snapshot = _resolve_balance_snapshot(ctx, snapshot_target, prefer_cached=True)
+        snapshot = await _fetch_profile_snapshot(ctx, snapshot_target)
 
     chat_state = _chat_data(ctx)
     state_payload: dict[str, Any]
@@ -1507,7 +1504,7 @@ async def on_profile_menu(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> Non
         with suppress(BadRequest):
             await safe_answer(query)
 
-    await open_profile(update, ctx, source="menu", suppress_nav=True)
+    await open_profile(update, ctx, source="menu", suppress_nav=False)
 
 
 def _topup_url() -> Optional[str]:

--- a/ui/buttons/router.py
+++ b/ui/buttons/router.py
@@ -53,7 +53,7 @@ _LAST_CALLBACK_AT: dict[tuple[int, str], float] = {}
 # Allowed menu callback payloads handled by ``route_callback`` below.
 MENU_PAT = re.compile(
     r"^(btn:profile|kb_open|menu:(photo|music|video|dialog)|img_engine:.+|"
-    r"banana:back_photo|back_main|back|dialog:off|video:kling|suno:(start|attach))$"
+    r"banana:back_photo|back_main|back|home:open|dialog:(?:off|toggle)|video:kling|suno:(start|attach))$"
 )
 
 
@@ -778,7 +778,7 @@ async def route_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         await open_dialog_mode(update, context)
         return
 
-    if data == "dialog:off":
+    if data in {"dialog:off", "dialog:toggle"}:
         from handlers.menu import close_dialog_mode
 
         _mark_handled()
@@ -817,4 +817,10 @@ async def route_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
         _mark_handled()
         await open_main_menu(update, context)
+        return
+    if data == "home:open":
+        from handlers.home import cb_open as home_open
+
+        _mark_handled()
+        await home_open(update, context)
         return


### PR DESCRIPTION
## Summary
- add an idempotent home menu handler that stores message ids in Redis and shares the same callback for “В меню” buttons
- persist free-chat state in Redis, refresh dialog cards in place, and route text messages without deleting user input
- refresh profile snapshots from Postgres via the bot helper so balances are up to date when opening the profile

## Testing
- pytest tests/test_chat_mode_switch.py tests/test_profile_navigation.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911c59c1cd4832288e4c4db0c1f890d)